### PR TITLE
New singleton implementation that removes all statics

### DIFF
--- a/packages/dev/core/src/Meshes/Compression/index.ts
+++ b/packages/dev/core/src/Meshes/Compression/index.ts
@@ -1,3 +1,3 @@
 export * from "./dracoCompression";
 export * from "./meshoptCompression";
-export * from "./dracoDecoder";
+export { DracoDecoder } from "./dracoDecoder";


### PR DESCRIPTION
An idea for enforcing singleton pattern w/o using statics

Export the singleton at the module level. Do not export the class. 
To export this singleton without the heavy overhead of the old constructor, separate it into a  new `initialize` method that users must call. This has the nice side effect of forcing users to be intentional with the lifecycle management of a DracoDecoder.

In case the singleton pattern is a Mistake, we can always go back and expose the class to users?

All of this is based on the idea that a module-level singleton is even a good idea... TBD?