### PR TITLE
docs: add Import OBJ planning tickets

### DIFF
--- a/.scratch/import-obj/PRD.md
+++ b/.scratch/import-obj/PRD.md
@@ -82,10 +82,16 @@ Make Import OBJ default-visible in **Inputs / Aggregate imports**. Make Read OBJ
 - Wire runtime exports and registration, editor descriptors and port styling, default palette/library discovery, JSON persistence, and worker build execution. Saved graphs execute in a worker through package-barrel self-registration.
 - Add a network-free built-in Import OBJ library graph and synthetic original OBJ/MTL/texture fixtures. Do not add codegen, icons, an NAE MCP server, or loader/parser changes.
 
+## Acceptance Criteria
+
+- [ ] Import OBJ preserves Babylon's default `materialLoadingFailsSilently: true`; when a parsable OBJ references an unavailable MTL, the build succeeds as a geometry-only asset.
+- [ ] The unavailable-MTL regression uses existing loader/node diagnostics only and does not add a new warning channel; actual conversion and export failures remain contextual errors.
+
 ## Testing Decisions
 
 - Test external behavior at the highest existing seam: NodeAsset.buildAsync with JSON roundtrip and GLB inspection should prove typed source activation, aggregate execution, conversion, mesh/material/texture preservation, and output structure together.
 - Use synthetic original OBJ, MTL, and 1x1 texture fixtures so the core and worker tests do not depend on network access. Include multiple named objects/groups, material splits, names/colors, selected texture embedding, and a missing-MTL geometry-only case.
+- Add a focused regression with a parsable OBJ that references an unavailable MTL. Assert `materialLoadingFailsSilently: true` remains the default, the build succeeds with geometry only, no new warning channel is emitted, and existing loader/node diagnostics remain the only diagnostic surface.
 - Test the source lifecycle at the Read OBJ/editor seam: URL success, stale request suppression, clear, failed-source retention, invalid local selection retention, malformed persistence rejection, relative-path resolution, case-insensitive lookup, unambiguous basename fallback, and concurrent build-scoped file roots.
 - Test global FilesInputStore and object-URL cleanup after both success and failure, including concurrent same-name bundles.
 - Test editor controller and worker behavior for descriptor/registry/palette/property/library counts, default-visible versus Show primitives discovery, typed ports, forwarded source properties, execution, and JSON roundtrip.

--- a/.scratch/import-obj/PRD.md
+++ b/.scratch/import-obj/PRD.md
@@ -1,0 +1,107 @@
+# PRD — Add Import OBJ to Node Assets Editor
+
+Status: ready-for-agent
+
+## Feature request template context
+
+We only accept feature requests that are discussed on the BabylonJS forum.
+
+**Is your feature request related to a problem? Please describe.**
+
+NAE cannot import Wavefront OBJ, and OBJ's optional MTL and texture companions cannot currently be selected, persisted, or resolved as one authored source.
+
+**Describe the solution you'd like**
+
+Add a built-in `Read OBJ -> OBJ to Universal` Import OBJ aggregate with URL and local file-set sources, editor discovery and properties, graph persistence and worker execution, and a network-free built-in OBJ-to-glTF pipeline. The local workflow must support one OBJ plus optional MTL and texture companions while preserving Babylon loader behavior and safe source/build lifecycle semantics.
+
+**Discussion**
+
+N/A — authorized internal NodeAssets proof-of-concept workflow
+
+## Problem Statement
+
+The Node Assets Editor (NAE) currently has no OBJ source lane. Authors cannot make a typed OBJ source payload, select an OBJ with its optional MTL and texture companions, persist that authored source, or build the result offline through the existing Universal-to-glTF delivery path. Treating OBJ as Babylon or glTF would hide a distinct source format and would make companion resolution and error behavior ambiguous.
+
+## Solution
+
+Add a distinct shallow OBJ source representation and flat OBJ source connection-point kind. Provide a built-in **Import OBJ** aggregate composed of **Read OBJ** and **OBJ to Universal**, with one Universal output. Read OBJ supports URL activation and local selection of exactly one `.obj` plus zero or more companion files. URL sources resolve MTL and texture references relative to the URL folder; local sources persist primary and companion bytes/paths for offline builds. The source payload and build lifecycle preserve the existing Read-block last-successful, stale-request, clear, and failed-source semantics.
+
+Use Babylon's existing OBJ loader through its registration wrapper and `LoadAssetContainerAsync`, then convert in a NullEngine scene to GLB with the existing exporter and WebIO before producing Universal. Do not modify the OBJ loader or add a separate parser. Preserve current Babylon behavior for object/group meshes, `_mmN` material splits, supported colors/maps, and last-reference behavior for multiple `mtllib` declarations. Missing MTL is a geometry-only success; other conversion and export failures surface as contextual errors.
+
+Make Import OBJ default-visible in **Inputs / Aggregate imports**. Make Read OBJ and OBJ to Universal available under **Show primitives**. Forward child property sections and source controls to the aggregate. Wire the runtime, editor descriptors, connection-point/port style, exports, registry, palette, persistence, worker build, and offline built-in library entry without adding an icon, codegen path, or MCP server.
+
+## User Stories
+
+1. As a Node Assets Editor author, I want to discover Import OBJ in the default Inputs palette, so that OBJ is a first-class supported source without exposing implementation details.
+2. As a graph author, I want Import OBJ to produce one Universal output, so that OBJ joins the existing source-to-Universal funnel.
+3. As an advanced author, I want Read OBJ and OBJ to Universal to appear when Show primitives is enabled, so that I can inspect and compose the underlying typed path.
+4. As a graph author, I want OBJ to remain a distinct source kind rather than masquerading as Babylon or glTF, so that wires and runtime payloads communicate the actual format.
+5. As a user, I want to activate an OBJ URL, so that I can import a remote or served OBJ source using the same source-boundary workflow as sibling Read blocks.
+6. As a URL user, I want the primary OBJ bytes and source kind persisted after activation, so that a saved graph can rebuild the authored source.
+7. As a URL user, I want MTL and texture references resolved relative to the URL folder, so that ordinary OBJ companion paths work without manual rewriting.
+8. As a local user, I want to select exactly one OBJ file, so that a standalone OBJ can be imported without requiring companions.
+9. As a local bundle user, I want to select one OBJ plus optional MTL and texture files together, so that companion resources can be authored as one source.
+10. As a local bundle user, I want selected primary and companion bytes and paths persisted, so that local OBJ imports remain buildable offline after reload.
+11. As a local bundle user, I want supplied relative paths preserved, so that MTL references and texture paths retain the author's intended relationship.
+12. As a local bundle user, I want case-insensitive companion lookup and an unambiguous basename fallback for normal browser multi-select, so that common file-picker output resolves without unsafe guessing.
+13. As a local bundle user, I want invalid selections rejected without replacing the current valid source, so that an accidental selection cannot silently break my graph.
+14. As a source-block user, I want the last successful source choice to become active, so that URL and local-source precedence is predictable.
+15. As a source-block user, I want stale URL requests, clear actions, and failed activations to follow sibling Read-block semantics, so that asynchronous interaction cannot overwrite a newer source or erase a known-good source unexpectedly.
+16. As a build user, I want the source to resolve through the registered Babylon OBJ loader, so that Import OBJ follows the supported loader behavior rather than a divergent parser.
+17. As a build user, I want OBJ conversion to run through a NullEngine scene, the existing GLB exporter, WebIO, and Universal, so that the built-in pipeline is network-free and compatible with the current delivery lane.
+18. As a graph author, I want the saved Import OBJ aggregate to execute in a worker, so that editor preview/build behavior matches persisted graph execution.
+19. As a graph author, I want child source properties automatically forwarded to Import OBJ, so that I can configure a compact aggregate without expanding it.
+20. As a graph author, I want a contextual diagnostic when conversion or export fails, so that the failing source or stage is understandable.
+21. As an OBJ author, I want one mesh per OBJ object or group, so that named source structure is preserved.
+22. As an OBJ author, I want material changes to retain Babylon's `_mmN` split behavior, so that geometry boundaries remain compatible with existing OBJ imports.
+23. As an OBJ author, I want supported material colors and maps to survive conversion, so that the output remains visually faithful within the existing loader behavior.
+24. As an OBJ author, I want multiple `mtllib` declarations to retain Babylon's current last-reference behavior, so that this feature does not introduce a new interpretation of existing files.
+25. As a user with no MTL, I want geometry-only import to succeed, so that missing optional material files are not treated as fatal.
+26. As a user, I want loader defaults to remain the current Babylon defaults, so that Import OBJ is predictable and does not introduce an options UI.
+27. As a maintainer, I want the OBJ source representation and flat connection kind to be shallow and explicit, so that future source companions do not leak into unrelated format lanes.
+28. As a maintainer, I want the file-store root to be collision-safe and build-scoped, so that concurrent imports with the same filenames cannot overwrite one another.
+29. As a maintainer, I want global file-store entries and object URLs cleaned up after both success and failure, so that repeated builds do not leak resources.
+30. As a pipeline-library user, I want a built-in Import OBJ workflow with synthetic original OBJ/MTL fixtures, so that the feature can be demonstrated and tested without network access.
+31. As a graph author, I want the Import OBJ graph to round-trip through JSON, so that source data, aggregate structure, and configuration survive save/load.
+32. As a maintainer, I want existing glTF, USD, Babylon, and Node Geometry imports unchanged, so that adding OBJ does not broaden or destabilize unrelated source workflows.
+33. As a maintainer, I do not want icons, code generation, or an NAE MCP server added for this proof of concept, so that the feature stays within the approved product surface.
+
+## Implementation Decisions
+
+- Add a distinct shallow OBJ source representation and flat OBJ source connection-point kind. OBJ is not represented as Babylon, glTF, or Universal until the explicit OBJ-to-Universal transcoder runs.
+- Model Import OBJ as a real aggregate: `Read OBJ -> OBJ to Universal`, exposing one Universal output. Read OBJ remains a hidden primitive by default and is revealed by Show primitives.
+- Add Import OBJ to the default Inputs / Aggregate imports palette. Add Read OBJ and OBJ to Universal to Show primitives. Use the existing NAE descriptor model; it has no icon field, so no icon work is needed.
+- Preserve the sibling Read-block source state machine: URL activation fetches primary OBJ bytes and stores URL/source kind; stale requests cannot replace newer successful state; clear and failed-source behavior match existing semantics; invalid local selections do not replace the current source.
+- URL builds resolve MTL and texture references relative to the URL folder. Local activation accepts exactly one `.obj` plus zero or more selected companions, persists primary and companion bytes/paths, preserves supplied relative paths, uses case-insensitive lookup, and permits only an unambiguous basename fallback for normal browser multi-select.
+- Use a collision-safe, build-scoped virtual `file:` root for local companions. Integrate the existing global FilesInputStore/object-URL lifecycle, and clean entries and URLs after success and failure. Concurrent imports must not overwrite one another.
+- Reuse Babylon's existing OBJ loader through its registration wrapper and `LoadAssetContainerAsync`; do not change the loader or create a second parser. Build with a NullEngine scene, export GLB through the existing exporter and WebIO, and convert to Universal.
+- Preserve loader behavior: one mesh per object/group; `_mmN` splits for material changes; supported colors/maps; and current last-reference behavior for multiple `mtllib` declarations.
+- Expose no loader-options UI. Keep defaults: optimizeWithUV true, UVScaling (1,1), invertY false, invertTextureY true, importVertexColors false, computeNormals false, optimizeNormals false, skipMaterials false, materialLoadingFailsSilently true, and useLegacyBehavior false.
+- Missing MTL is a successful geometry-only import. Other conversion/export failures must surface contextually rather than becoming silent success.
+- Forward aggregate child property sections and source controls automatically, so compact and expanded views use the same authored values.
+- Wire runtime exports and registration, editor descriptors and port styling, default palette/library discovery, JSON persistence, and worker build execution. Saved graphs execute in a worker through package-barrel self-registration.
+- Add a network-free built-in Import OBJ library graph and synthetic original OBJ/MTL/texture fixtures. Do not add codegen, icons, an NAE MCP server, or loader/parser changes.
+
+## Testing Decisions
+
+- Test external behavior at the highest existing seam: NodeAsset.buildAsync with JSON roundtrip and GLB inspection should prove typed source activation, aggregate execution, conversion, mesh/material/texture preservation, and output structure together.
+- Use synthetic original OBJ, MTL, and 1x1 texture fixtures so the core and worker tests do not depend on network access. Include multiple named objects/groups, material splits, names/colors, selected texture embedding, and a missing-MTL geometry-only case.
+- Test the source lifecycle at the Read OBJ/editor seam: URL success, stale request suppression, clear, failed-source retention, invalid local selection retention, malformed persistence rejection, relative-path resolution, case-insensitive lookup, unambiguous basename fallback, and concurrent build-scoped file roots.
+- Test global FilesInputStore and object-URL cleanup after both success and failure, including concurrent same-name bundles.
+- Test editor controller and worker behavior for descriptor/registry/palette/property/library counts, default-visible versus Show primitives discovery, typed ports, forwarded source properties, execution, and JSON roundtrip.
+- Use browser-level coverage only where needed for File and multi-select picker behavior; avoid duplicating runtime tests in the browser.
+- Follow existing NodeAssets import, aggregate, worker, editor controller, and pipeline-library tests as prior art. No visualization test is required because the feature is an asset import/build workflow rather than a rendering change.
+- Assert user-visible behavior and public contracts, not private parser or loader implementation details. Existing glTF, USD, Babylon, and Node Geometry import tests must remain green.
+
+## Out of Scope
+
+- Editing or exporting OBJ.
+- Changes to the Babylon OBJ loader or a new OBJ parser.
+- Merging multiple MTL files, unsupported MTL features, smoothing/illumination work, or a new material semantics layer.
+- Loader-options UI, credentials, ZIP handling, directory crawling, new progress/abort APIs, or alternate companion-selection workflows.
+- Icons, code generation, and an NAE MCP server.
+- Changes to existing glTF, USD, Babylon, or Node Geometry import behavior except for required shared registration wiring.
+
+## Further Notes
+
+Import OBJ is approved as an internal NodeAssets proof-of-concept workflow. Acceptance requires it to be default-visible and usable; primitives must be typed and discoverable under Show primitives; URL root resolution must work; local OBJ+MTL+texture bundles must persist and build offline; multiple meshes, materials, names, and selected textures must survive into the exported GLB; missing MTL must succeed geometry-only; source errors, races, clear behavior, cleanup, registration, worker execution, and roundtrip must be correct; the built-in pipeline must run offline; focused tests must pass; and no MCP, icon, or codegen changes may be introduced.

--- a/.scratch/import-obj/issues/01-basic-import-obj-workflow.md
+++ b/.scratch/import-obj/issues/01-basic-import-obj-workflow.md
@@ -49,6 +49,7 @@ Wire the runtime exports and package-barrel self-registration, editor descriptor
 - [ ] JSON roundtrip preserves the aggregate, source selection, names, and build behavior.
 - [ ] The worker can load the saved graph and build the basic OBJ workflow offline.
 - [ ] A basic network-free Import OBJ built-in pipeline/library entry builds successfully.
+- [ ] Babylon's default `materialLoadingFailsSilently: true` is preserved; a parsable OBJ with an unavailable referenced MTL succeeds as geometry-only, using existing loader/node diagnostics only and no new warning channel.
 - [ ] Focused runtime, editor, worker, and persistence tests cover the above public behavior, and existing glTF, USD, Babylon, and Node Geometry imports remain unchanged.
 - [ ] No icon, codegen, loader/parser, or NAE MCP changes are introduced.
 

--- a/.scratch/import-obj/issues/01-basic-import-obj-workflow.md
+++ b/.scratch/import-obj/issues/01-basic-import-obj-workflow.md
@@ -1,0 +1,57 @@
+# Add the basic Import OBJ workflow end to end
+
+Status: ready-for-agent
+Blocked by: None
+
+## Parent
+
+[Add Import OBJ to Node Assets Editor](../PRD.md)
+
+## Feature request context
+
+This is an authorized internal NodeAssets proof-of-concept workflow. The repository's public feature-request template requires a forum Discussion; that requirement does not apply here.
+
+## What to build
+
+Deliver a complete minimal Import OBJ tracer from a typed OBJ source representation and connection-point kind through the Read OBJ primitive, OBJ-to-Universal transcoder, Import OBJ aggregate, editor discovery, persistence, worker execution, and a basic offline pipeline-library entry.
+
+The runtime must model OBJ as its own shallow source payload rather than as Babylon or glTF. Add the ordinary typed path `Read OBJ -> OBJ to Universal`, with one Universal output exposed by the aggregate. Use Babylon's existing OBJ loader through its registration wrapper and `LoadAssetContainerAsync`, then convert through a NullEngine scene, the existing GLB exporter, WebIO, and Universal. Do not modify the loader or create a new parser. Support URL sources and exactly one local `.obj` file in this first slice; the source serialization must be compatible with adding companion entries in issue 02.
+
+Preserve the sibling Read-block behavior for URL activation, last-successful source selection, stale requests, clear, failed-source handling, and malformed persisted source rejection. Keep the existing OBJ loader defaults and expose no loader-options UI. Preserve object/group names and multiple geometry through the conversion, while leaving companion-file handling and material/texture bundle behavior to issue 02.
+
+Wire the runtime exports and package-barrel self-registration, editor descriptors and typed port style, default Inputs / Aggregate imports palette, Show primitives entries, aggregate child property forwarding, JSON persistence, worker build, and a basic network-free OBJ library entry. Do not add icons, code generation, or an NAE MCP server. Implement tests first at the highest existing seams.
+
+## User stories covered
+
+1. As a Node Assets Editor author, I want to discover Import OBJ in the default Inputs palette, so that OBJ is a first-class source.
+2. As a graph author, I want Import OBJ to expose one Universal output, so that OBJ joins the Universal funnel.
+3. As an advanced author, I want Read OBJ and OBJ to Universal under Show primitives, so that the typed primitive path is inspectable.
+4. As a graph author, I want OBJ to remain a distinct source kind, so that the graph does not masquerade as another format.
+5. As a user, I want to activate an OBJ URL or upload one local OBJ, so that simple OBJ sources build without companions.
+6. As a source-block user, I want last-successful, stale-request, clear, and failed-source semantics to match sibling Read blocks, so that asynchronous source edits are predictable.
+7. As a build user, I want OBJ to use the registered Babylon loader and existing GLB/Universal path, so that behavior is consistent and offline-capable.
+8. As a graph author, I want a persisted Import OBJ graph to execute in a worker, so that editor and saved builds agree.
+9. As a graph author, I want aggregate child properties forwarded, so that the compact node remains usable.
+10. As an OBJ author, I want object/group names and multiple geometry to survive, so that basic structure is retained.
+11. As a graph author, I want contextual source and conversion failures, so that invalid inputs are diagnosable.
+
+## Acceptance criteria
+
+- [ ] A fresh graph can discover and add **Import OBJ** in **Inputs / Aggregate imports** by default.
+- [ ] With **Show primitives** enabled, **Read OBJ** and **OBJ to Universal** are discoverable; their source and Universal connection points are typed as OBJ and Universal rather than Babylon, glTF, or an untyped value.
+- [ ] The runtime path is a real typed `Read OBJ -> OBJ to Universal` aggregate with one Universal output, and the public exports and package-barrel self-registration make it available in a fresh runtime and worker context.
+- [ ] A simple URL OBJ builds through the existing Export glTF path into a non-empty inspectable GLB.
+- [ ] A single local `.obj` upload builds offline into the same kind of GLB; companion-file support is additive and remains compatible with the persisted source representation.
+- [ ] Multiple named OBJ objects/groups and their resulting multiple meshes survive the loader/export path with their names observable in the GLB.
+- [ ] URL activation stores the primary OBJ bytes and URL/source kind; a later URL request cannot overwrite a newer successful source; clear and failed activation preserve the established sibling semantics.
+- [ ] Invalid or malformed persisted OBJ source data is rejected contextually and cannot produce a misleading successful build.
+- [ ] Import OBJ exposes the forwarded Read OBJ source property section without duplicating or diverging from the primitive's value.
+- [ ] JSON roundtrip preserves the aggregate, source selection, names, and build behavior.
+- [ ] The worker can load the saved graph and build the basic OBJ workflow offline.
+- [ ] A basic network-free Import OBJ built-in pipeline/library entry builds successfully.
+- [ ] Focused runtime, editor, worker, and persistence tests cover the above public behavior, and existing glTF, USD, Babylon, and Node Geometry imports remain unchanged.
+- [ ] No icon, codegen, loader/parser, or NAE MCP changes are introduced.
+
+## Blocked by
+
+None - can start immediately.

--- a/.scratch/import-obj/issues/02-persistent-obj-companion-bundles.md
+++ b/.scratch/import-obj/issues/02-persistent-obj-companion-bundles.md
@@ -47,7 +47,8 @@ Use synthetic original OBJ/MTL fixtures and a 1x1 texture to prove material name
 - [ ] FilesInputStore/global file entries and object URLs are removed after both successful and failed builds, including concurrent same-name bundles.
 - [ ] Companion resources are ready before export, and an OBJ+MTL fixture with a 1x1 texture produces an inspectable GLB containing the expected material names/colors and an embedded texture.
 - [ ] Multiple material changes retain Babylon's `_mmN` geometry split behavior, supported maps/colors survive, and multiple `mtllib` declarations retain Babylon's current last-reference behavior.
-- [ ] A missing MTL remains a successful geometry-only import under the existing default behavior.
+- [ ] Babylon's default `materialLoadingFailsSilently: true` is preserved: a parsable OBJ whose referenced MTL is unavailable remains a successful geometry-only import, with no new warning channel.
+- [ ] A focused regression test covers the unavailable-MTL case and verifies that existing loader/node diagnostics remain the only diagnostic surface.
 - [ ] The worker can build a persisted local bundle offline after JSON roundtrip.
 - [ ] The built-in Import OBJ pipeline/library entry exercises an MTL and texture without network access.
 - [ ] Focused runtime, editor, worker, persistence, lifecycle, and browser-level tests cover the above behavior and issue 01 remains green.

--- a/.scratch/import-obj/issues/02-persistent-obj-companion-bundles.md
+++ b/.scratch/import-obj/issues/02-persistent-obj-companion-bundles.md
@@ -1,0 +1,58 @@
+# Support persistent OBJ companion bundles
+
+Status: ready-for-agent
+Blocked by: 01
+
+## Parent
+
+[Add Import OBJ to Node Assets Editor](../PRD.md)
+
+## Feature request context
+
+This is an authorized internal NodeAssets proof-of-concept workflow. The repository's public feature-request template requires a forum Discussion; that requirement does not apply here.
+
+## What to build
+
+Extend the end-to-end Import OBJ tracer from issue 01 to support local bundles containing exactly one `.obj` plus zero or more selected MTL and texture companions, while preserving URL companion behavior and Babylon's existing missing-MTL default.
+
+Add the browser multi-file selection/picker path and validate that exactly one OBJ is selected. Persist every selected companion's bytes and supplied path alongside the primary OBJ so a saved graph can build offline. Preserve supplied relative paths, perform case-insensitive lookup, and provide an unambiguous basename fallback for normal browser multi-select output. Invalid selections must report a contextual source error and must not replace the current valid source.
+
+Resolve URL MTL and texture references relative to the URL folder. For local builds, use a collision-safe, build-scoped virtual `file:` root integrated with the existing global FilesInputStore/object-URL lifecycle. Ensure companion resources are ready before GLB export, clean global entries and object URLs on both success and failure, and isolate concurrent imports even when bundles contain the same filenames.
+
+Use synthetic original OBJ/MTL fixtures and a 1x1 texture to prove material names, colors, and selected texture embedding in the exported GLB. Preserve multiple `mtllib` last-reference behavior and the existing default that a missing MTL is a successful geometry-only import. Update the built-in fixture/pipeline and tests without modifying the Babylon loader, adding loader-options UI, or introducing icons, codegen, or an NAE MCP server. Implement tests first and cover browser File/multi-select behavior only at the necessary seam.
+
+## User stories covered
+
+1. As a local bundle user, I want to select one OBJ with optional MTL and texture companions, so that related files are authored as one source.
+2. As a local bundle user, I want companion bytes and paths persisted, so that the bundle builds offline after JSON roundtrip.
+3. As a local bundle user, I want relative paths preserved and case-insensitive lookup, so that ordinary OBJ/MTL references resolve.
+4. As a local bundle user, I want unambiguous basename fallback for browser multi-select, so that common picker output works without unsafe guessing.
+5. As a local bundle user, I want invalid selections rejected without replacing my current source, so that a bad selection does not destroy a good graph.
+6. As a URL user, I want MTL and texture paths resolved relative to the OBJ URL folder, so that hosted bundles work without rewriting references.
+7. As an OBJ author, I want material names, colors, and texture maps to survive, so that the exported GLB retains supported material information.
+8. As a user with no MTL, I want geometry-only import to succeed, so that optional material files remain optional.
+9. As a maintainer, I want build-scoped collision-safe file roots and cleanup, so that concurrent builds and repeated use do not overwrite or leak resources.
+10. As a graph author, I want bundle JSON roundtrip and worker execution, so that persisted local sources behave like freshly selected sources.
+11. As a pipeline-library user, I want an offline synthetic OBJ/MTL/texture example, so that companion support is demonstrable without network access.
+
+## Acceptance criteria
+
+- [ ] Local selection accepts exactly one `.obj` and zero or more MTL/texture companions; zero OBJ files, multiple OBJ files, unsupported or ambiguous selections fail contextually.
+- [ ] An invalid local selection does not replace the current valid source or its persisted bytes.
+- [ ] The browser multi-file helper/picker preserves the selected primary and companion paths and supports the intended File/multi-select behavior at its browser-level seam.
+- [ ] Local JSON persistence includes the primary OBJ bytes/path and every selected companion's bytes/path; a roundtrip restores an offline-buildable source.
+- [ ] Supplied relative paths are retained, companion matching is case-insensitive, and basename fallback is used only when the match is unambiguous.
+- [ ] URL OBJ builds resolve MTL and texture references relative to the URL folder, while retaining the primary URL/source kind and existing stale-request, clear, and failed-source semantics.
+- [ ] Local builds use a collision-safe, build-scoped virtual `file:` root; concurrent bundles with the same filenames cannot overwrite one another.
+- [ ] FilesInputStore/global file entries and object URLs are removed after both successful and failed builds, including concurrent same-name bundles.
+- [ ] Companion resources are ready before export, and an OBJ+MTL fixture with a 1x1 texture produces an inspectable GLB containing the expected material names/colors and an embedded texture.
+- [ ] Multiple material changes retain Babylon's `_mmN` geometry split behavior, supported maps/colors survive, and multiple `mtllib` declarations retain Babylon's current last-reference behavior.
+- [ ] A missing MTL remains a successful geometry-only import under the existing default behavior.
+- [ ] The worker can build a persisted local bundle offline after JSON roundtrip.
+- [ ] The built-in Import OBJ pipeline/library entry exercises an MTL and texture without network access.
+- [ ] Focused runtime, editor, worker, persistence, lifecycle, and browser-level tests cover the above behavior and issue 01 remains green.
+- [ ] No OBJ loader/parser changes, loader-options UI, credentials, ZIP/directory crawling, progress/abort API, icon, codegen, or NAE MCP work is introduced.
+
+## Blocked by
+
+01 — [Add the basic Import OBJ workflow end to end](01-basic-import-obj-workflow.md)


### PR DESCRIPTION
## Summary

- Add the approved Import OBJ PRD to the local issue tracker.
- Add the basic end-to-end Import OBJ vertical slice.
- Add the persistent OBJ companion-bundle vertical slice, blocked by issue 01.

## Testing

- `git diff --cached --check`
- Documentation-only change; no runtime tests were needed.

## Ticket paths

- `.scratch/import-obj/PRD.md`
- `.scratch/import-obj/issues/01-basic-import-obj-workflow.md`
- `.scratch/import-obj/issues/02-persistent-obj-companion-bundles.md`
