### PR TITLE
Add basic OBJ import workflow

### DIFF
--- a/packages/dev/node-assets/src/Blocks/importOBJAggregateBlock.ts
+++ b/packages/dev/node-assets/src/Blocks/importOBJAggregateBlock.ts
@@ -1,0 +1,84 @@
+import { AggregateBlock } from "../blockFoundation/aggregateBlock";
+import { RegisterBlock } from "../blockFoundation/blockRegistry";
+import { type NodeAssetConnectionPoint } from "../connection/nodeAssetConnectionPoint";
+import { type NodeAsset } from "../nodeAsset";
+import { type IOBJSourceFile, type OBJSourceKind } from "../representations/objSourceAsset";
+import { OBJToUniversalBlock } from "./objToUniversalBlock";
+import { type OBJSourceFetcher, ReadOBJBlock } from "./readOBJBlock";
+
+/** Built-in `Read OBJ -> OBJ to Universal` aggregate. */
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export class ImportOBJAggregateBlock extends AggregateBlock {
+    /** The class name, used for identification and safe under minification. */
+    public static override ClassName = "ImportOBJAggregateBlock";
+
+    /** The aggregate's Universal output. */
+    public readonly output: NodeAssetConnectionPoint;
+
+    /**
+     * Creates the built-in OBJ import aggregate.
+     * @param name The display name.
+     * @param nodeAsset The owning graph.
+     */
+    public constructor(name: string, nodeAsset: NodeAsset) {
+        super(name, nodeAsset);
+        const read = new ReadOBJBlock("Read OBJ", this.subgraph);
+        const transcoder = new OBJToUniversalBlock("OBJ to Universal", this.subgraph);
+        read.output.connectTo(transcoder.input);
+        this.output = this._exposeOutput(transcoder.output, "output");
+    }
+
+    /** The owned Read OBJ primitive. */
+    public get readBlock(): ReadOBJBlock {
+        const block = this.subgraph.attachedBlocks.find((candidate): candidate is ReadOBJBlock => candidate instanceof ReadOBJBlock);
+        if (!block) {
+            throw new Error(`The "${this.name}" aggregate has no ReadOBJBlock.`);
+        }
+        return block;
+    }
+
+    /** Defensive copy of the active primary OBJ file forwarded from the Read OBJ primitive. */
+    public get primary(): IOBJSourceFile | null {
+        return this.readBlock.primary;
+    }
+
+    /** Active source label forwarded from the Read OBJ primitive. */
+    public get source(): string | null {
+        return this.readBlock.source;
+    }
+
+    /** Active source kind forwarded from the Read OBJ primitive. */
+    public get sourceKind(): OBJSourceKind | null {
+        return this.readBlock.sourceKind;
+    }
+
+    /** Defensive copies of companion files forwarded from the Read OBJ primitive. */
+    public get companions(): ReadonlyArray<IOBJSourceFile> {
+        return this.readBlock.companions;
+    }
+
+    /**
+     * Makes one uploaded OBJ file the active child source.
+     * @param bytes The uploaded bytes.
+     * @param fileName The uploaded file name.
+     */
+    public setUploadedSource(bytes: Uint8Array, fileName: string): void {
+        this.readBlock.setUploadedSource(bytes, fileName);
+    }
+
+    /** Clears the active child source. */
+    public clearSource(): void {
+        this.readBlock.clearSource();
+    }
+
+    /**
+     * Loads and activates a URL on the owned Read OBJ primitive.
+     * @param url The OBJ URL.
+     * @param fetcher The fetch-compatible loader.
+     */
+    public async setUrlAsync(url: string, fetcher?: OBJSourceFetcher): Promise<void> {
+        await this.readBlock.setUrlAsync(url, fetcher);
+    }
+}
+
+RegisterBlock(ImportOBJAggregateBlock.ClassName, (name, nodeAsset) => new ImportOBJAggregateBlock(name, nodeAsset));

--- a/packages/dev/node-assets/src/Blocks/objToUniversalBlock.ts
+++ b/packages/dev/node-assets/src/Blocks/objToUniversalBlock.ts
@@ -1,0 +1,78 @@
+import { NullEngine } from "core/Engines/nullEngine";
+import { LoadAssetContainerAsync } from "core/Loading/sceneLoader";
+import { Tools } from "core/Misc/tools.pure";
+import { Scene } from "core/scene";
+import { GLTF2Export } from "serializers/glTF/2.0/glTFSerializer";
+
+import "loaders/OBJ/objFileLoader";
+
+import { RegisterBlock } from "../blockFoundation/blockRegistry";
+import { NodeAssetBlock } from "../blockFoundation/nodeAssetBlock";
+import { type NodeAssetConnectionPoint } from "../connection/nodeAssetConnectionPoint";
+import { NodeAssetConnectionPointType } from "../connection/nodeAssetConnectionPointType";
+import { type NodeAsset } from "../nodeAsset";
+import { GltfAsset } from "../representations/gltfAsset";
+import { IsOBJSourceAsset } from "../representations/objSourceAsset";
+
+/** Parses an OBJ source payload and explicitly crosses into Universal. */
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export class OBJToUniversalBlock extends NodeAssetBlock {
+    /** The class name, used for identification and safe under minification. */
+    public static override ClassName = "OBJToUniversalBlock";
+
+    /** The shallow OBJ source payload. */
+    public readonly input: NodeAssetConnectionPoint;
+    /** The Universal working payload. */
+    public readonly output: NodeAssetConnectionPoint;
+
+    /**
+     * Creates an OBJ-to-Universal transcoder.
+     * @param name The display name.
+     * @param nodeAsset The owning graph.
+     */
+    public constructor(name: string, nodeAsset: NodeAsset) {
+        super(name, nodeAsset);
+        this.input = this._registerInput("input", NodeAssetConnectionPointType.OBJ_SOURCE);
+        this.output = this._registerOutput("output", NodeAssetConnectionPointType.UNIVERSAL);
+    }
+
+    /** Loads the OBJ scene, exports it to GLB, and wraps the resulting Universal document. */
+    public override async _buildBlockAsync(): Promise<void> {
+        if (!IsOBJSourceAsset(this.input.value)) {
+            throw new Error(`The "${this.name}" block did not receive an OBJ source payload.`);
+        }
+        const source = this.input.value;
+        const primary = source.primary;
+        const engine = new NullEngine();
+        const scene = new Scene(engine);
+        try {
+            const rootUrl = source.sourceKind === "url" ? Tools.GetFolderPath(source.source) : "";
+            const container = await LoadAssetContainerAsync(primary.bytes, scene, { pluginExtension: ".obj", rootUrl });
+            container.addAllToScene();
+
+            const glbData = await GLTF2Export.GLBAsync(scene, "obj-universal", { exportWithoutWaitingForScene: true });
+            const glb = glbData.files["obj-universal.glb"];
+            const bytes = glb instanceof Blob ? new Uint8Array(await glb.arrayBuffer()) : new TextEncoder().encode(glb);
+            const { WebIO } = await import("@gltf-transform/core");
+            const { ALL_EXTENSIONS } = await import("@gltf-transform/extensions");
+            const document = await new WebIO().registerExtensions(ALL_EXTENSIONS).readBinary(bytes);
+            this.output.value = new GltfAsset(document, {
+                identity: source.source,
+                revision: 0,
+                manifest: { format: "universal", importedFrom: "obj", source: source.source },
+            });
+        } catch (error) {
+            throw new Error(`The "${this.name}" block failed to convert "${source.source}" to Universal: ${error instanceof Error ? error.message : String(error)}`, {
+                cause: error,
+            });
+        } finally {
+            try {
+                scene.dispose();
+            } finally {
+                engine.dispose();
+            }
+        }
+    }
+}
+
+RegisterBlock(OBJToUniversalBlock.ClassName, (name, nodeAsset) => new OBJToUniversalBlock(name, nodeAsset));

--- a/packages/dev/node-assets/src/Blocks/objToUniversalBlock.ts
+++ b/packages/dev/node-assets/src/Blocks/objToUniversalBlock.ts
@@ -14,6 +14,17 @@ import { type NodeAsset } from "../nodeAsset";
 import { GltfAsset } from "../representations/gltfAsset";
 import { IsOBJSourceAsset } from "../representations/objSourceAsset";
 
+function GetOBJRootUrl(source: string): string {
+    try {
+        return new URL(".", source).href;
+    } catch (error) {
+        if (error instanceof TypeError) {
+            return Tools.GetFolderPath(source);
+        }
+        throw error;
+    }
+}
+
 /** Parses an OBJ source payload and explicitly crosses into Universal. */
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export class OBJToUniversalBlock extends NodeAssetBlock {
@@ -47,7 +58,7 @@ export class OBJToUniversalBlock extends NodeAssetBlock {
         let scene: Scene | undefined;
         try {
             scene = new Scene(engine);
-            const rootUrl = source.sourceKind === "url" ? Tools.GetFolderPath(source.source) : "";
+            const rootUrl = source.sourceKind === "url" ? GetOBJRootUrl(source.source) : "";
             const obj = new TextDecoder().decode(primary.bytes);
             const container = await LoadAssetContainerAsync(`data:${obj}`, scene, { pluginExtension: ".obj", rootUrl });
             container.addAllToScene();

--- a/packages/dev/node-assets/src/Blocks/objToUniversalBlock.ts
+++ b/packages/dev/node-assets/src/Blocks/objToUniversalBlock.ts
@@ -44,10 +44,12 @@ export class OBJToUniversalBlock extends NodeAssetBlock {
         const source = this.input.value;
         const primary = source.primary;
         const engine = new NullEngine();
-        const scene = new Scene(engine);
+        let scene: Scene | undefined;
         try {
+            scene = new Scene(engine);
             const rootUrl = source.sourceKind === "url" ? Tools.GetFolderPath(source.source) : "";
-            const container = await LoadAssetContainerAsync(primary.bytes, scene, { pluginExtension: ".obj", rootUrl });
+            const obj = new TextDecoder().decode(primary.bytes);
+            const container = await LoadAssetContainerAsync(`data:${obj}`, scene, { pluginExtension: ".obj", rootUrl });
             container.addAllToScene();
 
             const glbData = await GLTF2Export.GLBAsync(scene, "obj-universal", { exportWithoutWaitingForScene: true });
@@ -67,7 +69,7 @@ export class OBJToUniversalBlock extends NodeAssetBlock {
             });
         } finally {
             try {
-                scene.dispose();
+                scene?.dispose();
             } finally {
                 engine.dispose();
             }

--- a/packages/dev/node-assets/src/Blocks/readOBJBlock.ts
+++ b/packages/dev/node-assets/src/Blocks/readOBJBlock.ts
@@ -1,0 +1,273 @@
+import { type Nullable } from "core/types";
+import { DecodeBase64ToBinary, EncodeArrayBufferToBase64 } from "core/Misc/stringTools";
+
+import { RegisterBlock } from "../blockFoundation/blockRegistry";
+import { NodeAssetBlock } from "../blockFoundation/nodeAssetBlock";
+import { type NodeAssetConnectionPoint } from "../connection/nodeAssetConnectionPoint";
+import { NodeAssetConnectionPointType } from "../connection/nodeAssetConnectionPointType";
+import { type BuildScope } from "../evaluation/buildScope";
+import { type NodeAsset } from "../nodeAsset";
+import { type IOBJSourceFile, OBJSourceAsset, type OBJSourceKind } from "../representations/objSourceAsset";
+import { type NodeAssetBlockSerialization } from "../serialization/nodeAssetSerialization";
+
+/** Minimal response surface used to load an OBJ URL. */
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export interface IOBJSourceResponse {
+    readonly ok: boolean;
+    readonly status: number;
+    readonly statusText: string;
+    arrayBuffer(): Promise<ArrayBuffer>;
+}
+
+/** Fetch-compatible loader used by {@link ReadOBJBlock.setUrlAsync}. */
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export type OBJSourceFetcher = (url: string) => Promise<IOBJSourceResponse>;
+
+/** Reports whether an asynchronous OBJ source operation became the active source. */
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export interface IOBJSourceApplyResult {
+    /** Whether the operation's resolved bytes became active. */
+    applied: boolean;
+}
+
+function CloneSourceFile(file: IOBJSourceFile): IOBJSourceFile {
+    return Object.freeze({ path: file.path, bytes: file.bytes.slice() });
+}
+
+function IsOBJFileName(fileName: string): boolean {
+    return fileName.trim().length > 0 && /\.obj$/i.test(fileName);
+}
+
+function DecodeSerializedBytes(value: unknown): Uint8Array {
+    if (typeof value !== "string") {
+        throw new TypeError("primary.bytes must be a base64 string.");
+    }
+    const bytes = new Uint8Array(DecodeBase64ToBinary(value));
+    if (EncodeArrayBufferToBase64(bytes) !== value) {
+        throw new TypeError("primary.bytes must be canonical base64.");
+    }
+    return bytes;
+}
+
+/** Resolves a URL or one uploaded `.obj` file into a shallow OBJ source payload. */
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export class ReadOBJBlock extends NodeAssetBlock {
+    /** The class name, used for identification and safe under minification. */
+    public static override ClassName = "ReadOBJBlock";
+
+    /** The shallow OBJ source payload. */
+    public readonly output: NodeAssetConnectionPoint;
+
+    private _primary: Nullable<IOBJSourceFile> = null;
+    private _source: Nullable<string> = null;
+    private _sourceKind: Nullable<OBJSourceKind> = null;
+    private readonly _companions: ReadonlyArray<IOBJSourceFile> = Object.freeze([]);
+    private _sourceAttempt = 0;
+    private _lastSuccessfulSourceAttempt = 0;
+
+    /**
+     * Creates an OBJ read block.
+     * @param name The display name.
+     * @param nodeAsset The owning graph.
+     */
+    public constructor(name: string, nodeAsset: NodeAsset) {
+        super(name, nodeAsset);
+        this.output = this._registerOutput("output", NodeAssetConnectionPointType.OBJ_SOURCE);
+    }
+
+    /** A defensive copy of the active primary OBJ file. */
+    public get primary(): IOBJSourceFile | null {
+        return this._primary ? CloneSourceFile(this._primary) : null;
+    }
+
+    /** The active source URL or uploaded file name. */
+    public get source(): string | null {
+        return this._source;
+    }
+
+    /** Whether the active source was loaded from a URL or upload. */
+    public get sourceKind(): OBJSourceKind | null {
+        return this._sourceKind;
+    }
+
+    /** Defensive copies of the active companion files. Empty for the basic workflow. */
+    public get companions(): ReadonlyArray<IOBJSourceFile> {
+        return Object.freeze(this._companions.map(CloneSourceFile));
+    }
+
+    /**
+     * Makes one uploaded OBJ file the active source.
+     * @param bytes The uploaded `.obj` bytes.
+     * @param fileName The uploaded file name.
+     */
+    public setUploadedSource(bytes: Uint8Array, fileName: string): void {
+        if (!(bytes instanceof Uint8Array) || !IsOBJFileName(fileName)) {
+            throw new TypeError("Read OBJ requires a single .obj file.");
+        }
+        this._lastSuccessfulSourceAttempt = ++this._sourceAttempt;
+        this._primary = CloneSourceFile({ path: fileName, bytes });
+        this._source = fileName;
+        this._sourceKind = "upload";
+    }
+
+    /**
+     * Reads one uploaded OBJ and makes it active only if no newer source has succeeded.
+     * @param loadBytesAsync The uploaded file reader.
+     * @param fileName The uploaded file name.
+     * @param canApplyResult Optional ownership guard checked immediately before resolved bytes become active.
+     * @param applyResult Optional operation result populated after ownership and source-order checks.
+     */
+    public async setUploadedSourceAsync(
+        loadBytesAsync: () => Promise<ArrayBuffer>,
+        fileName: string,
+        canApplyResult: () => boolean = () => true,
+        applyResult?: IOBJSourceApplyResult
+    ): Promise<void> {
+        if (!IsOBJFileName(fileName)) {
+            throw new TypeError("Read OBJ requires a single .obj file.");
+        }
+        if (applyResult) {
+            applyResult.applied = false;
+        }
+        const sourceAttempt = ++this._sourceAttempt;
+        const bytes = new Uint8Array(await loadBytesAsync());
+        if (!canApplyResult() || sourceAttempt < this._lastSuccessfulSourceAttempt) {
+            return;
+        }
+        this._lastSuccessfulSourceAttempt = sourceAttempt;
+        this._primary = CloneSourceFile({ path: fileName, bytes });
+        this._source = fileName;
+        this._sourceKind = "upload";
+        if (applyResult) {
+            applyResult.applied = true;
+        }
+    }
+
+    /** Clears the active source and prevents older pending URL requests from replacing it. */
+    public clearSource(): void {
+        this._lastSuccessfulSourceAttempt = ++this._sourceAttempt;
+        this._primary = null;
+        this._source = null;
+        this._sourceKind = null;
+    }
+
+    /**
+     * Loads a URL and makes it active only after the request succeeds.
+     * @param url The OBJ URL.
+     * @param fetcher The fetch-compatible loader.
+     * @param canApplyResult Optional ownership guard checked immediately before resolved bytes become active.
+     */
+    public async setUrlAsync(
+        url: string,
+        fetcher: OBJSourceFetcher = async (sourceUrl) => await fetch(sourceUrl),
+        canApplyResult: () => boolean = () => true,
+        applyResult?: IOBJSourceApplyResult
+    ): Promise<void> {
+        if (typeof url !== "string" || url.trim().length === 0) {
+            throw new TypeError("Read OBJ requires a non-empty URL.");
+        }
+        if (applyResult) {
+            applyResult.applied = false;
+        }
+        const sourceAttempt = ++this._sourceAttempt;
+        let bytes: Uint8Array;
+        try {
+            const response = await fetcher(url);
+            if (!response.ok) {
+                throw new Error(`${response.status} ${response.statusText}`.trim());
+            }
+            bytes = new Uint8Array(await response.arrayBuffer());
+        } catch (error) {
+            if (!canApplyResult() || sourceAttempt < this._lastSuccessfulSourceAttempt) {
+                return;
+            }
+            throw new Error(`Could not load OBJ from "${url}": ${error instanceof Error ? error.message : String(error)}`, { cause: error });
+        }
+        if (!canApplyResult() || sourceAttempt < this._lastSuccessfulSourceAttempt) {
+            return;
+        }
+        this._lastSuccessfulSourceAttempt = sourceAttempt;
+        this._primary = CloneSourceFile({ path: url, bytes });
+        this._source = url;
+        this._sourceKind = "url";
+        if (applyResult) {
+            applyResult.applied = true;
+        }
+    }
+
+    /**
+     * Emits the active source without parsing OBJ geometry.
+     * @param scope The build scope used to account source bytes.
+     */
+    public override async _buildBlockAsync(scope?: BuildScope): Promise<void> {
+        const primary = this._primary;
+        const source = this._source;
+        const sourceKind = this._sourceKind;
+        if (!primary || !source || !sourceKind) {
+            throw new Error(`The "${this.name}" read block has no OBJ source.`);
+        }
+        scope?.accountSourceBytes(primary.bytes.byteLength + this._companions.reduce((total, companion) => total + companion.bytes.byteLength, 0));
+        this.output.value = new OBJSourceAsset(primary, source, sourceKind, this._companions);
+    }
+
+    /**
+     * Serializes the primary bytes, source choice, and forward-compatible companion list.
+     * @returns The serialized block.
+     */
+    public override serialize(): NodeAssetBlockSerialization {
+        return {
+            ...super.serialize(),
+            primary: this._primary ? { path: this._primary.path, bytes: EncodeArrayBufferToBase64(this._primary.bytes) } : null,
+            source: this._source,
+            sourceKind: this._sourceKind ?? "",
+            companions: [],
+        };
+    }
+
+    /**
+     * Restores one coherent persisted OBJ source state.
+     * @param serializationObject The serialized block.
+     */
+    public override _deserialize(serializationObject: NodeAssetBlockSerialization): void {
+        super._deserialize(serializationObject);
+        try {
+            const primary = serializationObject.primary;
+            const source = serializationObject.source;
+            const sourceKind = serializationObject.sourceKind;
+            const companions = serializationObject.companions;
+            if (!Array.isArray(companions) || companions.length !== 0) {
+                throw new TypeError("companions must be an empty array in the basic OBJ workflow.");
+            }
+
+            if (primary === null && source === null && sourceKind === "") {
+                this._primary = null;
+                this._source = null;
+                this._sourceKind = null;
+                return;
+            }
+            if (
+                typeof primary !== "object" ||
+                primary === null ||
+                Array.isArray(primary) ||
+                typeof primary.path !== "string" ||
+                primary.path.trim().length === 0 ||
+                typeof source !== "string" ||
+                source.trim().length === 0 ||
+                (sourceKind !== "url" && sourceKind !== "upload")
+            ) {
+                throw new TypeError("primary, source, and sourceKind must be present together.");
+            }
+            if (sourceKind === "upload" && !IsOBJFileName(primary.path)) {
+                throw new TypeError("an uploaded primary path must end in .obj.");
+            }
+
+            this._primary = CloneSourceFile({ path: primary.path, bytes: DecodeSerializedBytes(primary.bytes) });
+            this._source = source;
+            this._sourceKind = sourceKind;
+        } catch (error) {
+            throw new TypeError(`The "${this.name}" block has invalid persisted OBJ source state: ${error instanceof Error ? error.message : String(error)}`, { cause: error });
+        }
+    }
+}
+
+RegisterBlock(ReadOBJBlock.ClassName, (name, nodeAsset) => new ReadOBJBlock(name, nodeAsset));

--- a/packages/dev/node-assets/src/Blocks/readOBJBlock.ts
+++ b/packages/dev/node-assets/src/Blocks/readOBJBlock.ts
@@ -253,6 +253,7 @@ export class ReadOBJBlock extends NodeAssetBlock {
                 primary.path.trim().length === 0 ||
                 typeof source !== "string" ||
                 source.trim().length === 0 ||
+                source !== primary.path ||
                 (sourceKind !== "url" && sourceKind !== "upload")
             ) {
                 throw new TypeError("primary, source, and sourceKind must be present together.");

--- a/packages/dev/node-assets/src/Blocks/readOBJBlock.ts
+++ b/packages/dev/node-assets/src/Blocks/readOBJBlock.ts
@@ -156,6 +156,7 @@ export class ReadOBJBlock extends NodeAssetBlock {
      * @param url The OBJ URL.
      * @param fetcher The fetch-compatible loader.
      * @param canApplyResult Optional ownership guard checked immediately before resolved bytes become active.
+     * @param applyResult Optional operation result populated after ownership and source-order checks.
      */
     public async setUrlAsync(
         url: string,

--- a/packages/dev/node-assets/src/connection/nodeAssetConnectionPointType.ts
+++ b/packages/dev/node-assets/src/connection/nodeAssetConnectionPointType.ts
@@ -54,4 +54,7 @@ export enum NodeAssetConnectionPointType {
 
     /** Lightweight resolved USD source bytes consumed only by USD-to-Universal transcoding. */
     USD_SOURCE = 10,
+
+    /** A shallow OBJ source payload consumed only by OBJ-to-Universal transcoding. */
+    OBJ_SOURCE = 11,
 }

--- a/packages/dev/node-assets/src/connection/nodeAssetValueMap.ts
+++ b/packages/dev/node-assets/src/connection/nodeAssetValueMap.ts
@@ -4,6 +4,7 @@ import { type BabylonSource } from "../representations/babylonSource";
 import { type GltfAsset } from "../representations/gltfAsset";
 import { type NodeGeometryAsset } from "../representations/nodeGeometryAsset";
 import { type NodeGeometrySource } from "../representations/nodeGeometrySource";
+import { type OBJSourceAsset } from "../representations/objSourceAsset";
 import { type UsdAsset } from "../representations/usdAsset";
 import { type UsdSourceAsset } from "../representations/usdSourceAsset";
 import { type NodeAssetConnectionPointType } from "./nodeAssetConnectionPointType";
@@ -74,4 +75,5 @@ export type NodeAssetValueMap = {
     [NodeAssetConnectionPointType.UNIVERSAL]: GltfAsset;
     [NodeAssetConnectionPointType.BABYLON_SOURCE]: BabylonSource;
     [NodeAssetConnectionPointType.USD_SOURCE]: UsdSourceAsset;
+    [NodeAssetConnectionPointType.OBJ_SOURCE]: OBJSourceAsset;
 };

--- a/packages/dev/node-assets/src/index.ts
+++ b/packages/dev/node-assets/src/index.ts
@@ -43,6 +43,7 @@ export { type IUsdAssetMetadata, IsUsdAsset, UsdAsset } from "./representations/
 export { IsUsdSourceAsset, UsdSourceAsset, type USDSourceKind } from "./representations/usdSourceAsset";
 export { BabylonAsset, type IBabylonAssetMetadata, IsBabylonAsset } from "./representations/babylonAsset";
 export { BabylonSource, IsBabylonSource } from "./representations/babylonSource";
+export { type IOBJSourceFile, IsOBJSourceAsset, OBJSourceAsset, type OBJSourceKind } from "./representations/objSourceAsset";
 export { type INodeGeometryAssetMetadata, IsNodeGeometryAsset, NodeGeometryAsset } from "./representations/nodeGeometryAsset";
 export { type INodeGeometrySourceMetadata, IsNodeGeometrySource, NodeGeometrySource, type NodeGeometrySourceKind } from "./representations/nodeGeometrySource";
 export {
@@ -62,6 +63,9 @@ export { ExportGLTFAggregateBlock } from "./Blocks/exportGLTFAggregateBlock";
 export { type BabylonSourceFetcher, type BabylonSourceKind, type IBabylonSourceResponse, ReadBabylonBlock } from "./Blocks/readBabylonBlock";
 export { BabylonToUniversalBlock } from "./Blocks/babylonToUniversalBlock";
 export { ImportBabylonAggregateBlock } from "./Blocks/importBabylonAggregateBlock";
+export { type IOBJSourceApplyResult, type IOBJSourceResponse, type OBJSourceFetcher, ReadOBJBlock } from "./Blocks/readOBJBlock";
+export { OBJToUniversalBlock } from "./Blocks/objToUniversalBlock";
+export { ImportOBJAggregateBlock } from "./Blocks/importOBJAggregateBlock";
 export { type IUSDSourceResponse, ReadUSDBlock, type USDSourceFetcher } from "./Blocks/readUSDBlock";
 export { USDToUniversalBlock } from "./Blocks/usdToUniversalBlock";
 export { ImportUSDAggregateBlock } from "./Blocks/importUSDAggregateBlock";

--- a/packages/dev/node-assets/src/representations/objSourceAsset.ts
+++ b/packages/dev/node-assets/src/representations/objSourceAsset.ts
@@ -47,6 +47,12 @@ export class OBJSourceAsset {
         if (sourceKind !== "url" && sourceKind !== "upload") {
             throw new TypeError('The OBJ source kind must be either "url" or "upload".');
         }
+        if (source !== primary.path) {
+            throw new TypeError("The OBJ source identity must match the primary path.");
+        }
+        if (sourceKind === "upload" && !/\.obj$/i.test(primary.path)) {
+            throw new TypeError("The uploaded OBJ primary path must end in .obj.");
+        }
         if (!Array.isArray(companions)) {
             throw new TypeError("The OBJ companions must be an array.");
         }

--- a/packages/dev/node-assets/src/representations/objSourceAsset.ts
+++ b/packages/dev/node-assets/src/representations/objSourceAsset.ts
@@ -1,0 +1,81 @@
+/** Whether an OBJ source was resolved from a URL or an uploaded file. */
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export type OBJSourceKind = "url" | "upload";
+
+/** One path-addressable file in a shallow OBJ source payload. */
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export interface IOBJSourceFile {
+    /** The source path retained for loader resolution and persistence. */
+    readonly path: string;
+    /** The file's encoded bytes. */
+    readonly bytes: Uint8Array;
+}
+
+function CloneSourceFile(file: IOBJSourceFile): IOBJSourceFile {
+    return Object.freeze({ path: file.path, bytes: file.bytes.slice() });
+}
+
+function ValidateSourceFile(file: IOBJSourceFile, label: string): void {
+    if (typeof file !== "object" || file === null || typeof file.path !== "string" || file.path.trim().length === 0 || !(file.bytes instanceof Uint8Array)) {
+        throw new TypeError(`The OBJ ${label} must contain a non-empty path and Uint8Array bytes.`);
+    }
+}
+
+/** Immutable shallow OBJ source payload consumed only by OBJ-to-Universal transcoding. */
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export class OBJSourceAsset {
+    private readonly _primary: IOBJSourceFile;
+    private readonly _companions: ReadonlyArray<IOBJSourceFile>;
+
+    /** The active source URL or uploaded file name. */
+    public readonly source: string;
+    /** Whether the source was resolved from a URL or upload. */
+    public readonly sourceKind: OBJSourceKind;
+
+    /**
+     * Creates an immutable OBJ source payload with defensive copies of all file bytes.
+     * @param primary The required primary OBJ file.
+     * @param source The active source URL or uploaded file name.
+     * @param sourceKind Whether the source was resolved from a URL or upload.
+     * @param companions Optional path-addressable companion files.
+     */
+    public constructor(primary: IOBJSourceFile, source: string, sourceKind: OBJSourceKind, companions: ReadonlyArray<IOBJSourceFile> = []) {
+        ValidateSourceFile(primary, "primary");
+        if (typeof source !== "string" || source.trim().length === 0) {
+            throw new TypeError("The OBJ source identity must be a non-empty string.");
+        }
+        if (sourceKind !== "url" && sourceKind !== "upload") {
+            throw new TypeError('The OBJ source kind must be either "url" or "upload".');
+        }
+        if (!Array.isArray(companions)) {
+            throw new TypeError("The OBJ companions must be an array.");
+        }
+        companions.forEach((companion) => ValidateSourceFile(companion, "companion"));
+
+        this._primary = CloneSourceFile(primary);
+        this._companions = Object.freeze(companions.map(CloneSourceFile));
+        this.source = source;
+        this.sourceKind = sourceKind;
+        Object.freeze(this);
+    }
+
+    /** A defensive copy of the required primary OBJ file. */
+    public get primary(): IOBJSourceFile {
+        return CloneSourceFile(this._primary);
+    }
+
+    /** Defensive copies of the optional path-addressable companion files. */
+    public get companions(): ReadonlyArray<IOBJSourceFile> {
+        return Object.freeze(this._companions.map(CloneSourceFile));
+    }
+}
+
+/**
+ * Tests whether a runtime value is a shallow OBJ source payload.
+ * @param value The value to test.
+ * @returns Whether the value is an {@link OBJSourceAsset}.
+ */
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export function IsOBJSourceAsset(value: unknown): value is OBJSourceAsset {
+    return value instanceof OBJSourceAsset;
+}

--- a/packages/dev/node-assets/src/representations/objSourceAsset.ts
+++ b/packages/dev/node-assets/src/representations/objSourceAsset.ts
@@ -33,11 +33,11 @@ export class OBJSourceAsset {
     public readonly sourceKind: OBJSourceKind;
 
     /**
-     * Creates an immutable OBJ source payload with defensive copies of all file bytes.
+     * Creates an immutable basic-workflow OBJ source payload with a defensive copy of the primary bytes.
      * @param primary The required primary OBJ file.
      * @param source The active source URL or uploaded file name.
      * @param sourceKind Whether the source was resolved from a URL or upload.
-     * @param companions Optional path-addressable companion files.
+     * @param companions Reserved for forward-compatible companion files; must be empty in the basic workflow.
      */
     public constructor(primary: IOBJSourceFile, source: string, sourceKind: OBJSourceKind, companions: ReadonlyArray<IOBJSourceFile> = []) {
         ValidateSourceFile(primary, "primary");
@@ -56,7 +56,9 @@ export class OBJSourceAsset {
         if (!Array.isArray(companions)) {
             throw new TypeError("The OBJ companions must be an array.");
         }
-        companions.forEach((companion) => ValidateSourceFile(companion, "companion"));
+        if (companions.length !== 0) {
+            throw new TypeError("The OBJ companions must be an empty array in the basic OBJ workflow.");
+        }
 
         this._primary = CloneSourceFile(primary);
         this._companions = Object.freeze(companions.map(CloneSourceFile));
@@ -70,7 +72,7 @@ export class OBJSourceAsset {
         return CloneSourceFile(this._primary);
     }
 
-    /** Defensive copies of the optional path-addressable companion files. */
+    /** The reserved companion file list, which is always empty in the basic workflow. */
     public get companions(): ReadonlyArray<IOBJSourceFile> {
         return Object.freeze(this._companions.map(CloneSourceFile));
     }

--- a/packages/dev/node-assets/test/unit/blockRegistry.test.ts
+++ b/packages/dev/node-assets/test/unit/blockRegistry.test.ts
@@ -41,6 +41,7 @@ import {
     ImportGLTFAggregateBlock,
     ImportNodeGeometryAggregateBlock,
     ImportNodeGeometryBlock,
+    ImportOBJAggregateBlock,
     ImportUSDBlock,
     ImportUSDAggregateBlock,
     ImportImageBlock,
@@ -80,9 +81,11 @@ import {
     WriteGLTFBlock,
     ReadGLTFBlock,
     ReadNodeGeometryBlock,
+    ReadOBJBlock,
     ReadBabylonBlock,
     ReuseIdenticalMeshesBlock,
     ReadUSDBlock,
+    OBJToUniversalBlock,
     USDToUniversalBlock,
     CustomAggregateBlock,
     // eslint-disable-next-line import/no-internal-modules
@@ -272,9 +275,12 @@ describe("block self-registration", () => {
                     ReadUSDBlock.ClassName,
                     USDToUniversalBlock.ClassName,
                     ImportUSDAggregateBlock.ClassName,
+                    ReadOBJBlock.ClassName,
+                    OBJToUniversalBlock.ClassName,
+                    ImportOBJAggregateBlock.ClassName,
                 ])
             );
-            expect(registeredClassNames).toHaveLength(80);
+            expect(registeredClassNames).toHaveLength(83);
         });
 
         it.each(registeredClassNames)("round-trips %s through serialize/Parse", (className) => {

--- a/packages/dev/node-assets/test/unit/objUniversalFunnel.test.ts
+++ b/packages/dev/node-assets/test/unit/objUniversalFunnel.test.ts
@@ -17,6 +17,8 @@ import { NodeAssetConnectionPointType } from "../../src/connection/nodeAssetConn
 import { NodeAsset } from "../../src/nodeAsset";
 import { IsOBJSourceAsset, OBJSourceAsset } from "../../src/representations/objSourceAsset";
 
+vi.mock("draco3dgltf", async () => await vi.importActual("draco3dgltf"));
+
 const OBJFixture = new TextEncoder().encode(`# Synthetic NodeAssets OBJ fixture
 o FirstObject
 v 0 0 0

--- a/packages/dev/node-assets/test/unit/objUniversalFunnel.test.ts
+++ b/packages/dev/node-assets/test/unit/objUniversalFunnel.test.ts
@@ -171,6 +171,30 @@ describe("OBJ Universal funnel", () => {
         }
     });
 
+    it("builds a host-root query OBJ URL and resolves its MTL without dropping the host", async () => {
+        const source = "https://example.com?format=obj";
+        const materialUrl = "https://example.com/model.mtl";
+        const loadFile = vi.spyOn(Tools, "LoadFile").mockImplementation((url, onSuccess, _onProgress, _offlineProvider, _useArrayBuffer, onError) => {
+            if (url === materialUrl) {
+                onSuccess(MTLFixture);
+            } else {
+                onError?.(undefined, new Error(`Unexpected MTL URL: ${url}`));
+            }
+            return { abort: () => undefined, onCompleteObservable: new Observable() };
+        });
+        try {
+            const { asset, fetcher } = await CreateUrlPipelineAsync(source, OBJWithMaterialFixture);
+            const result = await asset.buildAsync();
+
+            expect(fetcher).toHaveBeenCalledExactlyOnceWith(source);
+            expect(loadFile).toHaveBeenCalledExactlyOnceWith(materialUrl, expect.any(Function), undefined, undefined, false, expect.any(Function));
+            expect(result.byteLength).toBeGreaterThan(0);
+            expect(await GetAssetFactsAsync(result)).toMatchObject({ meshCount: 1, primitiveCount: 1 });
+        } finally {
+            loadFile.mockRestore();
+        }
+    });
+
     it("rejects incoherent direct OBJ source payloads", () => {
         expect(() => new OBJSourceAsset({ path: "fixture.obj", bytes: OBJFixture }, "different.obj", "upload", [])).toThrow(/source identity must match the primary path/);
         expect(() => new OBJSourceAsset({ path: "fixture.txt", bytes: OBJFixture }, "fixture.txt", "upload", [])).toThrow(/uploaded OBJ primary path must end in \.obj/);

--- a/packages/dev/node-assets/test/unit/objUniversalFunnel.test.ts
+++ b/packages/dev/node-assets/test/unit/objUniversalFunnel.test.ts
@@ -7,6 +7,7 @@ import { Scene } from "core/scene";
 import { GLTF2Export } from "serializers/glTF/2.0/glTFSerializer";
 import { describe, expect, it, vi } from "vitest";
 
+import { ExportGLTFBlock } from "../../src/Blocks/exportGLTFBlock";
 import { ExportGLTFAggregateBlock } from "../../src/Blocks/exportGLTFAggregateBlock";
 import { ImportOBJAggregateBlock } from "../../src/Blocks/importOBJAggregateBlock";
 import { OBJToUniversalBlock } from "../../src/Blocks/objToUniversalBlock";
@@ -33,19 +34,37 @@ v 2 1 0
 f 4//1 5//1 6//1
 `);
 
+const OBJWithMaterialFixture = new TextEncoder().encode(`mtllib model.mtl
+o MaterialObject
+v 0 0 0
+v 1 0 0
+v 0 1 0
+vn 0 0 1
+usemtl Material
+f 1//1 2//1 3//1
+`);
+
+const MTLFixture = `newmtl Material
+Kd 1.0 0.0 0.0
+`;
+
 function ArrayBufferFor(bytes: Uint8Array): ArrayBuffer {
     return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
 }
 
-async function GetAssetFactsAsync(glb: Uint8Array): Promise<{ readonly sceneCount: number; readonly nodes: readonly string[]; readonly meshCount: number }> {
+async function GetAssetFactsAsync(
+    glb: Uint8Array
+): Promise<{ readonly sceneCount: number; readonly nodes: readonly string[]; readonly meshCount: number; readonly primitiveCount: number }> {
     const document = await new WebIO().registerExtensions(ALL_EXTENSIONS).readBinary(glb);
+    const meshes = document.getRoot().listMeshes();
     return {
         sceneCount: document.getRoot().listScenes().length,
         nodes: document
             .getRoot()
             .listNodes()
             .map((node) => node.getName()),
-        meshCount: document.getRoot().listMeshes().length,
+        meshCount: meshes.length,
+        primitiveCount: meshes.reduce((total, mesh) => total + mesh.listPrimitives().length, 0),
     };
 }
 
@@ -65,6 +84,25 @@ function CreatePrimitivePipeline(
     read.output.connectTo(transcoder.input);
     transcoder.output.connectTo(exporter.input);
     return { asset, read, transcoder };
+}
+
+async function CreateUrlPipelineAsync(url: string, bytes = OBJFixture) {
+    const asset = new NodeAsset("url-obj");
+    const read = new ReadOBJBlock("Read OBJ", asset);
+    const fetcher = vi.fn(async () => ({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        arrayBuffer: async () => ArrayBufferFor(bytes),
+    }));
+    await read.setUrlAsync(url, fetcher);
+    const objToUniversal = new OBJToUniversalBlock("OBJ to Universal", asset);
+    const universalToGltf = new UniversalToGLTFBlock("Universal to glTF", asset);
+    const exporter = new ExportGLTFBlock("Export glTF", asset);
+    read.output.connectTo(objToUniversal.input);
+    objToUniversal.output.connectTo(universalToGltf.input);
+    universalToGltf.output.connectTo(exporter.input);
+    return { asset, fetcher };
 }
 
 describe("OBJ Universal funnel", () => {
@@ -99,19 +137,53 @@ describe("OBJ Universal funnel", () => {
         expect(IsOBJSourceAsset(read.output.value)).toBe(true);
     });
 
-    it("accepts an extensionless direct URL identified as OBJ by its query", () => {
+    it("builds an extensionless query OBJ URL into an inspectable GLB", async () => {
         const source = "https://example.com/assets/model?format=obj";
-        const asset = new OBJSourceAsset({ path: source, bytes: OBJFixture }, source, "url", []);
+        const { asset, fetcher } = await CreateUrlPipelineAsync(source);
+        const result = await asset.buildAsync();
 
-        expect(asset.primary.path).toBe(source);
-        expect(asset.source).toBe(source);
-        expect(asset.sourceKind).toBe("url");
+        expect(fetcher).toHaveBeenCalledExactlyOnceWith(source);
+        expect(result.byteLength).toBeGreaterThan(0);
+        expect(await GetAssetFactsAsync(result)).toMatchObject({ meshCount: 2, primitiveCount: 2 });
+    });
+
+    it("builds a conventional OBJ URL and resolves its MTL relative to the source folder", async () => {
+        const source = "https://example.com/assets/model.obj";
+        const materialUrl = "https://example.com/assets/model.mtl";
+        const loadFile = vi.spyOn(Tools, "LoadFile").mockImplementation((url, onSuccess, _onProgress, _offlineProvider, _useArrayBuffer, onError) => {
+            if (url === materialUrl) {
+                onSuccess(MTLFixture);
+            } else {
+                onError?.(undefined, new Error(`Unexpected MTL URL: ${url}`));
+            }
+            return { abort: () => undefined, onCompleteObservable: new Observable() };
+        });
+        try {
+            const { asset, fetcher } = await CreateUrlPipelineAsync(source, OBJWithMaterialFixture);
+            const result = await asset.buildAsync();
+
+            expect(fetcher).toHaveBeenCalledExactlyOnceWith(source);
+            expect(loadFile).toHaveBeenCalledExactlyOnceWith(materialUrl, expect.any(Function), undefined, undefined, false, expect.any(Function));
+            expect(result.byteLength).toBeGreaterThan(0);
+            expect(await GetAssetFactsAsync(result)).toMatchObject({ meshCount: 1, primitiveCount: 1 });
+        } finally {
+            loadFile.mockRestore();
+        }
     });
 
     it("rejects incoherent direct OBJ source payloads", () => {
         expect(() => new OBJSourceAsset({ path: "fixture.obj", bytes: OBJFixture }, "different.obj", "upload", [])).toThrow(/source identity must match the primary path/);
         expect(() => new OBJSourceAsset({ path: "fixture.txt", bytes: OBJFixture }, "fixture.txt", "upload", [])).toThrow(/uploaded OBJ primary path must end in \.obj/);
         expect(() => new OBJSourceAsset({ path: "fixture.OBJ", bytes: OBJFixture }, "fixture.OBJ", "upload", [])).not.toThrow();
+    });
+
+    it("rejects non-empty companion arrays in the basic OBJ workflow", () => {
+        expect(
+            () =>
+                new OBJSourceAsset({ path: "fixture.obj", bytes: OBJFixture }, "fixture.obj", "upload", [
+                    { path: "fixture.mtl", bytes: new TextEncoder().encode("newmtl Material") },
+                ])
+        ).toThrowError(new TypeError("The OBJ companions must be an empty array in the basic OBJ workflow."));
     });
 
     it("builds an uploaded OBJ into a readable GLB and preserves multiple object and group names", async () => {
@@ -126,6 +198,7 @@ describe("OBJ Universal funnel", () => {
                 sceneCount: 1,
                 nodes: expect.arrayContaining(["FirstObject", "SecondGroup"]),
                 meshCount: 2,
+                primitiveCount: 2,
             });
             expect(sceneDispose).toHaveBeenCalled();
             expect(engineDispose).toHaveBeenCalled();

--- a/packages/dev/node-assets/test/unit/objUniversalFunnel.test.ts
+++ b/packages/dev/node-assets/test/unit/objUniversalFunnel.test.ts
@@ -96,6 +96,14 @@ describe("OBJ Universal funnel", () => {
         expect(IsOBJSourceAsset(read.output.value)).toBe(true);
     });
 
+    it("rejects incoherent direct OBJ source payloads", () => {
+        expect(() => new OBJSourceAsset({ path: "fixture.obj", bytes: OBJFixture }, "different.obj", "upload", [])).toThrow(/source identity must match the primary path/);
+        expect(() => new OBJSourceAsset({ path: "fixture.txt", bytes: OBJFixture }, "fixture.txt", "upload", [])).toThrow(
+            /uploaded OBJ primary path must end in \.obj/
+        );
+        expect(() => new OBJSourceAsset({ path: "fixture.OBJ", bytes: OBJFixture }, "fixture.OBJ", "upload", [])).not.toThrow();
+    });
+
     it("builds an uploaded OBJ into a readable GLB and preserves multiple object and group names", async () => {
         const sceneDispose = vi.spyOn(Scene.prototype, "dispose");
         const engineDispose = vi.spyOn(NullEngine.prototype, "dispose");

--- a/packages/dev/node-assets/test/unit/objUniversalFunnel.test.ts
+++ b/packages/dev/node-assets/test/unit/objUniversalFunnel.test.ts
@@ -1,0 +1,327 @@
+import { WebIO } from "@gltf-transform/core";
+import { ALL_EXTENSIONS } from "@gltf-transform/extensions";
+import { NullEngine } from "core/Engines/nullEngine";
+import { Observable } from "core/Misc/observable";
+import { Tools } from "core/Misc/tools.pure";
+import { Scene } from "core/scene";
+import { GLTF2Export } from "serializers/glTF/2.0/glTFSerializer";
+import { describe, expect, it, vi } from "vitest";
+
+import { ExportGLTFAggregateBlock } from "../../src/Blocks/exportGLTFAggregateBlock";
+import { ImportOBJAggregateBlock } from "../../src/Blocks/importOBJAggregateBlock";
+import { OBJToUniversalBlock } from "../../src/Blocks/objToUniversalBlock";
+import { ReadOBJBlock } from "../../src/Blocks/readOBJBlock";
+import { UniversalToGLTFBlock } from "../../src/Blocks/universalToGLTFBlock";
+import { WriteGLTFBlock } from "../../src/Blocks/writeGLTFBlock";
+import { NodeAssetConnectionPointType } from "../../src/connection/nodeAssetConnectionPointType";
+import { NodeAsset } from "../../src/nodeAsset";
+import { IsOBJSourceAsset, OBJSourceAsset } from "../../src/representations/objSourceAsset";
+
+const OBJFixture = new TextEncoder().encode(`# Synthetic NodeAssets OBJ fixture
+o FirstObject
+v 0 0 0
+v 1 0 0
+v 0 1 0
+vn 0 0 1
+f 1//1 2//1 3//1
+g SecondGroup
+v 2 0 0
+v 3 0 0
+v 2 1 0
+f 4//1 5//1 6//1
+`);
+
+function ArrayBufferFor(bytes: Uint8Array): ArrayBuffer {
+    return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
+}
+
+async function GetAssetFactsAsync(glb: Uint8Array): Promise<{ readonly sceneCount: number; readonly nodes: readonly string[]; readonly meshCount: number }> {
+    const document = await new WebIO().registerExtensions(ALL_EXTENSIONS).readBinary(glb);
+    return {
+        sceneCount: document.getRoot().listScenes().length,
+        nodes: document
+            .getRoot()
+            .listNodes()
+            .map((node) => node.getName()),
+        meshCount: document.getRoot().listMeshes().length,
+    };
+}
+
+function CreatePrimitivePipeline(bytes = OBJFixture, fileName = "fixture.OBJ"): {
+    readonly asset: NodeAsset;
+    readonly read: ReadOBJBlock;
+    readonly transcoder: OBJToUniversalBlock;
+} {
+    const asset = new NodeAsset("primitive-obj");
+    const read = new ReadOBJBlock("Read OBJ", asset);
+    read.setUploadedSource(bytes, fileName);
+    const transcoder = new OBJToUniversalBlock("OBJ to Universal", asset);
+    const exporter = new ExportGLTFAggregateBlock("Export glTF", asset);
+    read.output.connectTo(transcoder.input);
+    transcoder.output.connectTo(exporter.input);
+    return { asset, read, transcoder };
+}
+
+describe("OBJ Universal funnel", () => {
+    it("keeps an immutable shallow OBJ source behind its matching transcoder", async () => {
+        const sourceBytes = OBJFixture.slice();
+        const source = new OBJSourceAsset({ path: "fixture.obj", bytes: sourceBytes }, "fixture.obj", "upload", []);
+        sourceBytes[0] = 0;
+
+        const firstPrimary = source.primary;
+        firstPrimary.bytes[0] = 0;
+        expect(source.primary.bytes).toEqual(OBJFixture);
+        expect(source.companions).toEqual([]);
+        expect(Object.isFrozen(source.primary)).toBe(true);
+        expect(Object.isFrozen(source.companions)).toBe(true);
+        expect(IsOBJSourceAsset(source)).toBe(true);
+
+        const asset = new NodeAsset("obj-source-kind");
+        const read = new ReadOBJBlock("Read OBJ", asset);
+        const toUniversal = new OBJToUniversalBlock("OBJ to Universal", asset);
+        const toGltf = new UniversalToGLTFBlock("Universal to glTF", asset);
+        const write = new WriteGLTFBlock("Write glTF", asset);
+
+        expect(read.inputs).toHaveLength(0);
+        expect(read.output.type).toBe(NodeAssetConnectionPointType.OBJ_SOURCE);
+        expect(toUniversal.input.type).toBe(NodeAssetConnectionPointType.OBJ_SOURCE);
+        expect(() => read.output.connectTo(toGltf.input)).toThrow(/incompatible connection point types/);
+        expect(() => read.output.connectTo(write.input)).toThrow(/incompatible connection point types/);
+        expect(() => read.output.connectTo(toUniversal.input)).not.toThrow();
+
+        read.setUploadedSource(OBJFixture, "fixture.obj");
+        await read._buildBlockAsync();
+        expect(IsOBJSourceAsset(read.output.value)).toBe(true);
+    });
+
+    it("builds an uploaded OBJ into a readable GLB and preserves multiple object and group names", async () => {
+        const sceneDispose = vi.spyOn(Scene.prototype, "dispose");
+        const engineDispose = vi.spyOn(NullEngine.prototype, "dispose");
+        try {
+            const { asset } = CreatePrimitivePipeline();
+            const result = await asset.buildAsync();
+
+            expect(result.byteLength).toBeGreaterThan(0);
+            expect(await GetAssetFactsAsync(result)).toEqual({
+                sceneCount: 1,
+                nodes: expect.arrayContaining(["FirstObject", "SecondGroup"]),
+                meshCount: 2,
+            });
+            expect(sceneDispose).toHaveBeenCalled();
+            expect(engineDispose).toHaveBeenCalled();
+        } finally {
+            sceneDispose.mockRestore();
+            engineDispose.mockRestore();
+        }
+    });
+
+    it("round-trips primary bytes, source identity, empty companions, and aggregate behavior", async () => {
+        const asset = new NodeAsset("aggregate-obj");
+        const importer = new ImportOBJAggregateBlock("Import OBJ", asset);
+        importer.setUploadedSource(OBJFixture, "fixture.obj");
+        const exporter = new ExportGLTFAggregateBlock("Export glTF", asset);
+        importer.output.connectTo(exporter.input);
+
+        expect(importer.inputs).toHaveLength(0);
+        expect(importer.outputs).toEqual([importer.output]);
+        expect(importer.output.type).toBe(NodeAssetConnectionPointType.UNIVERSAL);
+        expect(importer.subgraph.attachedBlocks.map((block) => block.getClassName())).toEqual([ReadOBJBlock.ClassName, OBJToUniversalBlock.ClassName]);
+
+        const serialized = asset.serialize();
+        expect(serialized.blocks[0]).toMatchObject({
+            customType: ImportOBJAggregateBlock.ClassName,
+            aggregateVersion: 1,
+            subgraph: {
+                blocks: [
+                    {
+                        customType: ReadOBJBlock.ClassName,
+                        primary: { path: "fixture.obj", bytes: expect.any(String) },
+                        source: "fixture.obj",
+                        sourceKind: "upload",
+                        companions: [],
+                    },
+                    { customType: OBJToUniversalBlock.ClassName },
+                ],
+            },
+        });
+
+        const parsed = NodeAsset.Parse(JSON.parse(JSON.stringify(serialized)));
+        const parsedImporter = parsed.attachedBlocks[0] as ImportOBJAggregateBlock;
+        expect(parsedImporter.primary?.bytes).toEqual(OBJFixture);
+        expect(parsedImporter.source).toBe("fixture.obj");
+        expect(parsedImporter.sourceKind).toBe("upload");
+        expect(parsedImporter.companions).toEqual([]);
+        expect(await GetAssetFactsAsync(await parsed.buildAsync())).toMatchObject({ meshCount: 2 });
+    });
+
+    it("activates URLs only after success and keeps the last successful source on failure", async () => {
+        const asset = new NodeAsset("obj-source-choice");
+        const read = new ReadOBJBlock("Read OBJ", asset);
+        read.setUploadedSource(OBJFixture, "uploaded.obj");
+
+        await expect(
+            read.setUrlAsync("https://example.invalid/missing.obj", async () => ({
+                ok: false,
+                status: 404,
+                statusText: "Not Found",
+                arrayBuffer: async () => new ArrayBuffer(0),
+            }))
+        ).rejects.toThrow(/Could not load OBJ.*404 Not Found/);
+        expect(read.source).toBe("uploaded.obj");
+        expect(read.sourceKind).toBe("upload");
+
+        const remote = new TextEncoder().encode(new TextDecoder().decode(OBJFixture).replace("FirstObject", "RemoteObject"));
+        await read.setUrlAsync("https://cdn.example.com/assets/remote.obj?version=1", async () => ({
+            ok: true,
+            status: 200,
+            statusText: "OK",
+            arrayBuffer: async () => ArrayBufferFor(remote),
+        }));
+
+        expect(read.primary).toEqual({ path: "https://cdn.example.com/assets/remote.obj?version=1", bytes: remote });
+        expect(read.source).toBe("https://cdn.example.com/assets/remote.obj?version=1");
+        expect(read.sourceKind).toBe("url");
+        expect(read.companions).toEqual([]);
+    });
+
+    it("does not let an older URL replace a newer upload or a cleared source", async () => {
+        const asset = new NodeAsset("obj-source-race");
+        const read = new ReadOBJBlock("Read OBJ", asset);
+        let resolveResponse: ((response: { ok: boolean; status: number; statusText: string; arrayBuffer: () => Promise<ArrayBuffer> }) => void) | undefined;
+
+        const pendingUrl = read.setUrlAsync(
+            "https://example.com/remote.obj",
+            async () =>
+                await new Promise((resolve) => {
+                    resolveResponse = resolve;
+                })
+        );
+        read.setUploadedSource(OBJFixture, "uploaded.obj");
+        resolveResponse?.({
+            ok: true,
+            status: 200,
+            statusText: "OK",
+            arrayBuffer: async () => ArrayBufferFor(new Uint8Array([1, 2, 3])),
+        });
+        await pendingUrl;
+        expect(read.source).toBe("uploaded.obj");
+        expect(read.primary?.bytes).toEqual(OBJFixture);
+
+        const pendingAfterClear = read.setUrlAsync(
+            "https://example.com/cleared.obj",
+            async () =>
+                await new Promise((resolve) => {
+                    resolveResponse = resolve;
+                })
+        );
+        read.clearSource();
+        resolveResponse?.({
+            ok: true,
+            status: 200,
+            statusText: "OK",
+            arrayBuffer: async () => ArrayBufferFor(new Uint8Array([4, 5, 6])),
+        });
+        await pendingAfterClear;
+        expect(read.primary).toBeNull();
+        expect(read.source).toBeNull();
+        expect(read.sourceKind).toBeNull();
+        expect(read.companions).toEqual([]);
+    });
+
+    it("rejects invalid uploads without replacing the active source and owns defensive copies", () => {
+        const source = OBJFixture.slice();
+        const asset = new NodeAsset("obj-upload-validation");
+        const read = new ReadOBJBlock("Read OBJ", asset);
+        read.setUploadedSource(source, "valid.OBJ");
+        source[0] = 0;
+
+        const exposed = read.primary;
+        if (!exposed) {
+            throw new Error("Expected an active OBJ primary.");
+        }
+        exposed.bytes[0] = 0;
+        expect(read.primary?.bytes).toEqual(OBJFixture);
+        expect(() => read.setUploadedSource(new Uint8Array([1]), "not-obj.txt")).toThrow(/single \.obj file/i);
+        expect(read.source).toBe("valid.OBJ");
+        expect(read.primary?.bytes).toEqual(OBJFixture);
+    });
+
+    it("rejects malformed or incoherent persisted OBJ state contextually", () => {
+        const asset = new NodeAsset("obj-persistence-validation");
+        const read = new ReadOBJBlock("Read OBJ", asset);
+        read.setUploadedSource(OBJFixture, "fixture.obj");
+        const serialized = asset.serialize();
+
+        const invalidStates: Array<(block: Record<string, unknown>) => void> = [
+            (block) => {
+                block.primary = null;
+            },
+            (block) => {
+                block.sourceKind = "clipboard";
+            },
+            (block) => {
+                block.primary = { path: "fixture.obj", bytes: "***not-base64***" };
+            },
+            (block) => {
+                block.companions = [{ path: "future.mtl", bytes: "" }];
+            },
+            (block) => {
+                delete block.companions;
+            },
+            (block) => {
+                block.primary = { path: "fixture.txt", bytes: "" };
+            },
+        ];
+
+        for (const invalidate of invalidStates) {
+            const candidate = JSON.parse(JSON.stringify(serialized)) as { blocks: Array<Record<string, unknown>> };
+            invalidate(candidate.blocks[0]);
+            expect(() => NodeAsset.Parse(candidate)).toThrow(/Read OBJ.*persisted OBJ source state/);
+        }
+    });
+
+    it("accounts OBJ bytes before parsing", async () => {
+        const { asset } = CreatePrimitivePipeline();
+        await expect(asset.buildAsync({ limits: { maxSourceAssetBytes: OBJFixture.byteLength - 1 } })).rejects.toMatchObject({
+            code: "NODE_ASSET_LIMIT_SOURCE_BYTES",
+        });
+    });
+
+    it("preserves the loader's silent missing-MTL fallback and succeeds geometry-only", async () => {
+        const source = new TextEncoder().encode(`mtllib unavailable.mtl
+${new TextDecoder().decode(OBJFixture)}`);
+        const loadFile = vi.spyOn(Tools, "LoadFile").mockImplementation((_url, _onSuccess, _onProgress, _offlineProvider, _useArrayBuffer, onError) => {
+            onError?.(undefined, new Error("Unavailable synthetic MTL"));
+            return { abort: () => undefined, onCompleteObservable: new Observable() };
+        });
+        try {
+            const { asset } = CreatePrimitivePipeline(source, "missing-material.obj");
+            expect(await GetAssetFactsAsync(await asset.buildAsync())).toMatchObject({ meshCount: 2 });
+            expect(loadFile).toHaveBeenCalledWith("unavailable.mtl", expect.any(Function), undefined, undefined, false, expect.any(Function));
+        } finally {
+            loadFile.mockRestore();
+        }
+    });
+
+    it("disposes its scene and engine when an injected export failure rejects", async () => {
+        const asset = new NodeAsset("obj-cleanup");
+        const read = new ReadOBJBlock("Read OBJ", asset);
+        read.setUploadedSource(OBJFixture, "fixture.obj");
+        const transcoder = new OBJToUniversalBlock("OBJ to Universal", asset);
+        await read._buildBlockAsync();
+        transcoder.input.value = read.output.value;
+
+        const exportFailure = vi.spyOn(GLTF2Export, "GLBAsync").mockRejectedValueOnce(new Error("Injected OBJ export failure"));
+        const sceneDispose = vi.spyOn(Scene.prototype, "dispose");
+        const engineDispose = vi.spyOn(NullEngine.prototype, "dispose");
+        try {
+            await expect(transcoder._buildBlockAsync()).rejects.toThrow(/OBJ to Universal.*Injected OBJ export failure/);
+            expect(sceneDispose).toHaveBeenCalled();
+            expect(engineDispose).toHaveBeenCalled();
+        } finally {
+            exportFailure.mockRestore();
+            sceneDispose.mockRestore();
+            engineDispose.mockRestore();
+        }
+    });
+});

--- a/packages/dev/node-assets/test/unit/objUniversalFunnel.test.ts
+++ b/packages/dev/node-assets/test/unit/objUniversalFunnel.test.ts
@@ -49,7 +49,10 @@ async function GetAssetFactsAsync(glb: Uint8Array): Promise<{ readonly sceneCoun
     };
 }
 
-function CreatePrimitivePipeline(bytes = OBJFixture, fileName = "fixture.OBJ"): {
+function CreatePrimitivePipeline(
+    bytes = OBJFixture,
+    fileName = "fixture.OBJ"
+): {
     readonly asset: NodeAsset;
     readonly read: ReadOBJBlock;
     readonly transcoder: OBJToUniversalBlock;
@@ -96,11 +99,18 @@ describe("OBJ Universal funnel", () => {
         expect(IsOBJSourceAsset(read.output.value)).toBe(true);
     });
 
+    it("accepts an extensionless direct URL identified as OBJ by its query", () => {
+        const source = "https://example.com/assets/model?format=obj";
+        const asset = new OBJSourceAsset({ path: source, bytes: OBJFixture }, source, "url", []);
+
+        expect(asset.primary.path).toBe(source);
+        expect(asset.source).toBe(source);
+        expect(asset.sourceKind).toBe("url");
+    });
+
     it("rejects incoherent direct OBJ source payloads", () => {
         expect(() => new OBJSourceAsset({ path: "fixture.obj", bytes: OBJFixture }, "different.obj", "upload", [])).toThrow(/source identity must match the primary path/);
-        expect(() => new OBJSourceAsset({ path: "fixture.txt", bytes: OBJFixture }, "fixture.txt", "upload", [])).toThrow(
-            /uploaded OBJ primary path must end in \.obj/
-        );
+        expect(() => new OBJSourceAsset({ path: "fixture.txt", bytes: OBJFixture }, "fixture.txt", "upload", [])).toThrow(/uploaded OBJ primary path must end in \.obj/);
         expect(() => new OBJSourceAsset({ path: "fixture.OBJ", bytes: OBJFixture }, "fixture.OBJ", "upload", [])).not.toThrow();
     });
 

--- a/packages/dev/node-assets/test/unit/objUniversalFunnel.test.ts
+++ b/packages/dev/node-assets/test/unit/objUniversalFunnel.test.ts
@@ -271,6 +271,9 @@ describe("OBJ Universal funnel", () => {
             (block) => {
                 block.primary = { path: "fixture.txt", bytes: "" };
             },
+            (block) => {
+                block.source = "different.obj";
+            },
         ];
 
         for (const invalidate of invalidStates) {

--- a/packages/dev/node-assets/test/unit/typedRepresentations.test.ts
+++ b/packages/dev/node-assets/test/unit/typedRepresentations.test.ts
@@ -11,6 +11,7 @@ import { type NodeAssetJsonValue, type NodeAssetValueMap } from "../../src/conne
 import { BabylonAsset, IsBabylonAsset } from "../../src/representations/babylonAsset";
 import { GltfAsset, IsGltfAsset } from "../../src/representations/gltfAsset";
 import { IsNodeGeometryAsset, NodeGeometryAsset } from "../../src/representations/nodeGeometryAsset";
+import { OBJSourceAsset } from "../../src/representations/objSourceAsset";
 import { IsUsdAsset, UsdAsset } from "../../src/representations/usdAsset";
 import { UsdSourceAsset } from "../../src/representations/usdSourceAsset";
 
@@ -104,6 +105,7 @@ describe("typed representations", () => {
         expect(NodeAssetConnectionPointType.NODE_GEOMETRY).toBe(7);
         expect(NodeAssetConnectionPointType.UNIVERSAL).toBe(8);
         expect(NodeAssetConnectionPointType.USD_SOURCE).toBe(10);
+        expect(NodeAssetConnectionPointType.OBJ_SOURCE).toBe(11);
         expect("REPRESENTATION" in NodeAssetConnectionPointType).toBe(false);
         expect(NodeAssetConnectionPointType[NodeAssetConnectionPointType.GLTF_DOCUMENT]).toBe("GLTF_DOCUMENT");
     });
@@ -112,6 +114,7 @@ describe("typed representations", () => {
         expectTypeOf<NodeAssetValueMap[NodeAssetConnectionPointType.GLTF_DOCUMENT]>().toEqualTypeOf<GltfAsset>();
         expectTypeOf<NodeAssetValueMap[NodeAssetConnectionPointType.USD_STAGE]>().toEqualTypeOf<UsdAsset>();
         expectTypeOf<NodeAssetValueMap[NodeAssetConnectionPointType.USD_SOURCE]>().toEqualTypeOf<UsdSourceAsset>();
+        expectTypeOf<NodeAssetValueMap[NodeAssetConnectionPointType.OBJ_SOURCE]>().toEqualTypeOf<OBJSourceAsset>();
         expectTypeOf<NodeAssetValueMap[NodeAssetConnectionPointType.BABYLON_SCENE]>().toEqualTypeOf<BabylonAsset>();
         expectTypeOf<NodeAssetValueMap[NodeAssetConnectionPointType.NODE_GEOMETRY]>().toEqualTypeOf<NodeGeometryAsset>();
         expectTypeOf<NodeAssetValueMap[NodeAssetConnectionPointType.NUMBER]>().toEqualTypeOf<number>();

--- a/packages/tools/nodeAssetsEditor/src/nodeAssets/blockCatalog.ts
+++ b/packages/tools/nodeAssetsEditor/src/nodeAssets/blockCatalog.ts
@@ -31,6 +31,10 @@ export const ScenePortColor = "#d97b3f";
 /** Data-driven dot color for Universal ports, distinct from the glTF delivery lane. */
 export const UniversalPortColor = "#2f8f83";
 
+/** Data-driven dot color for OBJ source ports, distinct from every existing representation lane. */
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export const OBJPortColor = "#B86B3D";
+
 /** Data-driven dot colors for the scalar port kinds, so each renders distinctly from SCENE. */
 export const NumberPortColor = "#3f79d9";
 export const StringPortColor = "#3fa86b";
@@ -107,6 +111,10 @@ export const TranscodersHeaderColor = "#6B4C8A";
 /** Palette category and shared node header color for the Babylon operator block family. */
 export const BabylonCategory = "Babylon";
 export const BabylonHeaderColor = "#4A90D9";
+
+/** Shared node header color for the OBJ source and transcoder block family. */
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export const OBJHeaderColor = "#B86B3D";
 
 /** Palette category and shared node header color for the USD operator block family. */
 // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/packages/tools/nodeAssetsEditor/src/nodeAssets/blockDescriptors/importOBJAggregateBlockDescriptor.ts
+++ b/packages/tools/nodeAssetsEditor/src/nodeAssets/blockDescriptors/importOBJAggregateBlockDescriptor.ts
@@ -1,0 +1,15 @@
+import { ImportOBJAggregateBlock } from "node-assets/Blocks/importOBJAggregateBlock";
+
+import { AggregateImportsFamily, ConfigureBlockForEditor, OBJHeaderColor, RegisterBlockDescriptor } from "../blockCatalog";
+
+RegisterBlockDescriptor({
+    paletteItemId: "import-obj",
+    label: "Import OBJ",
+    description: "Read an OBJ source and cross into Universal.",
+    keywords: ["open", "load", "source", "obj", "Universal"],
+    category: "Inputs",
+    family: AggregateImportsFamily,
+    headerColor: OBJHeaderColor,
+    className: ImportOBJAggregateBlock.ClassName,
+    create: (nodeAsset) => ConfigureBlockForEditor(new ImportOBJAggregateBlock("Import OBJ", nodeAsset)),
+});

--- a/packages/tools/nodeAssetsEditor/src/nodeAssets/blockDescriptors/index.ts
+++ b/packages/tools/nodeAssetsEditor/src/nodeAssets/blockDescriptors/index.ts
@@ -5,6 +5,7 @@
  */
 
 import "./importGLTFBlockDescriptor";
+import "./importOBJAggregateBlockDescriptor";
 import "./importUSDBlockDescriptor";
 import "./importBabylonAggregateBlockDescriptor";
 import "./importNodeGeometryBlockDescriptor";
@@ -33,10 +34,12 @@ import "./ktx2CompressionBlockDescriptor";
 import "./exportGLTFBlockDescriptor";
 
 import "./readGLTFBlockDescriptor";
+import "./readOBJBlockDescriptor";
 import "./readUSDBlockDescriptor";
 import "./readBabylonBlockDescriptor";
 import "./readNodeGeometryBlockDescriptor";
 import "./gltfToUniversalBlockDescriptor";
+import "./objToUniversalBlockDescriptor";
 import "./writeGLTFBlockDescriptor";
 import "./usdToUniversalBlockDescriptor";
 import "./babylonToUniversalBlockDescriptor";

--- a/packages/tools/nodeAssetsEditor/src/nodeAssets/blockDescriptors/objToUniversalBlockDescriptor.ts
+++ b/packages/tools/nodeAssetsEditor/src/nodeAssets/blockDescriptors/objToUniversalBlockDescriptor.ts
@@ -1,0 +1,15 @@
+import { OBJToUniversalBlock } from "node-assets/Blocks/objToUniversalBlock";
+
+import { OBJHeaderColor, RegisterBlockDescriptor } from "../blockCatalog";
+
+RegisterBlockDescriptor({
+    paletteItemId: "obj-to-universal",
+    label: "OBJ to Universal",
+    description: "Parse an OBJ source and cross into Universal.",
+    keywords: ["convert", "transcode", "obj", "Universal"],
+    category: "OBJ",
+    headerColor: OBJHeaderColor,
+    className: OBJToUniversalBlock.ClassName,
+    abstractedBy: "import-obj",
+    create: (nodeAsset) => new OBJToUniversalBlock("OBJ to Universal", nodeAsset),
+});

--- a/packages/tools/nodeAssetsEditor/src/nodeAssets/blockDescriptors/readOBJBlockDescriptor.ts
+++ b/packages/tools/nodeAssetsEditor/src/nodeAssets/blockDescriptors/readOBJBlockDescriptor.ts
@@ -1,0 +1,147 @@
+import { ReadOBJBlock } from "node-assets/Blocks/readOBJBlock";
+
+import { type IPropertySection } from "../../nodeGraph/propertyModel";
+import { PromptForFileAsync } from "../browserFiles";
+import { ConfigureBlockForEditor, type IPropertySectionContext, OBJHeaderColor, RegisterBlockDescriptor } from "../blockCatalog";
+
+const SourceErrors = new WeakMap<ReadOBJBlock, string>();
+const PendingSourceRequests = new WeakMap<ReadOBJBlock, Promise<unknown>>();
+
+// eslint-disable-next-line @typescript-eslint/naming-convention
+async function PromptForOBJAsync(block: ReadOBJBlock, context: IPropertySectionContext): Promise<void> {
+    const file = await PromptForFileAsync(".obj");
+    if (!file) {
+        return;
+    }
+    const authoredBlock = context.prepareEdit(block);
+    if (!authoredBlock) {
+        return;
+    }
+    const applyResult = { applied: false };
+    const request = authoredBlock.setUploadedSourceAsync(
+        async () => await file.arrayBuffer(),
+        file.name,
+        () => context.prepareEdit(authoredBlock) === authoredBlock,
+        applyResult
+    );
+    PendingSourceRequests.set(authoredBlock, request);
+    try {
+        await request;
+        if (context.prepareEdit(authoredBlock) === authoredBlock && applyResult.applied) {
+            SourceErrors.delete(authoredBlock);
+        }
+    } catch (error) {
+        if (context.prepareEdit(authoredBlock) === authoredBlock && PendingSourceRequests.get(authoredBlock) === request) {
+            SourceErrors.set(authoredBlock, error instanceof Error ? error.message : String(error));
+        }
+    } finally {
+        if (PendingSourceRequests.get(authoredBlock) === request) {
+            PendingSourceRequests.delete(authoredBlock);
+        }
+    }
+    if (context.prepareEdit(authoredBlock) === authoredBlock) {
+        context.refresh();
+    }
+}
+
+// eslint-disable-next-line @typescript-eslint/naming-convention
+async function SetOBJUrlAsync(block: ReadOBJBlock, url: string, context: IPropertySectionContext): Promise<void> {
+    const authoredBlock = context.prepareEdit(block);
+    if (!authoredBlock) {
+        return;
+    }
+    const applyResult = { applied: false };
+    const request = authoredBlock.setUrlAsync(url, undefined, () => context.prepareEdit(authoredBlock) === authoredBlock, applyResult);
+    PendingSourceRequests.set(authoredBlock, request);
+    try {
+        await request;
+        if (context.prepareEdit(authoredBlock) === authoredBlock && applyResult.applied) {
+            SourceErrors.delete(authoredBlock);
+        }
+    } catch (error) {
+        if (context.prepareEdit(authoredBlock) === authoredBlock && PendingSourceRequests.get(authoredBlock) === request) {
+            SourceErrors.set(authoredBlock, error instanceof Error ? error.message : String(error));
+        }
+    } finally {
+        if (PendingSourceRequests.get(authoredBlock) === request) {
+            PendingSourceRequests.delete(authoredBlock);
+        }
+    }
+    if (context.prepareEdit(authoredBlock) === authoredBlock) {
+        context.refresh();
+    }
+}
+
+/**
+ * Builds the source controls shared by Read OBJ and Import OBJ.
+ * @param block The owned Read OBJ primitive.
+ * @param context Editor property actions.
+ * @param title Child-attributed section title.
+ * @returns The shared property section.
+ */
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export function CreateReadOBJPropertySection(block: ReadOBJBlock, context: IPropertySectionContext, title = "SOURCE"): IPropertySection {
+    const sourceError = SourceErrors.get(block);
+    return {
+        title,
+        properties: [
+            {
+                kind: "text",
+                label: "URL",
+                value: block.sourceKind === "url" ? (block.source ?? "") : "",
+                validateOnlyOnBlur: true,
+                onChange: (value) => {
+                    if (!value) {
+                        const authoredBlock = context.prepareEdit(block);
+                        if (!authoredBlock) {
+                            return;
+                        }
+                        authoredBlock.clearSource();
+                        PendingSourceRequests.delete(authoredBlock);
+                        SourceErrors.delete(authoredBlock);
+                        context.refresh();
+                        return;
+                    }
+                    void SetOBJUrlAsync(block, value, context);
+                },
+            },
+            {
+                kind: "text",
+                label: "Active source",
+                value: block.source ?? "No source loaded",
+                disabled: true,
+                onChange: () => undefined,
+            },
+            {
+                kind: "button",
+                label: "Upload OBJ\u2026",
+                onClick: () => {
+                    void PromptForOBJAsync(block, context);
+                },
+            },
+            ...(sourceError
+                ? ([
+                      {
+                          kind: "text",
+                          label: "Source error",
+                          value: sourceError,
+                          disabled: true,
+                          onChange: () => undefined,
+                      },
+                  ] as const)
+                : []),
+        ],
+    };
+}
+
+RegisterBlockDescriptor({
+    paletteItemId: "read-obj",
+    label: "Read OBJ",
+    description: "Read a URL or one uploaded .obj source.",
+    category: "Inputs",
+    headerColor: OBJHeaderColor,
+    className: ReadOBJBlock.ClassName,
+    abstractedBy: "import-obj",
+    create: (nodeAsset) => ConfigureBlockForEditor(new ReadOBJBlock("Read OBJ", nodeAsset)),
+    getPropertySection: (block, context) => CreateReadOBJPropertySection(block as ReadOBJBlock, context),
+});

--- a/packages/tools/nodeAssetsEditor/src/nodeAssets/blockNodeMapping.ts
+++ b/packages/tools/nodeAssetsEditor/src/nodeAssets/blockNodeMapping.ts
@@ -18,6 +18,7 @@ import {
     JsonPortColor,
     NodeGeometryPortColor,
     NumberPortColor,
+    OBJPortColor,
     ScenePortColor,
     StringPortColor,
     UsdStagePortColor,
@@ -67,6 +68,7 @@ const PortStyleByType: Partial<Record<NodeAssetConnectionPointType, { readonly n
     [NodeAssetConnectionPointType.NODE_GEOMETRY]: { name: "Node Geometry", color: NodeGeometryPortColor },
     [NodeAssetConnectionPointType.UNIVERSAL]: { name: "Universal", color: UniversalPortColor },
     [NodeAssetConnectionPointType.BABYLON_SOURCE]: { name: "Babylon", color: BabylonScenePortColor },
+    [NodeAssetConnectionPointType.OBJ_SOURCE]: { name: "OBJ", color: OBJPortColor },
 };
 
 /**

--- a/packages/tools/nodeAssetsEditor/src/nodeAssets/builtInLibraryEntries.ts
+++ b/packages/tools/nodeAssetsEditor/src/nodeAssets/builtInLibraryEntries.ts
@@ -91,6 +91,32 @@ class BuiltInPipelineBuilder {
         );
     }
 
+    public addOBJImport(name: string, x: number, y: number, data: Uint8Array, source: string): BlockReference {
+        const readId = this._allocateId();
+        const transcoderId = this._allocateId();
+        return this._addAggregate(
+            "ImportOBJAggregateBlock",
+            name,
+            x,
+            y,
+            [
+                {
+                    customType: "ReadOBJBlock",
+                    id: readId,
+                    name: "Read OBJ",
+                    primary: { path: source, bytes: EncodeArrayBufferToBase64(data) },
+                    source,
+                    sourceKind: "upload",
+                    companions: [],
+                },
+                { customType: "OBJToUniversalBlock", id: transcoderId, name: "OBJ to Universal" },
+            ],
+            [{ fromBlock: readId, fromPoint: "output", toBlock: transcoderId, toPoint: "input" }],
+            [],
+            [{ publicName: "output", blockId: transcoderId, pointName: "output" }]
+        );
+    }
+
     public addExport(x: number, y: number): BlockReference {
         const transcoderId = this._allocateId();
         const writeId = this._allocateId();
@@ -212,6 +238,10 @@ function CreateUsdImport(builder: BuiltInPipelineBuilder, x = 40, y = 120): Bloc
     );
 }
 
+function CreateOBJImport(builder: BuiltInPipelineBuilder, x = 40, y = 120): BlockReference {
+    return builder.addOBJImport("Import OBJ", x, y, BuiltInLibraryFixtures.obj, "catalog-objects.obj");
+}
+
 function CreateBabylonImport(builder: BuiltInPipelineBuilder, x = 40, y = 120): BlockReference {
     return builder.addImport(
         "ImportBabylonAggregateBlock",
@@ -265,6 +295,22 @@ function CreateGltfOptimizationEntry(): INodeAssetLibraryEntry {
 function CreateUsdOptimizationEntry(): INodeAssetLibraryEntry {
     const builder = new BuiltInPipelineBuilder("USD to Optimized glTF");
     const source = CreateUsdImport(builder);
+    const prune = builder.addBlock("RemoveUnusedResourcesBlock", "Remove Unused Resources", 360, 120, {
+        keptPropertyTypes: [],
+        keepLeafNodes: false,
+        keepAttributes: false,
+        keepSolidTextures: false,
+        keepExtras: false,
+    });
+    const output = builder.addExport(680, 120);
+    builder.connect(source, prune);
+    builder.connect(prune, output);
+    return builder.createEntry();
+}
+
+function CreateOBJOptimizationEntry(): INodeAssetLibraryEntry {
+    const builder = new BuiltInPipelineBuilder("OBJ to Optimized glTF");
+    const source = CreateOBJImport(builder);
     const prune = builder.addBlock("RemoveUnusedResourcesBlock", "Remove Unused Resources", 360, 120, {
         keptPropertyTypes: [],
         keepLeafNodes: false,
@@ -356,6 +402,7 @@ function CreateFullOptimizationEntry(): INodeAssetLibraryEntry {
 
 const BuiltInNodeAssetLibraryEntries = Object.freeze([
     CreateGltfOptimizationEntry(),
+    CreateOBJOptimizationEntry(),
     CreateUsdOptimizationEntry(),
     CreateBabylonOptimizationEntry(),
     CreateNodeGeometryEntry(),

--- a/packages/tools/nodeAssetsEditor/src/nodeAssets/builtInLibraryFixtures.ts
+++ b/packages/tools/nodeAssetsEditor/src/nodeAssets/builtInLibraryFixtures.ts
@@ -114,6 +114,19 @@ def Xform "World"
             cameras: [],
         })
     ),
+    obj: TextEncoderInstance.encode(`# Synthetic repository-authored OBJ source
+o CatalogObject
+v 0 0 0
+v 1 0 0
+v 0 1 0
+vn 0 0 1
+f 1//1 2//1 3//1
+g CatalogGroup
+v 2 0 0
+v 3 0 0
+v 2 1 0
+f 4//1 5//1 6//1
+`),
     nodeGeometry: TextEncoderInstance.encode(
         JSON.stringify({
             customType: "BABYLON.NodeGeometry",

--- a/packages/tools/nodeAssetsEditor/test/playwright/nodeAssetsEditor.test.ts
+++ b/packages/tools/nodeAssetsEditor/test/playwright/nodeAssetsEditor.test.ts
@@ -582,6 +582,7 @@ test.describe("Node Assets Editor — maintained default pipeline", () => {
         const exportNode = editor.nodeByTitle("Export glTF");
         const defaultItems = [
             "Import glTF",
+            "Import OBJ",
             "Import USD",
             "Import Babylon",
             "Import Node Geometry",
@@ -609,7 +610,7 @@ test.describe("Node Assets Editor — maintained default pipeline", () => {
 
         await expect(showPrimitives).not.toBeChecked();
         await expect(nodeGeometryCategory).toHaveCount(0);
-        await expect(categories).toHaveText(["Inputs (4)", "Universal (17)", "glTF (3)"]);
+        await expect(categories).toHaveText(["Inputs (5)", "Universal (17)", "glTF (3)"]);
         await expect(families).toHaveText(["Aggregate imports", "Cleanup", "Reduction", "Structure", "Attributes", "Textures", "Encoding/output"]);
         await expect(items).toHaveText(defaultItems);
         await search.fill("Write glTF");
@@ -621,23 +622,25 @@ test.describe("Node Assets Editor — maintained default pipeline", () => {
         await showPrimitives.check();
         await expect(items).toHaveText(["Write glTF"]);
         await search.clear();
-        await expect(categories).toHaveText(["Inputs (8)", "Universal (22)", "glTF (5)", "USD (1)", "Babylon (1)", "Node Geometry (1)"]);
+        await expect(categories).toHaveText(["Inputs (10)", "Universal (22)", "glTF (5)", "OBJ (1)", "USD (1)", "Babylon (1)", "Node Geometry (1)"]);
         await expect(families).toHaveText(["Aggregate imports", "Cleanup", "Reduction", "Structure", "Attributes", "Textures", "Encoding/output"]);
         await expect(items).toHaveText([
-            ...defaultItems.slice(0, 4),
+            ...defaultItems.slice(0, 5),
             "Read glTF",
+            "Read OBJ",
             "Read USD",
             "Read Babylon",
             "Read Node Geometry",
-            ...defaultItems.slice(4, 21),
+            ...defaultItems.slice(5, 22),
             "Universal → glTF",
             "Deduplicate Materials",
             "Deduplicate Textures",
             "Reuse Identical Meshes",
             "Deduplicate Data",
-            ...defaultItems.slice(21),
+            ...defaultItems.slice(22),
             "glTF → Universal",
             "Write glTF",
+            "OBJ to Universal",
             "USD → Universal",
             "Babylon → Universal",
             "Node Geometry → Universal",
@@ -651,7 +654,7 @@ test.describe("Node Assets Editor — maintained default pipeline", () => {
         await showPrimitives.uncheck();
         await expect(nodeGeometryCategory).toHaveCount(0);
         await expect(page.getByTitle("Read Babylon", { exact: true })).toHaveCount(0);
-        await expect(categories).toHaveText(["Inputs (4)", "Universal (17)", "glTF (3)"]);
+        await expect(categories).toHaveText(["Inputs (5)", "Universal (17)", "glTF (3)"]);
         await expect(items).toHaveText(defaultItems);
         await expect(editor.nodeByTitle("Read Babylon")).toBeVisible();
         await expect(editor.nodeByTitle("Write glTF")).toBeVisible();
@@ -659,7 +662,7 @@ test.describe("Node Assets Editor — maintained default pipeline", () => {
         await showPrimitives.check();
         await page.reload({ waitUntil: "load" });
         await expect(showPrimitives).toBeChecked();
-        await expect(categories).toHaveText(["Inputs (8)", "Universal (22)", "glTF (5)", "USD (1)", "Babylon (1)", "Node Geometry (1)"]);
+        await expect(categories).toHaveText(["Inputs (10)", "Universal (22)", "glTF (5)", "OBJ (1)", "USD (1)", "Babylon (1)", "Node Geometry (1)"]);
     });
 
     test("extends node selection with the platform multi-select modifier", async ({ page }) => {

--- a/packages/tools/nodeAssetsEditor/test/unit/blockNodeMapping.test.ts
+++ b/packages/tools/nodeAssetsEditor/test/unit/blockNodeMapping.test.ts
@@ -4,7 +4,7 @@ import { NodeAsset } from "node-assets/nodeAsset";
 import { NodeAssetBlock } from "node-assets/blockFoundation/nodeAssetBlock";
 import { NodeAssetConnectionPointType } from "node-assets/connection/nodeAssetConnectionPointType";
 
-import { NumberPortColor, ScenePortColor, UsdStagePortColor, BabylonScenePortColor, NodeGeometryPortColor, type IBlockDescriptor } from "../../src/nodeAssets/blockCatalog";
+import { NumberPortColor, OBJPortColor, ScenePortColor, UsdStagePortColor, BabylonScenePortColor, NodeGeometryPortColor, type IBlockDescriptor } from "../../src/nodeAssets/blockCatalog";
 import { BlockToNode, NodeIdForBlock, PointToPort, PortIdForPoint } from "../../src/nodeAssets/blockNodeMapping";
 
 class MappingTestBlock extends NodeAssetBlock {
@@ -24,6 +24,7 @@ class RepresentationMappingTestBlock extends NodeAssetBlock {
     public readonly babylon = this._registerOutput("babylon", NodeAssetConnectionPointType.BABYLON_SCENE);
     public readonly nodeGeometry = this._registerOutput("nodeGeometry", NodeAssetConnectionPointType.NODE_GEOMETRY);
     public readonly usdSource = this._registerOutput("usdSource", NodeAssetConnectionPointType.USD_SOURCE);
+    public readonly objSource = this._registerOutput("objSource", NodeAssetConnectionPointType.OBJ_SOURCE);
 
     public override async _buildBlockAsync(): Promise<void> {}
 }
@@ -74,6 +75,9 @@ describe("blockNodeMapping", () => {
         expect(PointToPort(block, block.babylon).color).toBe(BabylonScenePortColor);
         expect(PointToPort(block, block.nodeGeometry).color).toBe(NodeGeometryPortColor);
         expect(PointToPort(block, block.usdSource)).toMatchObject({ name: "USD", color: UsdStagePortColor });
+        expect(PointToPort(block, block.objSource)).toMatchObject({ name: "OBJ", color: OBJPortColor });
+        expect(OBJPortColor).not.toBe(UsdStagePortColor);
+        expect(OBJPortColor).not.toBe(BabylonScenePortColor);
     });
 
     it("builds a node with input ports before output ports", () => {

--- a/packages/tools/nodeAssetsEditor/test/unit/builtInLibraryEntries.test.ts
+++ b/packages/tools/nodeAssetsEditor/test/unit/builtInLibraryEntries.test.ts
@@ -11,6 +11,7 @@ import { type INodeAssetBuildClient } from "../../src/nodeAssets/nodeAssetBuildW
 
 const ExpectedPipelineNames = [
     "glTF Optimization",
+    "OBJ to Optimized glTF",
     "USD to Optimized glTF",
     "Babylon to Optimized glTF",
     "Node Geometry to glTF",
@@ -93,7 +94,7 @@ function CollectBlockTypes(blocks: SerializedBlockShape[]): string[] {
 }
 
 describe("built-in NodeAsset pipeline catalog", () => {
-    it("publishes exactly the seven maintained production pipelines", () => {
+    it("publishes exactly the eight maintained production pipelines", () => {
         const entries = CreateBuiltInNodeAssetLibraryEntries();
 
         expect(entries.map((entry) => entry.name)).toEqual(ExpectedPipelineNames);
@@ -150,4 +151,42 @@ describe("built-in NodeAsset pipeline catalog", () => {
             }
         }
     }, 180_000);
+
+    it("round-trips and builds the OBJ catalog entry without requesting the network", async () => {
+        const entry = CreateBuiltInNodeAssetLibraryEntries().find((candidate) => candidate.name === "OBJ to Optimized glTF");
+        expect(entry).toBeDefined();
+        if (!entry) {
+            return;
+        }
+
+        const fetchMock = vi.fn(async () => {
+            throw new Error("The built-in OBJ graph must not request the network.");
+        });
+        vi.stubGlobal("fetch", fetchMock);
+        try {
+            const editorFile = JSON.parse(entry.serializedGraph) as {
+                graph: {
+                    blocks: Array<{
+                        customType: string;
+                        subgraph?: { blocks?: Array<Record<string, unknown>> };
+                    }>;
+                };
+            };
+            const importer = editorFile.graph.blocks.find((block) => block.customType === "ImportOBJAggregateBlock");
+            expect(importer?.subgraph?.blocks?.[0]).toMatchObject({
+                customType: "ReadOBJBlock",
+                primary: { path: "catalog-objects.obj", bytes: expect.any(String) },
+                source: "catalog-objects.obj",
+                sourceKind: "upload",
+                companions: [],
+            });
+
+            const result = await NodeAsset.Parse(editorFile.graph).buildAsync();
+            const gltf = AssertValidGlb(result);
+            expect(gltf.meshes?.length).toBe(2);
+            expect(fetchMock).not.toHaveBeenCalled();
+        } finally {
+            vi.unstubAllGlobals();
+        }
+    });
 });

--- a/packages/tools/nodeAssetsEditor/test/unit/importExportFields.test.ts
+++ b/packages/tools/nodeAssetsEditor/test/unit/importExportFields.test.ts
@@ -983,8 +983,8 @@ describe("Import block source label", () => {
                 expect(FindPropertyInSection(controller, importNode, "READ OBJ", "Active source", "text").value).toBe("myMesh.OBJ");
             });
 
-            const compactGraph = JSON.parse(controller.serialize()) as { graph: { blocks: Array<{ customType: string }> } };
-            expect(compactGraph.graph.blocks[0].customType).toBe("ImportOBJAggregateBlock");
+            const compactGraph = JSON.parse(controller.serialize()) as { graph: { blocks: Array<{ name: string; customType: string }> } };
+            expect(compactGraph.graph.blocks.find((block) => block.name === "Import OBJ")?.customType).toBe("ImportOBJAggregateBlock");
 
             controller.setAggregateExpanded(importNode.id, true);
             const readNode = FindNode(controller, "Read OBJ");

--- a/packages/tools/nodeAssetsEditor/test/unit/importExportFields.test.ts
+++ b/packages/tools/nodeAssetsEditor/test/unit/importExportFields.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import { ImportImageBlock } from "node-assets/Blocks/importImageBlock";
 import { ReadBabylonBlock } from "node-assets/Blocks/readBabylonBlock";
 import { ReadNodeGeometryBlock } from "node-assets/Blocks/readNodeGeometryBlock";
+import { ReadOBJBlock } from "node-assets/Blocks/readOBJBlock";
 import { ReadUSDBlock, type USDSourceFetcher } from "node-assets/Blocks/readUSDBlock";
 import { NodeAsset } from "node-assets/nodeAsset";
 
@@ -22,6 +23,7 @@ vi.mock("../../src/nodeAssets/browserFiles", () => ({
 const ImportFileButtonLabel = "Upload glTF\u2026";
 const BabylonImportFileButtonLabel = "Upload Babylon\u2026";
 const UploadUSDButtonLabel = "Upload USD\u2026";
+const UploadOBJButtonLabel = "Upload OBJ\u2026";
 
 function FindNode(controller: NodeAssetGraphController, title: string): IGraphNode {
     const node = controller.state.nodes.find((candidate) => candidate.title === title);
@@ -939,6 +941,106 @@ describe("Import block source label", () => {
             FindPropertyInSection(controller, importNode, "READ BABYLON", BabylonImportFileButtonLabel, "button").onClick();
             await vi.waitFor(() => {
                 expect(FindPropertyInSection(controller, importNode, "READ BABYLON", "Active source", "text").value).toBe("myScene.babylon");
+            });
+
+            it("forwards exactly the Read OBJ controls across compact, expanded, and reloaded editor surfaces", async () => {
+                const controller = new NodeAssetGraphController();
+                try {
+                    const importNode = AddPaletteNode(controller, "import-obj");
+                    const compactSections = controller.buildPropertySections(importNode);
+                    expect(compactSections.map((section) => section.title)).toEqual(["GENERAL", "READ OBJ"]);
+                    expect(compactSections.find((section) => section.title === "READ OBJ")?.properties.map((property) => property.label)).toEqual([
+                        "URL",
+                        "Active source",
+                        UploadOBJButtonLabel,
+                    ]);
+
+                    vi.mocked(PromptForFileAsync).mockResolvedValue({
+                        name: "myMesh.OBJ",
+                        arrayBuffer: async () => new TextEncoder().encode("o Mesh\nv 0 0 0\nv 1 0 0\nv 0 1 0\nf 1 2 3\n").buffer,
+                    } as unknown as File);
+                    FindPropertyInSection(controller, importNode, "READ OBJ", UploadOBJButtonLabel, "button").onClick();
+                    await vi.waitFor(() => {
+                        expect(FindPropertyInSection(controller, importNode, "READ OBJ", "Active source", "text").value).toBe("myMesh.OBJ");
+                    });
+
+                    const compactGraph = JSON.parse(controller.serialize()) as { graph: { blocks: Array<{ customType: string }> } };
+                    expect(compactGraph.graph.blocks[0].customType).toBe("ImportOBJAggregateBlock");
+
+                    controller.setAggregateExpanded(importNode.id, true);
+                    const readNode = FindNode(controller, "Read OBJ");
+                    expect(controller.buildPropertySections(readNode).find((section) => section.title === "SOURCE")?.properties.map((property) => property.label)).toEqual([
+                        "URL",
+                        "Active source",
+                        UploadOBJButtonLabel,
+                    ]);
+                    expect(FindPropertyInSection(controller, readNode, "SOURCE", "Active source", "text").value).toBe("myMesh.OBJ");
+                    expect(FindPropertyInSection(controller, readNode, "SOURCE", "URL", "text").value).toBe("");
+
+                    const reloaded = new NodeAssetGraphController();
+                    try {
+                        reloaded.load(controller.serialize());
+                        const reloadedImport = FindNode(reloaded, "Import OBJ");
+                        expect(FindPropertyInSection(reloaded, reloadedImport, "READ OBJ", "Active source", "text").value).toBe("myMesh.OBJ");
+                    } finally {
+                        reloaded.dispose();
+                    }
+                } finally {
+                    controller.dispose();
+                }
+            });
+
+            it("does not apply a delayed OBJ URL result after aggregate detachment and graph replacement", async () => {
+                const controller = new NodeAssetGraphController();
+                let resolveResponse: ((response: Response) => void) | undefined;
+                let resolveCompletionObserved: (() => void) | undefined;
+                const completionObserved = new Promise<void>((resolve) => {
+                    resolveCompletionObserved = resolve;
+                });
+                const fetchMock = vi.fn(
+                    async () =>
+                        await new Promise<Response>((resolve) => {
+                            resolveResponse = resolve;
+                        })
+                );
+                const setUrlSpy = vi.spyOn(ReadOBJBlock.prototype, "setUrlAsync");
+                vi.stubGlobal("fetch", fetchMock);
+                try {
+                    const importNode = AddPaletteNode(controller, "import-obj");
+                    controller.setAggregateExpanded(importNode.id, true);
+                    const savedBuiltInGraph = controller.serialize();
+                    const readNode = FindNode(controller, "Read OBJ");
+                    FindPropertyInSection(controller, readNode, "SOURCE", "URL", "text").onChange("https://example.com/delayed.obj");
+                    await vi.waitFor(() => {
+                        expect(fetchMock).toHaveBeenCalledTimes(1);
+                    });
+                    const obsoleteBlock = setUrlSpy.mock.instances[0];
+                    const detachedGraph = JSON.parse(controller.serialize()) as { graph: { blocks: Array<{ name: string; customType: string }> } };
+                    expect(detachedGraph.graph.blocks.find((block) => block.name === "Import OBJ")?.customType).toBe("CustomAggregateBlock");
+
+                    controller.load(savedBuiltInGraph);
+                    resolveResponse?.({
+                        ok: true,
+                        status: 200,
+                        statusText: "OK",
+                        arrayBuffer: async () => {
+                            resolveCompletionObserved?.();
+                            return new TextEncoder().encode("o Delayed\nv 0 0 0\nv 1 0 0\nv 0 1 0\nf 1 2 3\n").buffer;
+                        },
+                    } as Response);
+                    await completionObserved;
+                    await Promise.resolve();
+                    await Promise.resolve();
+
+                    expect(obsoleteBlock?.primary).toBeNull();
+                    expect(obsoleteBlock?.source).toBeNull();
+                    const reloadedImport = FindNode(controller, "Import OBJ");
+                    expect(FindPropertyInSection(controller, reloadedImport, "READ OBJ", "Active source", "text").value).toBe("No source loaded");
+                } finally {
+                    setUrlSpy.mockRestore();
+                    vi.unstubAllGlobals();
+                    controller.dispose();
+                }
             });
 
             controller.setAggregateExpanded(importNode.id, true);

--- a/packages/tools/nodeAssetsEditor/test/unit/importExportFields.test.ts
+++ b/packages/tools/nodeAssetsEditor/test/unit/importExportFields.test.ts
@@ -943,106 +943,6 @@ describe("Import block source label", () => {
                 expect(FindPropertyInSection(controller, importNode, "READ BABYLON", "Active source", "text").value).toBe("myScene.babylon");
             });
 
-            it("forwards exactly the Read OBJ controls across compact, expanded, and reloaded editor surfaces", async () => {
-                const controller = new NodeAssetGraphController();
-                try {
-                    const importNode = AddPaletteNode(controller, "import-obj");
-                    const compactSections = controller.buildPropertySections(importNode);
-                    expect(compactSections.map((section) => section.title)).toEqual(["GENERAL", "READ OBJ"]);
-                    expect(compactSections.find((section) => section.title === "READ OBJ")?.properties.map((property) => property.label)).toEqual([
-                        "URL",
-                        "Active source",
-                        UploadOBJButtonLabel,
-                    ]);
-
-                    vi.mocked(PromptForFileAsync).mockResolvedValue({
-                        name: "myMesh.OBJ",
-                        arrayBuffer: async () => new TextEncoder().encode("o Mesh\nv 0 0 0\nv 1 0 0\nv 0 1 0\nf 1 2 3\n").buffer,
-                    } as unknown as File);
-                    FindPropertyInSection(controller, importNode, "READ OBJ", UploadOBJButtonLabel, "button").onClick();
-                    await vi.waitFor(() => {
-                        expect(FindPropertyInSection(controller, importNode, "READ OBJ", "Active source", "text").value).toBe("myMesh.OBJ");
-                    });
-
-                    const compactGraph = JSON.parse(controller.serialize()) as { graph: { blocks: Array<{ customType: string }> } };
-                    expect(compactGraph.graph.blocks[0].customType).toBe("ImportOBJAggregateBlock");
-
-                    controller.setAggregateExpanded(importNode.id, true);
-                    const readNode = FindNode(controller, "Read OBJ");
-                    expect(controller.buildPropertySections(readNode).find((section) => section.title === "SOURCE")?.properties.map((property) => property.label)).toEqual([
-                        "URL",
-                        "Active source",
-                        UploadOBJButtonLabel,
-                    ]);
-                    expect(FindPropertyInSection(controller, readNode, "SOURCE", "Active source", "text").value).toBe("myMesh.OBJ");
-                    expect(FindPropertyInSection(controller, readNode, "SOURCE", "URL", "text").value).toBe("");
-
-                    const reloaded = new NodeAssetGraphController();
-                    try {
-                        reloaded.load(controller.serialize());
-                        const reloadedImport = FindNode(reloaded, "Import OBJ");
-                        expect(FindPropertyInSection(reloaded, reloadedImport, "READ OBJ", "Active source", "text").value).toBe("myMesh.OBJ");
-                    } finally {
-                        reloaded.dispose();
-                    }
-                } finally {
-                    controller.dispose();
-                }
-            });
-
-            it("does not apply a delayed OBJ URL result after aggregate detachment and graph replacement", async () => {
-                const controller = new NodeAssetGraphController();
-                let resolveResponse: ((response: Response) => void) | undefined;
-                let resolveCompletionObserved: (() => void) | undefined;
-                const completionObserved = new Promise<void>((resolve) => {
-                    resolveCompletionObserved = resolve;
-                });
-                const fetchMock = vi.fn(
-                    async () =>
-                        await new Promise<Response>((resolve) => {
-                            resolveResponse = resolve;
-                        })
-                );
-                const setUrlSpy = vi.spyOn(ReadOBJBlock.prototype, "setUrlAsync");
-                vi.stubGlobal("fetch", fetchMock);
-                try {
-                    const importNode = AddPaletteNode(controller, "import-obj");
-                    controller.setAggregateExpanded(importNode.id, true);
-                    const savedBuiltInGraph = controller.serialize();
-                    const readNode = FindNode(controller, "Read OBJ");
-                    FindPropertyInSection(controller, readNode, "SOURCE", "URL", "text").onChange("https://example.com/delayed.obj");
-                    await vi.waitFor(() => {
-                        expect(fetchMock).toHaveBeenCalledTimes(1);
-                    });
-                    const obsoleteBlock = setUrlSpy.mock.instances[0];
-                    const detachedGraph = JSON.parse(controller.serialize()) as { graph: { blocks: Array<{ name: string; customType: string }> } };
-                    expect(detachedGraph.graph.blocks.find((block) => block.name === "Import OBJ")?.customType).toBe("CustomAggregateBlock");
-
-                    controller.load(savedBuiltInGraph);
-                    resolveResponse?.({
-                        ok: true,
-                        status: 200,
-                        statusText: "OK",
-                        arrayBuffer: async () => {
-                            resolveCompletionObserved?.();
-                            return new TextEncoder().encode("o Delayed\nv 0 0 0\nv 1 0 0\nv 0 1 0\nf 1 2 3\n").buffer;
-                        },
-                    } as Response);
-                    await completionObserved;
-                    await Promise.resolve();
-                    await Promise.resolve();
-
-                    expect(obsoleteBlock?.primary).toBeNull();
-                    expect(obsoleteBlock?.source).toBeNull();
-                    const reloadedImport = FindNode(controller, "Import OBJ");
-                    expect(FindPropertyInSection(controller, reloadedImport, "READ OBJ", "Active source", "text").value).toBe("No source loaded");
-                } finally {
-                    setUrlSpy.mockRestore();
-                    vi.unstubAllGlobals();
-                    controller.dispose();
-                }
-            });
-
             controller.setAggregateExpanded(importNode.id, true);
             const readNode = FindNode(controller, "Read Babylon");
             expect(FindPropertyInSection(controller, readNode, "SOURCE", "Active source", "text").value).toBe("myScene.babylon");
@@ -1058,6 +958,106 @@ describe("Import block source label", () => {
                 reloaded.dispose();
             }
         } finally {
+            controller.dispose();
+        }
+    });
+
+    it("forwards exactly the Read OBJ controls across compact, expanded, and reloaded editor surfaces", async () => {
+        const controller = new NodeAssetGraphController();
+        try {
+            const importNode = AddPaletteNode(controller, "import-obj");
+            const compactSections = controller.buildPropertySections(importNode);
+            expect(compactSections.map((section) => section.title)).toEqual(["GENERAL", "READ OBJ"]);
+            expect(compactSections.find((section) => section.title === "READ OBJ")?.properties.map((property) => property.label)).toEqual([
+                "URL",
+                "Active source",
+                UploadOBJButtonLabel,
+            ]);
+
+            vi.mocked(PromptForFileAsync).mockResolvedValue({
+                name: "myMesh.OBJ",
+                arrayBuffer: async () => new TextEncoder().encode("o Mesh\nv 0 0 0\nv 1 0 0\nv 0 1 0\nf 1 2 3\n").buffer,
+            } as unknown as File);
+            FindPropertyInSection(controller, importNode, "READ OBJ", UploadOBJButtonLabel, "button").onClick();
+            await vi.waitFor(() => {
+                expect(FindPropertyInSection(controller, importNode, "READ OBJ", "Active source", "text").value).toBe("myMesh.OBJ");
+            });
+
+            const compactGraph = JSON.parse(controller.serialize()) as { graph: { blocks: Array<{ customType: string }> } };
+            expect(compactGraph.graph.blocks[0].customType).toBe("ImportOBJAggregateBlock");
+
+            controller.setAggregateExpanded(importNode.id, true);
+            const readNode = FindNode(controller, "Read OBJ");
+            expect(controller.buildPropertySections(readNode).find((section) => section.title === "SOURCE")?.properties.map((property) => property.label)).toEqual([
+                "URL",
+                "Active source",
+                UploadOBJButtonLabel,
+            ]);
+            expect(FindPropertyInSection(controller, readNode, "SOURCE", "Active source", "text").value).toBe("myMesh.OBJ");
+            expect(FindPropertyInSection(controller, readNode, "SOURCE", "URL", "text").value).toBe("");
+
+            const reloaded = new NodeAssetGraphController();
+            try {
+                reloaded.load(controller.serialize());
+                const reloadedImport = FindNode(reloaded, "Import OBJ");
+                expect(FindPropertyInSection(reloaded, reloadedImport, "READ OBJ", "Active source", "text").value).toBe("myMesh.OBJ");
+            } finally {
+                reloaded.dispose();
+            }
+        } finally {
+            controller.dispose();
+        }
+    });
+
+    it("does not apply a delayed OBJ URL result after aggregate detachment and graph replacement", async () => {
+        const controller = new NodeAssetGraphController();
+        let resolveResponse: ((response: Response) => void) | undefined;
+        let resolveCompletionObserved: (() => void) | undefined;
+        const completionObserved = new Promise<void>((resolve) => {
+            resolveCompletionObserved = resolve;
+        });
+        const fetchMock = vi.fn(
+            async () =>
+                await new Promise<Response>((resolve) => {
+                    resolveResponse = resolve;
+                })
+        );
+        const setUrlSpy = vi.spyOn(ReadOBJBlock.prototype, "setUrlAsync");
+        vi.stubGlobal("fetch", fetchMock);
+        try {
+            const importNode = AddPaletteNode(controller, "import-obj");
+            controller.setAggregateExpanded(importNode.id, true);
+            const savedBuiltInGraph = controller.serialize();
+            const readNode = FindNode(controller, "Read OBJ");
+            FindPropertyInSection(controller, readNode, "SOURCE", "URL", "text").onChange("https://example.com/delayed.obj");
+            await vi.waitFor(() => {
+                expect(fetchMock).toHaveBeenCalledTimes(1);
+            });
+            const obsoleteBlock = setUrlSpy.mock.instances[0];
+            const detachedGraph = JSON.parse(controller.serialize()) as { graph: { blocks: Array<{ name: string; customType: string }> } };
+            expect(detachedGraph.graph.blocks.find((block) => block.name === "Import OBJ")?.customType).toBe("CustomAggregateBlock");
+
+            controller.load(savedBuiltInGraph);
+            resolveResponse?.({
+                ok: true,
+                status: 200,
+                statusText: "OK",
+                arrayBuffer: async () => {
+                    resolveCompletionObserved?.();
+                    return new TextEncoder().encode("o Delayed\nv 0 0 0\nv 1 0 0\nv 0 1 0\nf 1 2 3\n").buffer;
+                },
+            } as Response);
+            await completionObserved;
+            await Promise.resolve();
+            await Promise.resolve();
+
+            expect(obsoleteBlock?.primary).toBeNull();
+            expect(obsoleteBlock?.source).toBeNull();
+            const reloadedImport = FindNode(controller, "Import OBJ");
+            expect(FindPropertyInSection(controller, reloadedImport, "READ OBJ", "Active source", "text").value).toBe("No source loaded");
+        } finally {
+            setUrlSpy.mockRestore();
+            vi.unstubAllGlobals();
             controller.dispose();
         }
     });

--- a/packages/tools/nodeAssetsEditor/test/unit/nodeAssetBuildWorkerRegistration.test.ts
+++ b/packages/tools/nodeAssetsEditor/test/unit/nodeAssetBuildWorkerRegistration.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 // Importing the worker core evaluates its block-registration side effect in THIS test realm. Nothing
 // else here registers blocks: we deliberately read the registry through the node-assets submodules and
@@ -6,10 +6,10 @@ import { describe, expect, it } from "vitest";
 // every block via another path and mask a worker that under-registers). Vitest isolates the module
 // registry per test file, so the registry below reflects exactly what the preview build worker can
 // deserialize.
-import "../../src/nodeAssets/nodeAssetBuildWorkerCore";
+import { BuildSerializedNodeAssetAsync } from "../../src/nodeAssets/nodeAssetBuildWorkerCore";
 import { CreateBlockByClassName, GetRegisteredBlockClassNames } from "node-assets/blockFoundation/blockRegistry";
 import { NodeAsset } from "node-assets/nodeAsset";
-import { GetDefaultBuiltInNodeAssetLibraryEntry } from "../../src/nodeAssets/builtInLibraryEntries";
+import { CreateBuiltInNodeAssetLibraryEntries, GetDefaultBuiltInNodeAssetLibraryEntry } from "../../src/nodeAssets/builtInLibraryEntries";
 
 // The built-in block ClassNames, hardcoded (not derived from the package barrel) so this test fails
 // if the worker realm ever registers a different set than the package publishes. Keep in sync with
@@ -95,6 +95,9 @@ const ExpectedBlockClassNames = [
     "ReadBabylonBlock",
     "BabylonToUniversalBlock",
     "ImportBabylonAggregateBlock",
+    "ReadOBJBlock",
+    "OBJToUniversalBlock",
+    "ImportOBJAggregateBlock",
 ] as const;
 
 const DefaultPipelineClassNames = ["ImportGLTFAggregateBlock", "WeldVerticesBlock", "RemoveUnusedResourcesBlock", "ExportGLTFAggregateBlock"] as const;
@@ -129,4 +132,30 @@ describe("preview build worker block registration", () => {
         expect(parsed.attachedBlocks).toHaveLength(1);
         expect(parsed.attachedBlocks[0].getClassName()).toBe(className);
     });
+
+    it("reconstructs and builds the saved built-in OBJ graph offline in the worker realm", async () => {
+        const entry = CreateBuiltInNodeAssetLibraryEntries().find((candidate) => candidate.name === "OBJ to Optimized glTF");
+        expect(entry).toBeDefined();
+        if (!entry) {
+            return;
+        }
+        const editorFile = JSON.parse(entry.serializedGraph) as { graph: unknown };
+        const fetchMock = vi.fn(async () => {
+            throw new Error("The worker OBJ graph must not request the network.");
+        });
+        vi.stubGlobal("fetch", fetchMock);
+        try {
+            const result = await BuildSerializedNodeAssetAsync(editorFile.graph, {
+                basisEncoderJsUrl: "",
+                basisEncoderWasmUrl: "",
+                dracoDecoderWasmUrl: "",
+                dracoEncoderWasmUrl: "",
+                usdWasmUrl: "",
+            });
+            expect(result.byteLength).toBeGreaterThan(0);
+            expect(fetchMock).not.toHaveBeenCalled();
+        } finally {
+            vi.unstubAllGlobals();
+        }
+    }, 30_000);
 });

--- a/packages/tools/nodeAssetsEditor/test/unit/nodeAssetBuildWorkerRegistration.test.ts
+++ b/packages/tools/nodeAssetsEditor/test/unit/nodeAssetBuildWorkerRegistration.test.ts
@@ -11,6 +11,8 @@ import { CreateBlockByClassName, GetRegisteredBlockClassNames } from "node-asset
 import { NodeAsset } from "node-assets/nodeAsset";
 import { CreateBuiltInNodeAssetLibraryEntries, GetDefaultBuiltInNodeAssetLibraryEntry } from "../../src/nodeAssets/builtInLibraryEntries";
 
+vi.mock("draco3dgltf", async () => await vi.importActual("draco3dgltf"));
+
 // The built-in block ClassNames, hardcoded (not derived from the package barrel) so this test fails
 // if the worker realm ever registers a different set than the package publishes. Keep in sync with
 // packages/dev/node-assets/test/unit/blockRegistry.test.ts.

--- a/packages/tools/nodeAssetsEditor/test/unit/nodeAssetGraphController.test.ts
+++ b/packages/tools/nodeAssetsEditor/test/unit/nodeAssetGraphController.test.ts
@@ -239,6 +239,7 @@ describe("NodeAssetGraphController", () => {
     it("loads the exact production catalog through the normal graph load path", () => {
         const expectedCatalog = [
             ["glTF Optimization", ["Import glTF", "Weld Vertices", "Remove Unused Resources", "Export glTF"]],
+            ["OBJ to Optimized glTF", ["Import OBJ", "Remove Unused Resources", "Export glTF"]],
             ["USD to Optimized glTF", ["Import USD", "Remove Unused Resources", "Export glTF"]],
             ["Babylon to Optimized glTF", ["Import Babylon", "Weld Vertices", "Export glTF"]],
             ["Node Geometry to glTF", ["Import Node Geometry", "Export glTF"]],

--- a/packages/tools/nodeAssetsEditor/test/unit/paletteCategories.test.ts
+++ b/packages/tools/nodeAssetsEditor/test/unit/paletteCategories.test.ts
@@ -32,6 +32,7 @@ describe("BuildPaletteCategories", () => {
                 category: "Inputs",
                 items: [
                     { family: "Aggregate imports", label: "Import glTF" },
+                    { family: "Aggregate imports", label: "Import OBJ" },
                     { family: "Aggregate imports", label: "Import USD" },
                     { family: "Aggregate imports", label: "Import Babylon" },
                     { family: "Aggregate imports", label: "Import Node Geometry" },
@@ -81,17 +82,18 @@ describe("BuildPaletteCategories", () => {
             };
         });
 
-        expect(primitiveCategories.map((category) => category.label)).toEqual(["Inputs", "Universal", "glTF", "USD", "Babylon", "Node Geometry"]);
+        expect(primitiveCategories.map((category) => category.label)).toEqual(["Inputs", "Universal", "glTF", "OBJ", "USD", "Babylon", "Node Geometry"]);
         for (const defaultCategory of defaultCategories) {
             expect(primitiveCategories.find((category) => category.label === defaultCategory.label)?.items.slice(0, defaultCategory.items.length)).toEqual(defaultCategory.items);
         }
         expect(additions).toEqual([
-            { category: "Inputs", items: ["Read glTF", "Read USD", "Read Babylon", "Read Node Geometry"] },
+            { category: "Inputs", items: ["Read glTF", "Read OBJ", "Read USD", "Read Babylon", "Read Node Geometry"] },
             {
                 category: "Universal",
                 items: ["Universal → glTF", "Deduplicate Materials", "Deduplicate Textures", "Reuse Identical Meshes", "Deduplicate Data"],
             },
             { category: "glTF", items: ["glTF → Universal", "Write glTF"] },
+            { category: "OBJ", items: ["OBJ to Universal"] },
             { category: "USD", items: ["USD → Universal"] },
             { category: "Babylon", items: ["Babylon → Universal"] },
             { category: "Node Geometry", items: ["Node Geometry → Universal"] },


### PR DESCRIPTION
## Summary

- add a distinct, immutable OBJ source representation and typed Read OBJ to OBJ to Universal runtime lane
- preserve source races, persistence, loader defaults, contextual failures, and guaranteed scene/engine cleanup
- add the Import OBJ aggregate, editor discovery and controls, worker registration, and an offline built-in OBJ pipeline
- cover real upload and URL GLB conversion, names, persistence, editor lifecycle, worker reconstruction, network-free catalog execution, and URL-relative MTL resolution
- reserve the companion schema while rejecting non-empty companions until issue 02 implements resolver/file-store behavior
- resolve absolute OBJ URL roots with URL semantics, including host-root query endpoints, while preserving relative/non-URL fallback behavior

## Validation

- Final immutable head: `390ab6ae13caca973b4a6d5867c67830210c8e34`.
- Independent final issue-01 acceptance audit: clean; all requirements and all three prior findings closed.
- Independent final standards review: clean across 15 commits / 25 files with zero actionable findings.
- Targeted OBJ funnel: 15/15; node-assets unit: 690/690; combined focused unit: 96 files / 1,053 tests.
- Final full unit first pass: 364 files passed; 5,386 passed, 1 expected failure, 30 skipped.
- Format, source/tools/test-tools builds, editor build, ESLint, all 16 tree-shaking checks, and all 4 side-effect manifest sync checks passed.
- Full NAE Playwright first pass with retries disabled: 39/39 passed.
- Fresh validation worktree required the explicitly authorized dependency bootstrap (`npm ci` after initial missing `tsc` probe); every product gate then passed first pass.
- Final worktree, process tree, generated artifacts, and ports 1348/1359 were clean.

Base: `publish-obj-issues`