### PR TITLE
[NAE] Enable primary drag panning on empty graph canvas

### DIFF
--- a/packages/tools/nodeAssetsEditor/src/nodeGraph/components/GraphCanvas.tsx
+++ b/packages/tools/nodeAssetsEditor/src/nodeGraph/components/GraphCanvas.tsx
@@ -21,6 +21,7 @@ import { FindNearestConnectablePort, FindNodesInRegion } from "../canvasHitTest"
 import {
     type Gesture,
     type GestureAction,
+    type GestureResult,
     type MarqueeRect,
     type PendingWire,
     BeginBackgroundGesture,
@@ -28,6 +29,7 @@ import {
     BeginFrameGesture,
     BeginPortGesture,
     AdvanceGesture,
+    CancelGesture,
     CompleteGesture,
 } from "../gestureInterpreter";
 import { type ContextMenuTarget, type CanvasContextValue, CanvasContextProvider } from "./canvasContext";
@@ -102,6 +104,7 @@ export const GraphCanvas: FunctionComponent<{ context: EditorContextValue }> = (
     const [size, setSize] = useState({ width: 0, height: 0 });
     const [pendingWire, setPendingWire] = useState<PendingWire | null>(null);
     const [marquee, setMarquee] = useState<MarqueeRect | null>(null);
+    const [isPanning, setIsPanning] = useState(false);
     const [contextTarget, setContextTarget] = useState<ContextMenuTarget>({ kind: "canvas" });
 
     const setCamera = useCallback((next: Camera | ((current: Camera) => Camera)) => {
@@ -220,17 +223,74 @@ export const GraphCanvas: FunctionComponent<{ context: EditorContextValue }> = (
         [state, setCamera, attemptConnect]
     );
 
+    const applyGestureResult = useCallback(
+        (result: GestureResult) => {
+            const wasPanning = gestureRef.current.kind === "pan";
+            const willPan = result.gesture.kind === "pan";
+            gestureRef.current = result.gesture;
+            if (wasPanning !== willPan) {
+                setIsPanning(willPan);
+            }
+            executeActions(result.actions);
+        },
+        [executeActions]
+    );
+
+    const capturePointer = useCallback((pointerId: number) => {
+        const element = containerRef.current;
+        if (element && !element.hasPointerCapture(pointerId)) {
+            element.setPointerCapture(pointerId);
+        }
+    }, []);
+
+    const releasePointer = useCallback((pointerId: number) => {
+        const element = containerRef.current;
+        if (element?.hasPointerCapture(pointerId)) {
+            element.releasePointerCapture(pointerId);
+        }
+    }, []);
+
+    const startGesture = useCallback(
+        (event: ReactPointerEvent, result: GestureResult) => {
+            if (gestureRef.current.kind !== "none" || result.gesture.kind === "none") {
+                return;
+            }
+            capturePointer(event.pointerId);
+            applyGestureResult(result);
+        },
+        [capturePointer, applyGestureResult]
+    );
+
+    const cancelGesture = useCallback(
+        (pointerId: number, releaseCapture: boolean) => {
+            const current = gestureRef.current;
+            if (current.kind === "none" || current.pointerId !== pointerId) {
+                return;
+            }
+            applyGestureResult(CancelGesture(current, { pointerId }));
+            if (releaseCapture) {
+                releasePointer(pointerId);
+            }
+        },
+        [applyGestureResult, releasePointer]
+    );
+
     // Persistent window listeners drive the active gesture so dragging continues outside the canvas.
     useEffect(() => {
         const onPointerMove = (event: PointerEvent) => {
+            const current = gestureRef.current;
+            if (current.kind === "none" || current.pointerId !== event.pointerId) {
+                return;
+            }
             const { world, local } = pointerCoords(event.clientX, event.clientY);
-            const { gesture, actions } = AdvanceGesture(gestureRef.current, { world, local });
-            gestureRef.current = gesture;
-            executeActions(actions);
+            applyGestureResult(AdvanceGesture(current, { pointerId: event.pointerId, world, local }));
         };
 
         const onPointerUp = (event: PointerEvent) => {
             const current = gestureRef.current;
+            if (current.kind === "none" || current.pointerId !== event.pointerId) {
+                return;
+            }
             const world = screenToWorld(event.clientX, event.clientY);
             let resolvedTargetPortId: string | undefined;
             if (current.kind === "wire") {
@@ -248,18 +308,21 @@ export const GraphCanvas: FunctionComponent<{ context: EditorContextValue }> = (
                         canConnect: (from, to) => state.canConnect(from, to),
                     });
             }
-            const { gesture, actions } = CompleteGesture(current, { world, resolvedTargetPortId });
-            gestureRef.current = gesture;
-            executeActions(actions);
+            applyGestureResult(CompleteGesture(current, { pointerId: event.pointerId, world, resolvedTargetPortId }));
+            releasePointer(event.pointerId);
         };
+
+        const onPointerCancel = (event: PointerEvent) => cancelGesture(event.pointerId, true);
 
         window.addEventListener("pointermove", onPointerMove);
         window.addEventListener("pointerup", onPointerUp);
+        window.addEventListener("pointercancel", onPointerCancel);
         return () => {
             window.removeEventListener("pointermove", onPointerMove);
             window.removeEventListener("pointerup", onPointerUp);
+            window.removeEventListener("pointercancel", onPointerCancel);
         };
-    }, [state, screenToWorld, pointerCoords, executeActions]);
+    }, [state, screenToWorld, pointerCoords, applyGestureResult, releasePointer, cancelGesture]);
 
     // Keyboard shortcuts (ignored while typing in a form control so the panes keep working).
     useEffect(() => {
@@ -351,29 +414,36 @@ export const GraphCanvas: FunctionComponent<{ context: EditorContextValue }> = (
         () => ({
             editor: context,
             beginNodeInteraction: (nodeId, event) => {
-                const { gesture, actions } = BeginNodeGesture({
-                    nodeId,
-                    additive: event.shiftKey || event.ctrlKey || event.metaKey,
-                    isSelected: state.isNodeSelected(nodeId),
-                    world: screenToWorld(event.clientX, event.clientY),
-                });
-                executeActions(actions);
-                gestureRef.current = gesture;
+                if (gestureRef.current.kind !== "none") {
+                    return;
+                }
+                startGesture(
+                    event,
+                    BeginNodeGesture({
+                        pointerId: event.pointerId,
+                        nodeId,
+                        additive: event.shiftKey || event.ctrlKey || event.metaKey,
+                        isSelected: state.isNodeSelected(nodeId),
+                        world: screenToWorld(event.clientX, event.clientY),
+                    })
+                );
             },
             beginFrameInteraction: (frameId, event) => {
-                const { gesture, actions } = BeginFrameGesture({ frameId, world: screenToWorld(event.clientX, event.clientY) });
-                executeActions(actions);
-                gestureRef.current = gesture;
+                if (gestureRef.current.kind !== "none") {
+                    return;
+                }
+                startGesture(event, BeginFrameGesture({ pointerId: event.pointerId, frameId, world: screenToWorld(event.clientX, event.clientY) }));
             },
             beginPortInteraction: (portId, event) => {
+                if (gestureRef.current.kind !== "none") {
+                    return;
+                }
                 const node = state.getPortNode(portId);
                 const anchor = node ? GetPortAnchor(node, portId) : undefined;
                 if (!anchor) {
                     return;
                 }
-                const { gesture, actions } = BeginPortGesture({ portId, anchor, world: screenToWorld(event.clientX, event.clientY) });
-                executeActions(actions);
-                gestureRef.current = gesture;
+                startGesture(event, BeginPortGesture({ pointerId: event.pointerId, portId, anchor, world: screenToWorld(event.clientX, event.clientY) }));
             },
             selectWire: (wireId) => state.selectWire(wireId),
             openContextMenu: (target) => {
@@ -383,7 +453,7 @@ export const GraphCanvas: FunctionComponent<{ context: EditorContextValue }> = (
                 setContextTarget(target);
             },
         }),
-        [context, state, screenToWorld, executeActions]
+        [context, state, screenToWorld, startGesture]
     );
 
     const onBackgroundPointerDown = (event: ReactPointerEvent<HTMLDivElement>) => {
@@ -394,18 +464,18 @@ export const GraphCanvas: FunctionComponent<{ context: EditorContextValue }> = (
         containerRef.current?.focus();
 
         const { world, local } = pointerCoords(event.clientX, event.clientY);
-        const { gesture, actions } = BeginBackgroundGesture({
+        const result = BeginBackgroundGesture({
+            pointerId: event.pointerId,
             button: event.button,
             spaceHeld: spaceHeldRef.current,
             additive: event.shiftKey || event.ctrlKey || event.metaKey,
             world,
             local,
         });
-        if (gesture.kind === "pan") {
+        if (result.gesture.kind === "pan") {
             event.preventDefault();
         }
-        executeActions(actions);
-        gestureRef.current = gesture;
+        startGesture(event, result);
     };
 
     const onDragOver = (event: ReactDragEvent<HTMLDivElement>) => {
@@ -476,6 +546,7 @@ export const GraphCanvas: FunctionComponent<{ context: EditorContextValue }> = (
         backgroundImage: `radial-gradient(circle, ${tokens.colorNeutralStroke2} ${dotRadius}px, transparent ${dotRadius * 1.5}px)`,
         backgroundSize: `${gridSpacing}px ${gridSpacing}px`,
         backgroundPosition: `${camera.x}px ${camera.y}px`,
+        cursor: isPanning ? "grabbing" : "grab",
     };
 
     return (
@@ -486,7 +557,9 @@ export const GraphCanvas: FunctionComponent<{ context: EditorContextValue }> = (
             tabIndex={0}
             role="application"
             aria-label="Node graph canvas"
+            data-panning={isPanning ? "true" : undefined}
             onPointerDown={onBackgroundPointerDown}
+            onLostPointerCapture={(event) => cancelGesture(event.pointerId, false)}
             onDragOver={onDragOver}
             onDrop={onDrop}
         >

--- a/packages/tools/nodeAssetsEditor/src/nodeGraph/gestureInterpreter.ts
+++ b/packages/tools/nodeAssetsEditor/src/nodeGraph/gestureInterpreter.ts
@@ -40,11 +40,11 @@ export type MarqueeRect = {
  */
 export type Gesture =
     | { readonly kind: "none" }
-    | { readonly kind: "pan"; readonly lastLocal: Vec2 }
-    | { readonly kind: "marquee"; readonly startWorld: Vec2; readonly startLocal: Vec2; readonly additive: boolean }
-    | { readonly kind: "moveNodes"; readonly lastWorld: Vec2; readonly moved: boolean }
-    | { readonly kind: "moveFrame"; readonly frameId: string; readonly lastWorld: Vec2; readonly moved: boolean }
-    | { readonly kind: "wire"; readonly fromPortId: string; readonly fromAnchor: Vec2 };
+    | { readonly kind: "pan"; readonly pointerId: number; readonly lastLocal: Vec2; readonly moved: boolean; readonly clearSelectionOnClick: boolean }
+    | { readonly kind: "marquee"; readonly pointerId: number; readonly startWorld: Vec2; readonly startLocal: Vec2; readonly additive: boolean }
+    | { readonly kind: "moveNodes"; readonly pointerId: number; readonly lastWorld: Vec2; readonly moved: boolean }
+    | { readonly kind: "moveFrame"; readonly pointerId: number; readonly frameId: string; readonly lastWorld: Vec2; readonly moved: boolean }
+    | { readonly kind: "wire"; readonly pointerId: number; readonly fromPortId: string; readonly fromAnchor: Vec2 };
 
 /**
  * A discrete side effect the canvas component performs in response to a gesture transition. The
@@ -78,30 +78,32 @@ export type GestureResult = {
 const None: Gesture = { kind: "none" };
 
 /**
- * Begins a gesture from a pointer-down on the empty canvas background: middle-button or space+left starts
- * a pan; a plain left press starts a marquee (clearing the selection first unless it is additive).
- * @param input The pressed button, modifier state, and pointer position in world and viewport-local space.
+ * Begins a gesture from a pointer-down on the empty canvas background: middle-button, space+left, or an
+ * unmodified left press starts a pan; an additive left press starts a marquee.
+ * @param input The pointer identity, pressed button, modifier state, and position in world and viewport-local space.
  * @returns The started gesture and its initial actions.
  */
 export function BeginBackgroundGesture(input: {
+    readonly pointerId: number;
     readonly button: number;
     readonly spaceHeld: boolean;
     readonly additive: boolean;
     readonly world: Vec2;
     readonly local: Vec2;
 }): GestureResult {
-    const { button, spaceHeld, additive, world, local } = input;
-    const isPan = button === 1 || (button === 0 && spaceHeld);
+    const { pointerId, button, spaceHeld, additive, world, local } = input;
+    const isPan = button === 1 || (button === 0 && !additive);
     if (isPan) {
-        return { gesture: { kind: "pan", lastLocal: local }, actions: [] };
+        return {
+            gesture: { kind: "pan", pointerId, lastLocal: local, moved: false, clearSelectionOnClick: button === 0 && !spaceHeld && !additive },
+            actions: [],
+        };
     }
     if (button === 0) {
-        const actions: GestureAction[] = [];
-        if (!additive) {
-            actions.push({ kind: "clearSelection" });
-        }
-        actions.push({ kind: "setMarquee", rect: { x: local.x, y: local.y, width: 0, height: 0 } });
-        return { gesture: { kind: "marquee", startWorld: world, startLocal: local, additive }, actions };
+        return {
+            gesture: { kind: "marquee", pointerId, startWorld: world, startLocal: local, additive },
+            actions: [{ kind: "setMarquee", rect: { x: local.x, y: local.y, width: 0, height: 0 } }],
+        };
     }
     return { gesture: None, actions: [] };
 }
@@ -113,8 +115,14 @@ export function BeginBackgroundGesture(input: {
  * pointer position in world space.
  * @returns The move-nodes gesture and its selection/interaction actions.
  */
-export function BeginNodeGesture(input: { readonly nodeId: string; readonly additive: boolean; readonly isSelected: boolean; readonly world: Vec2 }): GestureResult {
-    const { nodeId, additive, isSelected, world } = input;
+export function BeginNodeGesture(input: {
+    readonly pointerId: number;
+    readonly nodeId: string;
+    readonly additive: boolean;
+    readonly isSelected: boolean;
+    readonly world: Vec2;
+}): GestureResult {
+    const { pointerId, nodeId, additive, isSelected, world } = input;
     const actions: GestureAction[] = [];
     if (additive) {
         actions.push({ kind: "toggleNodeSelection", nodeId });
@@ -122,7 +130,7 @@ export function BeginNodeGesture(input: { readonly nodeId: string; readonly addi
         actions.push({ kind: "selectNodes", nodeIds: [nodeId] });
     }
     actions.push({ kind: "beginInteraction" });
-    return { gesture: { kind: "moveNodes", lastWorld: world, moved: false }, actions };
+    return { gesture: { kind: "moveNodes", pointerId, lastWorld: world, moved: false }, actions };
 }
 
 /**
@@ -130,9 +138,9 @@ export function BeginNodeGesture(input: { readonly nodeId: string; readonly addi
  * @param input The frame id and the pointer position in world space.
  * @returns The move-frame gesture and its interaction action.
  */
-export function BeginFrameGesture(input: { readonly frameId: string; readonly world: Vec2 }): GestureResult {
-    const { frameId, world } = input;
-    return { gesture: { kind: "moveFrame", frameId, lastWorld: world, moved: false }, actions: [{ kind: "beginInteraction" }] };
+export function BeginFrameGesture(input: { readonly pointerId: number; readonly frameId: string; readonly world: Vec2 }): GestureResult {
+    const { pointerId, frameId, world } = input;
+    return { gesture: { kind: "moveFrame", pointerId, frameId, lastWorld: world, moved: false }, actions: [{ kind: "beginInteraction" }] };
 }
 
 /**
@@ -140,9 +148,9 @@ export function BeginFrameGesture(input: { readonly frameId: string; readonly wo
  * @param input The origin port id, its world-space anchor, and the pointer position in world space.
  * @returns The wire gesture and the initial pending-wire preview.
  */
-export function BeginPortGesture(input: { readonly portId: string; readonly anchor: Vec2; readonly world: Vec2 }): GestureResult {
-    const { portId, anchor, world } = input;
-    return { gesture: { kind: "wire", fromPortId: portId, fromAnchor: anchor }, actions: [{ kind: "setPendingWire", wire: { from: anchor, to: world } }] };
+export function BeginPortGesture(input: { readonly pointerId: number; readonly portId: string; readonly anchor: Vec2; readonly world: Vec2 }): GestureResult {
+    const { pointerId, portId, anchor, world } = input;
+    return { gesture: { kind: "wire", pointerId, fromPortId: portId, fromAnchor: anchor }, actions: [{ kind: "setPendingWire", wire: { from: anchor, to: world } }] };
 }
 
 /**
@@ -150,16 +158,22 @@ export function BeginPortGesture(input: { readonly portId: string; readonly anch
  * Node and frame moves ignore zero-length deltas and latch a `moved` flag so a click is distinguished
  * from a drag when the interaction is later committed.
  * @param gesture The active gesture.
- * @param input The pointer position in world and viewport-local space.
+ * @param input The pointer identity and position in world and viewport-local space.
  * @returns The updated gesture and the actions for this move.
  */
-export function AdvanceGesture(gesture: Gesture, input: { readonly world: Vec2; readonly local: Vec2 }): GestureResult {
-    const { world, local } = input;
+export function AdvanceGesture(gesture: Gesture, input: { readonly pointerId: number; readonly world: Vec2; readonly local: Vec2 }): GestureResult {
+    const { pointerId, world, local } = input;
+    if (gesture.kind !== "none" && gesture.pointerId !== pointerId) {
+        return { gesture, actions: [] };
+    }
     switch (gesture.kind) {
         case "pan": {
             const dx = local.x - gesture.lastLocal.x;
             const dy = local.y - gesture.lastLocal.y;
-            return { gesture: { kind: "pan", lastLocal: local }, actions: [{ kind: "panBy", dx, dy }] };
+            if (dx === 0 && dy === 0) {
+                return { gesture, actions: [] };
+            }
+            return { gesture: { ...gesture, lastLocal: local, moved: true }, actions: [{ kind: "panBy", dx, dy }] };
         }
         case "marquee": {
             const rect: MarqueeRect = {
@@ -175,7 +189,7 @@ export function AdvanceGesture(gesture: Gesture, input: { readonly world: Vec2; 
             if (delta.x === 0 && delta.y === 0) {
                 return { gesture, actions: [] };
             }
-            return { gesture: { kind: "moveNodes", lastWorld: world, moved: true }, actions: [{ kind: "translateSelectedNodes", delta }] };
+            return { gesture: { ...gesture, lastWorld: world, moved: true }, actions: [{ kind: "translateSelectedNodes", delta }] };
         }
         case "moveFrame": {
             const delta = { x: world.x - gesture.lastWorld.x, y: world.y - gesture.lastWorld.y };
@@ -183,7 +197,7 @@ export function AdvanceGesture(gesture: Gesture, input: { readonly world: Vec2; 
                 return { gesture, actions: [] };
             }
             return {
-                gesture: { kind: "moveFrame", frameId: gesture.frameId, lastWorld: world, moved: true },
+                gesture: { ...gesture, lastWorld: world, moved: true },
                 actions: [{ kind: "translateFrame", frameId: gesture.frameId, delta }],
             };
         }
@@ -196,17 +210,26 @@ export function AdvanceGesture(gesture: Gesture, input: { readonly world: Vec2; 
 }
 
 /**
- * Completes the active gesture on pointer-up and resets to no gesture. A marquee selects the nodes in its
- * region; a node/frame move ends its interaction (passing whether it actually moved); a wire connects to
- * the resolved target port when there is one and it differs from the origin.
+ * Completes the active gesture on pointer-up and resets to no gesture. An unmoved plain-primary pan clears
+ * selection; a marquee selects the nodes in its region; a node/frame move ends its interaction (passing
+ * whether it actually moved); a wire connects to the resolved target port when there is one and it differs
+ * from the origin.
  * @param gesture The active gesture.
- * @param input The pointer position in world space and, for wire gestures, the target port the caller
- * resolved from the drop position (a direct hit or the nearest connectable port), if any.
+ * @param input The pointer identity and position in world space and, for wire gestures, the target port the
+ * caller resolved from the drop position (a direct hit or the nearest connectable port), if any.
  * @returns The reset gesture and the actions that commit the gesture.
  */
-export function CompleteGesture(gesture: Gesture, input: { readonly world: Vec2; readonly resolvedTargetPortId?: string }): GestureResult {
-    const { world, resolvedTargetPortId } = input;
+export function CompleteGesture(gesture: Gesture, input: { readonly pointerId: number; readonly world: Vec2; readonly resolvedTargetPortId?: string }): GestureResult {
+    const { pointerId, world, resolvedTargetPortId } = input;
+    if (gesture.kind !== "none" && gesture.pointerId !== pointerId) {
+        return { gesture, actions: [] };
+    }
     switch (gesture.kind) {
+        case "pan":
+            return {
+                gesture: None,
+                actions: gesture.clearSelectionOnClick && !gesture.moved ? [{ kind: "clearSelection" }] : [],
+            };
         case "marquee": {
             const region: Bounds = {
                 minX: Math.min(gesture.startWorld.x, world.x),
@@ -233,6 +256,30 @@ export function CompleteGesture(gesture: Gesture, input: { readonly world: Vec2;
             actions.push({ kind: "setPendingWire", wire: null });
             return { gesture: None, actions };
         }
+        default:
+            return { gesture: None, actions: [] };
+    }
+}
+
+/**
+ * Cancels the active gesture for its owning pointer, clearing transient marquee/wire state and closing any
+ * bracketed node/frame interaction without applying completion-only actions.
+ * @param gesture The active gesture.
+ * @param input The pointer that was canceled.
+ * @returns The reset gesture and cleanup actions.
+ */
+export function CancelGesture(gesture: Gesture, input: { readonly pointerId: number }): GestureResult {
+    if (gesture.kind === "none" || gesture.pointerId !== input.pointerId) {
+        return { gesture, actions: [] };
+    }
+    switch (gesture.kind) {
+        case "marquee":
+            return { gesture: None, actions: [{ kind: "setMarquee", rect: null }] };
+        case "wire":
+            return { gesture: None, actions: [{ kind: "setPendingWire", wire: null }] };
+        case "moveNodes":
+        case "moveFrame":
+            return { gesture: None, actions: [{ kind: "endInteraction", moved: gesture.moved }] };
         default:
             return { gesture: None, actions: [] };
     }

--- a/packages/tools/nodeAssetsEditor/test/playwright/nae.utils.ts
+++ b/packages/tools/nodeAssetsEditor/test/playwright/nae.utils.ts
@@ -116,6 +116,27 @@ export class NodeAssetsEditorPage {
     }
 
     /**
+     * Finds a viewport point on the empty graph surface, excluding nodes, frames, wires, ports, and the minimap.
+     * @returns Client-space coordinates safely inside the canvas.
+     */
+    async findEmptyCanvasPoint(): Promise<{ readonly x: number; readonly y: number }> {
+        return await this.canvas.evaluate((canvas) => {
+            const rect = canvas.getBoundingClientRect();
+            const excludedSelector =
+                '[data-testid="graph-node"], [data-testid="graph-frame"], [data-testid="aggregate-frame"], [data-testid="graph-wire"], [data-port-id], [role="presentation"]';
+            for (let y = rect.top + 48; y < rect.bottom - 96; y += 24) {
+                for (let x = rect.left + 48; x < rect.right - 96; x += 24) {
+                    const hit = document.elementFromPoint(x, y);
+                    if (hit && canvas.contains(hit) && !hit.closest(excludedSelector)) {
+                        return { x, y };
+                    }
+                }
+            }
+            throw new Error("Could not find an empty point on the node graph canvas.");
+        });
+    }
+
+    /**
      * Locate a connection port of a node, optionally disambiguated by direction. Boundary nodes have a
      * single port (Import: one output, Export: one input), so the direction is optional; blocks with both
      * an input and an output (e.g. Compress Textures (KTX2)) need it to pick the right side.

--- a/packages/tools/nodeAssetsEditor/test/playwright/nodeAssetsEditor.test.ts
+++ b/packages/tools/nodeAssetsEditor/test/playwright/nodeAssetsEditor.test.ts
@@ -680,6 +680,94 @@ test.describe("Node Assets Editor — maintained default pipeline", () => {
         await expect(editor.nodes).toHaveCount(2);
     });
 
+    test("pans empty canvas without mutating graph layout and preserves node drag and wheel zoom", async ({ page }) => {
+        const editor = new NodeAssetsEditorPage(page);
+        await editor.goto();
+
+        const importNode = editor.nodeByTitle("Import glTF");
+        await editor.selectNode("Import glTF");
+        const selectedNodeName = page.getByRole("textbox").nth(0);
+        await expect(selectedNodeName).toHaveValue("Import glTF");
+
+        const readNodeState = async () =>
+            await importNode.evaluate((node: HTMLElement) => {
+                const rect = node.getBoundingClientRect();
+                return {
+                    worldLeft: node.style.left,
+                    worldTop: node.style.top,
+                    screenX: rect.x,
+                    screenY: rect.y,
+                    screenWidth: rect.width,
+                };
+            });
+
+        const beforePan = await readNodeState();
+        const start = await editor.findEmptyCanvasPoint();
+        const delta = { x: 48, y: 32 };
+        await expect(editor.canvas).toHaveCSS("cursor", "grab");
+        await page.mouse.move(start.x, start.y);
+        await page.mouse.down();
+        await expect(editor.canvas).toHaveCSS("cursor", "grabbing");
+        const beforeForeignMove = await readNodeState();
+        await editor.canvas.dispatchEvent("pointermove", {
+            pointerId: 999,
+            pointerType: "touch",
+            isPrimary: false,
+            buttons: 1,
+            clientX: start.x + 96,
+            clientY: start.y + 96,
+        });
+        const afterForeignMove = await readNodeState();
+        expect(afterForeignMove.screenX).toBe(beforeForeignMove.screenX);
+        expect(afterForeignMove.screenY).toBe(beforeForeignMove.screenY);
+        await page.mouse.move(start.x + delta.x, start.y + delta.y, { steps: 4 });
+        await page.mouse.up();
+        await expect(editor.canvas).toHaveCSS("cursor", "grab");
+
+        const afterPan = await readNodeState();
+        expect(afterPan.worldLeft).toBe(beforePan.worldLeft);
+        expect(afterPan.worldTop).toBe(beforePan.worldTop);
+        expect(afterPan.screenX).toBeCloseTo(beforePan.screenX + delta.x, 4);
+        expect(afterPan.screenY).toBeCloseTo(beforePan.screenY + delta.y, 4);
+        await expect(selectedNodeName).toHaveValue("Import glTF");
+
+        const cancelPoint = await editor.findEmptyCanvasPoint();
+        await page.mouse.move(cancelPoint.x, cancelPoint.y);
+        await page.mouse.down();
+        await expect(editor.canvas).toHaveCSS("cursor", "grabbing");
+        await editor.canvas.dispatchEvent("pointercancel", {
+            pointerId: 1,
+            pointerType: "mouse",
+            isPrimary: true,
+            buttons: 0,
+            clientX: cancelPoint.x,
+            clientY: cancelPoint.y,
+        });
+        await expect(editor.canvas).toHaveCSS("cursor", "grab");
+        await page.mouse.up();
+        await expect(selectedNodeName).toHaveValue("Import glTF");
+
+        const nodeTitle = importNode.getByText("Import glTF", { exact: true });
+        const titleBox = await nodeTitle.boundingBox();
+        if (!titleBox) {
+            throw new Error("Could not resolve the selected node title for dragging.");
+        }
+        await page.mouse.move(titleBox.x + titleBox.width / 2, titleBox.y + titleBox.height / 2);
+        await page.mouse.down();
+        await page.mouse.move(titleBox.x + titleBox.width / 2 + 24, titleBox.y + titleBox.height / 2 + 16, { steps: 4 });
+        await page.mouse.up();
+        const afterNodeDrag = await readNodeState();
+        expect({ left: afterNodeDrag.worldLeft, top: afterNodeDrag.worldTop }).not.toEqual({ left: afterPan.worldLeft, top: afterPan.worldTop });
+
+        const zoomPoint = await editor.findEmptyCanvasPoint();
+        await page.mouse.move(zoomPoint.x, zoomPoint.y);
+        await page.mouse.wheel(0, -200);
+        await expect.poll(async () => (await readNodeState()).screenWidth).toBeGreaterThan(afterNodeDrag.screenWidth);
+        const afterZoom = await readNodeState();
+        expect(afterZoom.worldLeft).toBe(afterNodeDrag.worldLeft);
+        expect(afterZoom.worldTop).toBe(afterNodeDrag.worldTop);
+    });
+
     test("reorganizes overlapping nodes into a left-to-right data flow", async ({ page }) => {
         const editor = new NodeAssetsEditorPage(page);
         await editor.goto();

--- a/packages/tools/nodeAssetsEditor/test/unit/nodeGraph/gestureInterpreter.test.ts
+++ b/packages/tools/nodeAssetsEditor/test/unit/nodeGraph/gestureInterpreter.test.ts
@@ -6,6 +6,7 @@ import {
     BeginFrameGesture,
     BeginNodeGesture,
     BeginPortGesture,
+    CancelGesture,
     CompleteGesture,
     type Gesture,
     type GestureAction,
@@ -17,30 +18,35 @@ function Kinds(actions: readonly GestureAction[]): string[] {
 
 describe("gestureInterpreter.BeginBackgroundGesture", () => {
     it("starts a pan on the middle button", () => {
-        const { gesture, actions } = BeginBackgroundGesture({ button: 1, spaceHeld: false, additive: false, world: { x: 5, y: 6 }, local: { x: 7, y: 8 } });
-        expect(gesture).toEqual({ kind: "pan", lastLocal: { x: 7, y: 8 } });
+        const { gesture, actions } = BeginBackgroundGesture({ pointerId: 7, button: 1, spaceHeld: false, additive: false, world: { x: 5, y: 6 }, local: { x: 7, y: 8 } });
+        expect(gesture).toEqual({ kind: "pan", pointerId: 7, lastLocal: { x: 7, y: 8 }, moved: false, clearSelectionOnClick: false });
         expect(actions).toEqual([]);
     });
 
     it("starts a pan on space + left button", () => {
-        const { gesture } = BeginBackgroundGesture({ button: 0, spaceHeld: true, additive: false, world: { x: 5, y: 6 }, local: { x: 7, y: 8 } });
+        const { gesture } = BeginBackgroundGesture({ pointerId: 7, button: 0, spaceHeld: true, additive: false, world: { x: 5, y: 6 }, local: { x: 7, y: 8 } });
         expect(gesture.kind).toBe("pan");
     });
 
-    it("starts a marquee and clears the selection on a plain left press", () => {
-        const { gesture, actions } = BeginBackgroundGesture({ button: 0, spaceHeld: false, additive: false, world: { x: 5, y: 6 }, local: { x: 7, y: 8 } });
-        expect(gesture).toEqual({ kind: "marquee", startWorld: { x: 5, y: 6 }, startLocal: { x: 7, y: 8 }, additive: false });
-        expect(actions).toEqual([{ kind: "clearSelection" }, { kind: "setMarquee", rect: { x: 7, y: 8, width: 0, height: 0 } }]);
+    it("starts a pan on a plain left press", () => {
+        const { gesture, actions } = BeginBackgroundGesture({ pointerId: 7, button: 0, spaceHeld: false, additive: false, world: { x: 5, y: 6 }, local: { x: 7, y: 8 } });
+        expect(gesture.kind).toBe("pan");
+        expect(actions).toEqual([]);
     });
 
     it("does not clear the selection on an additive (shift) left press", () => {
-        const { gesture, actions } = BeginBackgroundGesture({ button: 0, spaceHeld: false, additive: true, world: { x: 5, y: 6 }, local: { x: 7, y: 8 } });
+        const { gesture, actions } = BeginBackgroundGesture({ pointerId: 7, button: 0, spaceHeld: false, additive: true, world: { x: 5, y: 6 }, local: { x: 7, y: 8 } });
         expect(gesture.kind).toBe("marquee");
         expect(Kinds(actions)).toEqual(["setMarquee"]);
     });
 
+    it("keeps additive marquee priority when Space is also held", () => {
+        const { gesture } = BeginBackgroundGesture({ pointerId: 7, button: 0, spaceHeld: true, additive: true, world: { x: 5, y: 6 }, local: { x: 7, y: 8 } });
+        expect(gesture.kind).toBe("marquee");
+    });
+
     it("does nothing for other buttons", () => {
-        const { gesture, actions } = BeginBackgroundGesture({ button: 2, spaceHeld: false, additive: false, world: { x: 0, y: 0 }, local: { x: 0, y: 0 } });
+        const { gesture, actions } = BeginBackgroundGesture({ pointerId: 7, button: 2, spaceHeld: false, additive: false, world: { x: 0, y: 0 }, local: { x: 0, y: 0 } });
         expect(gesture).toEqual({ kind: "none" });
         expect(actions).toEqual([]);
     });
@@ -48,84 +54,138 @@ describe("gestureInterpreter.BeginBackgroundGesture", () => {
 
 describe("gestureInterpreter.BeginNodeGesture", () => {
     it("selects an unselected node and brackets the interaction", () => {
-        const { gesture, actions } = BeginNodeGesture({ nodeId: "n1", additive: false, isSelected: false, world: { x: 3, y: 4 } });
-        expect(gesture).toEqual({ kind: "moveNodes", lastWorld: { x: 3, y: 4 }, moved: false });
+        const { gesture, actions } = BeginNodeGesture({ pointerId: 7, nodeId: "n1", additive: false, isSelected: false, world: { x: 3, y: 4 } });
+        expect(gesture).toEqual({ kind: "moveNodes", pointerId: 7, lastWorld: { x: 3, y: 4 }, moved: false });
         expect(actions).toEqual([{ kind: "selectNodes", nodeIds: ["n1"] }, { kind: "beginInteraction" }]);
     });
 
     it("toggles selection on an additive press", () => {
-        const { actions } = BeginNodeGesture({ nodeId: "n1", additive: true, isSelected: true, world: { x: 0, y: 0 } });
+        const { actions } = BeginNodeGesture({ pointerId: 7, nodeId: "n1", additive: true, isSelected: true, world: { x: 0, y: 0 } });
         expect(actions).toEqual([{ kind: "toggleNodeSelection", nodeId: "n1" }, { kind: "beginInteraction" }]);
     });
 
     it("keeps an existing selection when the node is already selected", () => {
-        const { actions } = BeginNodeGesture({ nodeId: "n1", additive: false, isSelected: true, world: { x: 0, y: 0 } });
+        const { actions } = BeginNodeGesture({ pointerId: 7, nodeId: "n1", additive: false, isSelected: true, world: { x: 0, y: 0 } });
         expect(actions).toEqual([{ kind: "beginInteraction" }]);
     });
 });
 
 describe("gestureInterpreter.BeginFrameGesture", () => {
     it("brackets the interaction and tracks the frame", () => {
-        const { gesture, actions } = BeginFrameGesture({ frameId: "f1", world: { x: 9, y: 10 } });
-        expect(gesture).toEqual({ kind: "moveFrame", frameId: "f1", lastWorld: { x: 9, y: 10 }, moved: false });
+        const { gesture, actions } = BeginFrameGesture({ pointerId: 7, frameId: "f1", world: { x: 9, y: 10 } });
+        expect(gesture).toEqual({ kind: "moveFrame", pointerId: 7, frameId: "f1", lastWorld: { x: 9, y: 10 }, moved: false });
         expect(actions).toEqual([{ kind: "beginInteraction" }]);
     });
 });
 
 describe("gestureInterpreter.BeginPortGesture", () => {
     it("starts a wire and previews it from the anchor to the pointer", () => {
-        const { gesture, actions } = BeginPortGesture({ portId: "p1", anchor: { x: 100, y: 50 }, world: { x: 120, y: 60 } });
-        expect(gesture).toEqual({ kind: "wire", fromPortId: "p1", fromAnchor: { x: 100, y: 50 } });
+        const { gesture, actions } = BeginPortGesture({ pointerId: 7, portId: "p1", anchor: { x: 100, y: 50 }, world: { x: 120, y: 60 } });
+        expect(gesture).toEqual({ kind: "wire", pointerId: 7, fromPortId: "p1", fromAnchor: { x: 100, y: 50 } });
         expect(actions).toEqual([{ kind: "setPendingWire", wire: { from: { x: 100, y: 50 }, to: { x: 120, y: 60 } } }]);
     });
 });
 
 describe("gestureInterpreter.AdvanceGesture", () => {
+    it("ignores move and completion events from a pointer that does not own the gesture", () => {
+        const gesture = BeginBackgroundGesture({
+            pointerId: 7,
+            button: 0,
+            spaceHeld: false,
+            additive: false,
+            world: { x: 0, y: 0 },
+            local: { x: 10, y: 10 },
+        }).gesture;
+        const moved = AdvanceGesture(gesture, { pointerId: 8, world: { x: 50, y: 50 }, local: { x: 60, y: 60 } });
+        expect(moved.gesture).toBe(gesture);
+        expect(moved.actions).toEqual([]);
+
+        const completed = CompleteGesture(gesture, { pointerId: 8, world: { x: 50, y: 50 } });
+        expect(completed.gesture).toBe(gesture);
+        expect(completed.actions).toEqual([]);
+    });
+
     it("pans by the viewport-local delta", () => {
-        const gesture: Gesture = { kind: "pan", lastLocal: { x: 10, y: 10 } };
-        const { gesture: next, actions } = AdvanceGesture(gesture, { world: { x: 0, y: 0 }, local: { x: 25, y: 4 } });
+        const gesture: Gesture = { kind: "pan", pointerId: 7, lastLocal: { x: 10, y: 10 }, moved: false, clearSelectionOnClick: true };
+        const { gesture: next, actions } = AdvanceGesture(gesture, { pointerId: 7, world: { x: 0, y: 0 }, local: { x: 25, y: 4 } });
         expect(actions).toEqual([{ kind: "panBy", dx: 15, dy: -6 }]);
-        expect(next).toEqual({ kind: "pan", lastLocal: { x: 25, y: 4 } });
+        expect(next).toEqual({ kind: "pan", pointerId: 7, lastLocal: { x: 25, y: 4 }, moved: true, clearSelectionOnClick: true });
+    });
+
+    it("ignores a zero-delta pan move without latching movement", () => {
+        const gesture: Gesture = { kind: "pan", pointerId: 7, lastLocal: { x: 10, y: 10 }, moved: false, clearSelectionOnClick: true };
+        const { gesture: next, actions } = AdvanceGesture(gesture, { pointerId: 7, world: { x: 0, y: 0 }, local: { x: 10, y: 10 } });
+        expect(actions).toEqual([]);
+        expect(next).toBe(gesture);
     });
 
     it("normalizes the marquee rectangle regardless of drag direction", () => {
-        const gesture: Gesture = { kind: "marquee", startWorld: { x: 0, y: 0 }, startLocal: { x: 30, y: 40 }, additive: false };
-        const { actions } = AdvanceGesture(gesture, { world: { x: 0, y: 0 }, local: { x: 10, y: 100 } });
+        const gesture: Gesture = { kind: "marquee", pointerId: 7, startWorld: { x: 0, y: 0 }, startLocal: { x: 30, y: 40 }, additive: false };
+        const { actions } = AdvanceGesture(gesture, { pointerId: 7, world: { x: 0, y: 0 }, local: { x: 10, y: 100 } });
         expect(actions).toEqual([{ kind: "setMarquee", rect: { x: 10, y: 40, width: 20, height: 60 } }]);
     });
 
     it("translates selected nodes and latches moved on a non-zero delta", () => {
-        const gesture: Gesture = { kind: "moveNodes", lastWorld: { x: 0, y: 0 }, moved: false };
-        const { gesture: next, actions } = AdvanceGesture(gesture, { world: { x: 5, y: -3 }, local: { x: 0, y: 0 } });
+        const gesture: Gesture = { kind: "moveNodes", pointerId: 7, lastWorld: { x: 0, y: 0 }, moved: false };
+        const { gesture: next, actions } = AdvanceGesture(gesture, { pointerId: 7, world: { x: 5, y: -3 }, local: { x: 0, y: 0 } });
         expect(actions).toEqual([{ kind: "translateSelectedNodes", delta: { x: 5, y: -3 } }]);
-        expect(next).toEqual({ kind: "moveNodes", lastWorld: { x: 5, y: -3 }, moved: true });
+        expect(next).toEqual({ kind: "moveNodes", pointerId: 7, lastWorld: { x: 5, y: -3 }, moved: true });
     });
 
     it("ignores a zero-delta node move and keeps the moved latch", () => {
-        const moved: Gesture = { kind: "moveNodes", lastWorld: { x: 5, y: 5 }, moved: true };
-        const { gesture: next, actions } = AdvanceGesture(moved, { world: { x: 5, y: 5 }, local: { x: 0, y: 0 } });
+        const moved: Gesture = { kind: "moveNodes", pointerId: 7, lastWorld: { x: 5, y: 5 }, moved: true };
+        const { gesture: next, actions } = AdvanceGesture(moved, { pointerId: 7, world: { x: 5, y: 5 }, local: { x: 0, y: 0 } });
         expect(actions).toEqual([]);
         expect(next).toBe(moved);
     });
 
     it("translates a frame on a non-zero delta", () => {
-        const gesture: Gesture = { kind: "moveFrame", frameId: "f1", lastWorld: { x: 0, y: 0 }, moved: false };
-        const { gesture: next, actions } = AdvanceGesture(gesture, { world: { x: 2, y: 2 }, local: { x: 0, y: 0 } });
+        const gesture: Gesture = { kind: "moveFrame", pointerId: 7, frameId: "f1", lastWorld: { x: 0, y: 0 }, moved: false };
+        const { gesture: next, actions } = AdvanceGesture(gesture, { pointerId: 7, world: { x: 2, y: 2 }, local: { x: 0, y: 0 } });
         expect(actions).toEqual([{ kind: "translateFrame", frameId: "f1", delta: { x: 2, y: 2 } }]);
-        expect(next).toEqual({ kind: "moveFrame", frameId: "f1", lastWorld: { x: 2, y: 2 }, moved: true });
+        expect(next).toEqual({ kind: "moveFrame", pointerId: 7, frameId: "f1", lastWorld: { x: 2, y: 2 }, moved: true });
     });
 
     it("updates the pending wire endpoint while dragging a wire", () => {
-        const gesture: Gesture = { kind: "wire", fromPortId: "p1", fromAnchor: { x: 100, y: 50 } };
-        const { actions } = AdvanceGesture(gesture, { world: { x: 130, y: 70 }, local: { x: 0, y: 0 } });
+        const gesture: Gesture = { kind: "wire", pointerId: 7, fromPortId: "p1", fromAnchor: { x: 100, y: 50 } };
+        const { actions } = AdvanceGesture(gesture, { pointerId: 7, world: { x: 130, y: 70 }, local: { x: 0, y: 0 } });
         expect(actions).toEqual([{ kind: "setPendingWire", wire: { from: { x: 100, y: 50 }, to: { x: 130, y: 70 } } }]);
     });
 });
 
 describe("gestureInterpreter.CompleteGesture", () => {
+    it("clears the selection when a primary background pan completes without movement", () => {
+        const { gesture } = BeginBackgroundGesture({ pointerId: 7, button: 0, spaceHeld: false, additive: false, world: { x: 10, y: 20 }, local: { x: 30, y: 40 } });
+        const { gesture: next, actions } = CompleteGesture(gesture, { pointerId: 7, world: { x: 10, y: 20 } });
+        expect(next).toEqual({ kind: "none" });
+        expect(actions).toEqual([{ kind: "clearSelection" }]);
+    });
+
+    it("preserves the selection when a primary background pan moved", () => {
+        const started = BeginBackgroundGesture({ pointerId: 7, button: 0, spaceHeld: false, additive: false, world: { x: 10, y: 20 }, local: { x: 30, y: 40 } }).gesture;
+        const advanced = AdvanceGesture(started, { pointerId: 7, world: { x: 10, y: 20 }, local: { x: 31, y: 40 } }).gesture;
+        const { actions } = CompleteGesture(advanced, { pointerId: 7, world: { x: 10, y: 20 } });
+        expect(actions).toEqual([]);
+    });
+
+    it.each([
+        ["middle-button", { button: 1, spaceHeld: false }],
+        ["Space + primary", { button: 0, spaceHeld: true }],
+    ])("does not clear selection when an unmoved %s pan alias completes", (_name, input) => {
+        const gesture = BeginBackgroundGesture({
+            pointerId: 7,
+            ...input,
+            additive: false,
+            world: { x: 10, y: 20 },
+            local: { x: 30, y: 40 },
+        }).gesture;
+        const { actions } = CompleteGesture(gesture, { pointerId: 7, world: { x: 10, y: 20 } });
+        expect(actions).toEqual([]);
+    });
+
     it("selects nodes inside the marquee region and clears the overlay", () => {
-        const gesture: Gesture = { kind: "marquee", startWorld: { x: 10, y: 80 }, startLocal: { x: 0, y: 0 }, additive: true };
-        const { gesture: next, actions } = CompleteGesture(gesture, { world: { x: 40, y: 20 } });
+        const gesture: Gesture = { kind: "marquee", pointerId: 7, startWorld: { x: 10, y: 80 }, startLocal: { x: 0, y: 0 }, additive: true };
+        const { gesture: next, actions } = CompleteGesture(gesture, { pointerId: 7, world: { x: 40, y: 20 } });
         expect(actions).toEqual([
             { kind: "selectNodesInRegion", region: { minX: 10, minY: 20, maxX: 40, maxY: 80 }, additive: true },
             { kind: "setMarquee", rect: null },
@@ -134,14 +194,14 @@ describe("gestureInterpreter.CompleteGesture", () => {
     });
 
     it("ends a node move interaction with the moved flag", () => {
-        const gesture: Gesture = { kind: "moveNodes", lastWorld: { x: 0, y: 0 }, moved: true };
-        const { actions } = CompleteGesture(gesture, { world: { x: 0, y: 0 } });
+        const gesture: Gesture = { kind: "moveNodes", pointerId: 7, lastWorld: { x: 0, y: 0 }, moved: true };
+        const { actions } = CompleteGesture(gesture, { pointerId: 7, world: { x: 0, y: 0 } });
         expect(actions).toEqual([{ kind: "endInteraction", moved: true }]);
     });
 
     it("connects a wire to the resolved target port", () => {
-        const gesture: Gesture = { kind: "wire", fromPortId: "p1", fromAnchor: { x: 0, y: 0 } };
-        const { actions } = CompleteGesture(gesture, { world: { x: 0, y: 0 }, resolvedTargetPortId: "p2" });
+        const gesture: Gesture = { kind: "wire", pointerId: 7, fromPortId: "p1", fromAnchor: { x: 0, y: 0 } };
+        const { actions } = CompleteGesture(gesture, { pointerId: 7, world: { x: 0, y: 0 }, resolvedTargetPortId: "p2" });
         expect(actions).toEqual([
             { kind: "connect", fromPortId: "p1", toPortId: "p2" },
             { kind: "setPendingWire", wire: null },
@@ -149,20 +209,76 @@ describe("gestureInterpreter.CompleteGesture", () => {
     });
 
     it("does not connect a wire to its own origin port", () => {
-        const gesture: Gesture = { kind: "wire", fromPortId: "p1", fromAnchor: { x: 0, y: 0 } };
-        const { actions } = CompleteGesture(gesture, { world: { x: 0, y: 0 }, resolvedTargetPortId: "p1" });
+        const gesture: Gesture = { kind: "wire", pointerId: 7, fromPortId: "p1", fromAnchor: { x: 0, y: 0 } };
+        const { actions } = CompleteGesture(gesture, { pointerId: 7, world: { x: 0, y: 0 }, resolvedTargetPortId: "p1" });
         expect(actions).toEqual([{ kind: "setPendingWire", wire: null }]);
     });
 
     it("clears the pending wire when there is no target", () => {
-        const gesture: Gesture = { kind: "wire", fromPortId: "p1", fromAnchor: { x: 0, y: 0 } };
-        const { actions } = CompleteGesture(gesture, { world: { x: 0, y: 0 } });
+        const gesture: Gesture = { kind: "wire", pointerId: 7, fromPortId: "p1", fromAnchor: { x: 0, y: 0 } };
+        const { actions } = CompleteGesture(gesture, { pointerId: 7, world: { x: 0, y: 0 } });
         expect(actions).toEqual([{ kind: "setPendingWire", wire: null }]);
     });
 
     it("resets to no gesture when idle", () => {
-        const { gesture, actions } = CompleteGesture({ kind: "none" }, { world: { x: 0, y: 0 } });
+        const { gesture, actions } = CompleteGesture({ kind: "none" }, { pointerId: 7, world: { x: 0, y: 0 } });
         expect(gesture).toEqual({ kind: "none" });
+        expect(actions).toEqual([]);
+    });
+});
+
+describe("gestureInterpreter.CancelGesture", () => {
+    it("cancels an unmoved primary pan without clearing selection", () => {
+        const gesture = BeginBackgroundGesture({
+            pointerId: 7,
+            button: 0,
+            spaceHeld: false,
+            additive: false,
+            world: { x: 10, y: 20 },
+            local: { x: 30, y: 40 },
+        }).gesture;
+        const { gesture: next, actions } = CancelGesture(gesture, { pointerId: 7 });
+        expect(next).toEqual({ kind: "none" });
+        expect(actions).toEqual([]);
+    });
+
+    it("clears an active marquee without committing its selection", () => {
+        const gesture: Gesture = {
+            kind: "marquee",
+            pointerId: 7,
+            startWorld: { x: 10, y: 20 },
+            startLocal: { x: 30, y: 40 },
+            additive: true,
+        };
+        const { gesture: next, actions } = CancelGesture(gesture, { pointerId: 7 });
+        expect(next).toEqual({ kind: "none" });
+        expect(actions).toEqual([{ kind: "setMarquee", rect: null }]);
+    });
+
+    it("clears a pending wire without connecting it", () => {
+        const gesture: Gesture = { kind: "wire", pointerId: 7, fromPortId: "p1", fromAnchor: { x: 10, y: 20 } };
+        const { gesture: next, actions } = CancelGesture(gesture, { pointerId: 7 });
+        expect(next).toEqual({ kind: "none" });
+        expect(actions).toEqual([{ kind: "setPendingWire", wire: null }]);
+    });
+
+    it("closes a bracketed node move using its movement latch", () => {
+        const gesture: Gesture = { kind: "moveNodes", pointerId: 7, lastWorld: { x: 10, y: 20 }, moved: true };
+        const { gesture: next, actions } = CancelGesture(gesture, { pointerId: 7 });
+        expect(next).toEqual({ kind: "none" });
+        expect(actions).toEqual([{ kind: "endInteraction", moved: true }]);
+    });
+
+    it("closes a bracketed frame move without inventing movement", () => {
+        const gesture: Gesture = { kind: "moveFrame", pointerId: 7, frameId: "f1", lastWorld: { x: 10, y: 20 }, moved: false };
+        const { actions } = CancelGesture(gesture, { pointerId: 7 });
+        expect(actions).toEqual([{ kind: "endInteraction", moved: false }]);
+    });
+
+    it("ignores cancellation from a pointer that does not own the gesture", () => {
+        const gesture: Gesture = { kind: "pan", pointerId: 7, lastLocal: { x: 10, y: 20 }, moved: true, clearSelectionOnClick: true };
+        const { gesture: next, actions } = CancelGesture(gesture, { pointerId: 8 });
+        expect(next).toBe(gesture);
         expect(actions).toEqual([]);
     });
 });


### PR DESCRIPTION
## Summary
- route unmodified primary background drags to viewport-pixel camera panning while preserving modified marquee selection and existing pan aliases
- enforce initiating-pointer ownership through capture, completion, cancellation, and lost-capture cleanup
- add grab/grabbing feedback plus unit and browser regressions for panning, cancellation, node dragging, wire dragging, and wheel zoom

## Validation
- `npx vitest run --project=unit packages/tools/nodeAssetsEditor/test/unit/nodeGraph/gestureInterpreter.test.ts` (35 passed)
- focused Node Assets Editor Playwright panning and occupied-input wire replacement tests (2 passed)
- targeted ESLint and Prettier checks
- `npm run build:deployment -w @tools/node-assets-editor`

The package-wide standalone TypeScript check is currently blocked by unrelated existing core diagnostics; its output contained no diagnostics for the changed files.
