### PR TITLE
feat(nae): add accessible palette description tooltips

### DIFF
--- a/.scratch/palette-description-tooltips/issues/01-implement-accessible-palette-description-tooltips.md
+++ b/.scratch/palette-description-tooltips/issues/01-implement-accessible-palette-description-tooltips.md
@@ -1,6 +1,6 @@
 # Implement accessible palette description tooltips
 
-Status: ready-for-agent
+Status: resolved
 
 ## Parent
 
@@ -12,17 +12,17 @@ Make the Node Assets Editor palette name-first and compact by removing always-vi
 
 ## Acceptance criteria
 
-- [ ] Descriptions no longer render as visible palette subheadings; node names remain visible with existing typography and wrapping.
-- [ ] Non-empty descriptions use `shared-ui-components/fluent/primitives/tooltip`, open on pointer hover and keyboard focus, and are exposed through the tooltip's accessible description relationship.
-- [ ] The focusable trigger keeps the node name as its accessible name; no native `title` tooltip competes with Fluent.
-- [ ] Missing, empty, or whitespace-only descriptions create no tooltip.
-- [ ] Tooltip defaults control timing, placement, wrapping, portal, and pointer behavior; no manual tooltip state or layout wrapper is added.
-- [ ] Description metadata and description/keyword/category filtering remain unchanged.
-- [ ] Drag payloads and canvas drops remain unchanged, and no click-to-create, keyboard-to-create, or touch gesture is introduced.
-- [ ] Pane scrolling, category/family rendering, Show primitives, and item row density remain intact apart from removal of the description line.
-- [ ] Tests are developed first and prove hidden descriptions, hover, focus, accessible semantics, search, and an unchanged palette-item drop through stable locators.
-- [ ] Focused unit, Playwright, build/type-check, lint, and format validation passes, followed by a rendered check of the Node Assets Editor dev surface.
-- [ ] `/code-review` reports no unresolved findings.
+- [x] Descriptions no longer render as visible palette subheadings; node names remain visible with existing typography and wrapping.
+- [x] Non-empty descriptions use `shared-ui-components/fluent/primitives/tooltip`, open on pointer hover and keyboard focus, and are exposed through the tooltip's accessible description relationship.
+- [x] The focusable trigger keeps the node name as its accessible name; no native `title` tooltip competes with Fluent.
+- [x] Missing, empty, or whitespace-only descriptions create no tooltip.
+- [x] Tooltip defaults control timing, placement, wrapping, portal, and pointer behavior; no manual tooltip state or layout wrapper is added.
+- [x] Description metadata and description/keyword/category filtering remain unchanged.
+- [x] Drag payloads and canvas drops remain unchanged, and no click-to-create, keyboard-to-create, or touch gesture is introduced.
+- [x] Pane scrolling, category/family rendering, Show primitives, and item row density remain intact apart from removal of the description line.
+- [x] Tests are developed first and prove hidden descriptions, hover, focus, accessible semantics, search, and an unchanged palette-item drop through stable locators.
+- [x] Focused unit, Playwright, build/type-check, lint, and format validation passes, followed by a rendered check of the Node Assets Editor dev surface.
+- [x] `/code-review` reports no unresolved findings.
 
 ## Blocked by
 
@@ -30,4 +30,7 @@ None - can start immediately.
 
 ## Comments
 
-No comments yet.
+- 2026-07-21: Implemented compact label-only rows with trimmed shared Fluent description tooltips, visible-label accessible names, keyboard focus, and unchanged drag payloads/search metadata.
+- Validation: palette unit tests 13/13; focused package Playwright 1/1; full NAE Playwright project 39/39; NAE build, changed-file ESLint, Prettier, and diff checks passed.
+- Rendered validation: rows remained 34 px high; hover and focus showed the themed 240 px-default tooltip; the palette scrolled 500 px inside its pane; click kept 4 nodes and the existing drop path created a fifth node.
+- Two-axis `/code-review`: standards and spec both reported no unresolved findings.

--- a/packages/tools/nodeAssetsEditor/src/nodeAssets/blockCatalog.ts
+++ b/packages/tools/nodeAssetsEditor/src/nodeAssets/blockCatalog.ts
@@ -123,7 +123,7 @@ export interface IBlockDescriptor {
     readonly paletteItemId: string;
     /** Human readable label, used both in the palette and as the new node's title. */
     readonly label: string;
-    /** Concise explanation shown in the palette. */
+    /** Optional concise explanation exposed as palette help and used by search. */
     readonly description?: string;
     /** Workflow terms and aliases used by palette search. */
     readonly keywords?: readonly string[];

--- a/packages/tools/nodeAssetsEditor/src/nodeGraph/components/PaletteView.tsx
+++ b/packages/tools/nodeAssetsEditor/src/nodeGraph/components/PaletteView.tsx
@@ -2,6 +2,7 @@ import { Fragment, type DragEvent, type FunctionComponent, useEffect, useMemo, u
 
 import { Accordion, AccordionHeader, AccordionItem, AccordionPanel, Body1, Caption1, Checkbox, makeStyles, tokens } from "@fluentui/react-components";
 import { SearchBar } from "shared-ui-components/fluent/primitives/searchBar";
+import { Tooltip } from "shared-ui-components/fluent/primitives/tooltip";
 
 import { type EditorContextValue } from "../editorContext";
 import { type IPaletteCategory, type IPaletteItem, type IPalettePreferences, PaletteDragFormat } from "../paletteModel";
@@ -61,9 +62,6 @@ const useStyles = makeStyles({
             backgroundColor: tokens.colorNeutralBackground1Pressed,
             cursor: "grabbing",
         },
-    },
-    description: {
-        color: tokens.colorNeutralForeground2,
     },
     empty: {
         color: tokens.colorNeutralForeground3,
@@ -147,25 +145,33 @@ export const PaletteView: FunctionComponent<{ context: EditorContextValue; prefe
                                 </AccordionHeader>
                                 <AccordionPanel>
                                     <div className={classes.panel}>
-                                        {category.items.map((item, itemIndex) => (
-                                            <Fragment key={item.id}>
-                                                {item.family !== undefined && item.family !== category.items[itemIndex - 1]?.family && (
-                                                    <Caption1 className={classes.family} data-testid="palette-family">
-                                                        {item.family}
-                                                    </Caption1>
-                                                )}
-                                                <div
-                                                    className={classes.row}
-                                                    data-testid="palette-item"
-                                                    draggable={true}
-                                                    title={item.label}
-                                                    onDragStart={(event) => onDragStart(event, item)}
-                                                >
-                                                    <Body1 data-testid="palette-item-label">{item.label}</Body1>
-                                                    {item.description && <Caption1 className={classes.description}>{item.description}</Caption1>}
-                                                </div>
-                                            </Fragment>
-                                        ))}
+                                        {category.items.map((item, itemIndex) => {
+                                            const tooltipContent = item.description?.trim() || undefined;
+                                            const labelId = `palette-item-label-${item.id}`;
+                                            return (
+                                                <Fragment key={item.id}>
+                                                    {item.family !== undefined && item.family !== category.items[itemIndex - 1]?.family && (
+                                                        <Caption1 className={classes.family} data-testid="palette-family">
+                                                            {item.family}
+                                                        </Caption1>
+                                                    )}
+                                                    <Tooltip content={tooltipContent}>
+                                                        <div
+                                                            aria-labelledby={labelId}
+                                                            className={classes.row}
+                                                            data-testid="palette-item"
+                                                            draggable={true}
+                                                            tabIndex={0}
+                                                            onDragStart={(event) => onDragStart(event, item)}
+                                                        >
+                                                            <Body1 id={labelId} data-testid="palette-item-label">
+                                                                {item.label}
+                                                            </Body1>
+                                                        </div>
+                                                    </Tooltip>
+                                                </Fragment>
+                                            );
+                                        })}
                                     </div>
                                 </AccordionPanel>
                             </AccordionItem>

--- a/packages/tools/nodeAssetsEditor/src/nodeGraph/paletteModel.ts
+++ b/packages/tools/nodeAssetsEditor/src/nodeGraph/paletteModel.ts
@@ -14,7 +14,7 @@ export interface IPaletteItem {
     readonly label: string;
     /** Optional family heading shown within the containing category. */
     readonly family?: string;
-    /** Concise explanation shown below the label. */
+    /** Optional concise explanation exposed as palette help and used by search. */
     readonly description?: string;
     /** Workflow terms and aliases used by palette search. */
     readonly keywords?: readonly string[];

--- a/packages/tools/nodeAssetsEditor/test/playwright/nae.utils.ts
+++ b/packages/tools/nodeAssetsEditor/test/playwright/nae.utils.ts
@@ -107,6 +107,15 @@ export class NodeAssetsEditorPage {
     }
 
     /**
+     * Locate a palette item through the palette's stable test seam and exact visible label.
+     * @param label - The palette item's visible label.
+     * @returns The palette item row locator.
+     */
+    paletteItem(label: string): Locator {
+        return this.page.getByTestId("palette-item").filter({ has: this.page.getByText(label, { exact: true }) });
+    }
+
+    /**
      * Select a node by clicking its header title, which reveals its properties in the right pane.
      * @param title - The node's visible title.
      * @param occurrence - Optional disambiguator when several nodes share the title (see {@link nodeByTitle}).
@@ -154,7 +163,7 @@ export class NodeAssetsEditorPage {
      * @param at - Drop point as canvas-rect fractions (0..1); defaults to the center.
      */
     async dropPaletteItem(label: string, at: CanvasPoint = { x: 0.5, y: 0.5 }): Promise<void> {
-        const source = await this.page.getByTitle(label, { exact: true }).first().elementHandle();
+        const source = await this.paletteItem(label).first().elementHandle();
         const target = await this.canvas.elementHandle();
         if (!source || !target) {
             throw new Error(`Could not resolve palette item "${label}" or the canvas for the drop gesture.`);

--- a/packages/tools/nodeAssetsEditor/test/playwright/nodeAssetsEditor.test.ts
+++ b/packages/tools/nodeAssetsEditor/test/playwright/nodeAssetsEditor.test.ts
@@ -552,20 +552,40 @@ test.describe("Node Assets Editor — maintained default pipeline", () => {
         await expect(editor.previewCanvas).toBeVisible();
     });
 
-    test("finds nodes by workflow intent and shows their descriptions", async ({ page }) => {
+    test("keeps palette descriptions searchable and exposes them on hover and focus", async ({ page }) => {
         const editor = new NodeAssetsEditorPage(page);
         await editor.goto();
 
         const search = page.getByPlaceholder("Search palette");
-        for (const [query, label, description] of [
-            ["decimate", "Simplify Meshes", "Reduce Universal mesh geometry to a target ratio and error limit."],
-            ["unused", "Remove Unused Resources", "Remove resources that are no longer referenced by the scene."],
-            ["compress", "Compress Textures (KTX2)", "Compress scene textures to KTX2 / Basis Universal."],
-        ]) {
-            await search.fill(query);
-            await expect(page.getByTitle(label, { exact: true })).toBeVisible();
-            await expect(page.getByText(description, { exact: true })).toBeVisible();
-        }
+        const label = "Simplify Meshes";
+        const description = "Reduce Universal mesh geometry to a target ratio and error limit.";
+        await search.fill("target ratio");
+
+        const paletteItem = editor.paletteItem(label);
+        const tooltip = page.getByRole("tooltip");
+        await expect(paletteItem).toBeVisible();
+        await search.clear();
+        await paletteItem.scrollIntoViewIfNeeded();
+        await expect(page.getByText(description, { exact: true })).toBeHidden();
+        await expect(paletteItem).toHaveAccessibleName(label);
+        await expect(paletteItem).toHaveAttribute("tabindex", "0");
+        await expect(paletteItem).not.toHaveAttribute("title");
+
+        await paletteItem.hover();
+        await expect(tooltip).toBeVisible({ timeout: 10_000 });
+        await expect(tooltip).toHaveText(description);
+        await expect(paletteItem).toHaveAccessibleDescription(description);
+
+        await page.mouse.move(0, 0);
+        await expect(tooltip).toBeHidden();
+        await paletteItem.focus();
+        await expect(paletteItem).toBeFocused();
+        await expect(tooltip).toBeVisible({ timeout: 10_000 });
+        await expect(tooltip).toHaveText(description);
+        await expect(paletteItem).toHaveAccessibleDescription(description);
+
+        await editor.dropPaletteItem(label, { x: 0.65, y: 0.75 });
+        await expect(editor.nodeByTitle(label)).toBeVisible();
     });
 
     test("persists Show primitives without changing canvas or expanded aggregate nodes", async ({ page }) => {
@@ -650,7 +670,7 @@ test.describe("Node Assets Editor — maintained default pipeline", () => {
         await search.clear();
         await showPrimitives.uncheck();
         await expect(nodeGeometryCategory).toHaveCount(0);
-        await expect(page.getByTitle("Read Babylon", { exact: true })).toHaveCount(0);
+        await expect(editor.paletteItem("Read Babylon")).toHaveCount(0);
         await expect(categories).toHaveText(["Inputs (4)", "Universal (17)", "glTF (3)"]);
         await expect(items).toHaveText(defaultItems);
         await expect(editor.nodeByTitle("Read Babylon")).toBeVisible();
@@ -1175,7 +1195,7 @@ test.describe("Node Assets Editor — Universal glTF aggregates", () => {
             buffer: createNodeGeometryEditorFile(),
         });
         await expect(editor.nodes).toHaveCount(2);
-        await expect(page.getByTitle("Evaluate Node Geometry", { exact: true })).toHaveCount(0);
+        await expect(editor.paletteItem("Evaluate Node Geometry")).toHaveCount(0);
 
         await editor.selectNode("Import Node Geometry");
         await propertyTextbox("Snippet ID").fill("#TEST#1");


### PR DESCRIPTION
## Summary

- render compact, label-only palette rows and expose meaningful descriptions through the shared Fluent Tooltip
- preserve searchable description metadata and exact drag payloads while adding keyboard focus and visible-label accessible names
- replace title-based Playwright lookups with a stable palette-item locator and cover description search, hover, focus, semantics, and drop

## Validation

- `npx vitest run --project=unit packages/tools/nodeAssetsEditor/test/unit/paletteCategories.test.ts` - 13 passed
- `npm run test:e2e -w @tools/node-assets-editor -- --grep "keeps palette descriptions searchable" --workers=1 --retries=0` - 1 passed
- `npx playwright test -c playwright.config.ts --project=nodeAssetsEditor --workers=1 --retries=0` - 39 passed
- `npm run build -w @tools/node-assets-editor` - passed
- changed-file ESLint and Prettier checks - passed
- rendered NAE validation - 34 px compact rows, hover/focus tooltip, contained pane scroll, unchanged click behavior, and successful palette drop
- two-axis code review - no standards or spec findings