### PR TITLE
Add uploaded FBX import to Node Assets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22161,6 +22161,7 @@
             "name": "@dev/node-assets",
             "version": "1.0.0",
             "dependencies": {
+                "@dev/loaders": "^1.0.0",
                 "@gltf-transform/core": "^4.4.1",
                 "@gltf-transform/extensions": "^4.4.1",
                 "@gltf-transform/functions": "^4.4.1",

--- a/packages/dev/node-assets/package.json
+++ b/packages/dev/node-assets/package.json
@@ -22,6 +22,7 @@
     },
     "sideEffects": true,
     "dependencies": {
+        "@dev/loaders": "^1.0.0",
         "@gltf-transform/core": "^4.4.1",
         "@gltf-transform/extensions": "^4.4.1",
         "@gltf-transform/functions": "^4.4.1",

--- a/packages/dev/node-assets/src/Blocks/fbxToUniversalBlock.ts
+++ b/packages/dev/node-assets/src/Blocks/fbxToUniversalBlock.ts
@@ -44,6 +44,7 @@ export class FBXToUniversalBlock extends NodeAssetBlock {
         const engine = new NullEngine();
         const scene = new Scene(engine);
         let container: AssetContainer | undefined;
+        let conversionError: Error | undefined;
         try {
             const loader = new FBXFileLoader();
             container = await loader.loadAssetContainerAsync(scene, source.data, source.rootUrl, undefined, source.source);
@@ -61,19 +62,38 @@ export class FBXToUniversalBlock extends NodeAssetBlock {
                 manifest: { format: "universal", importedFrom: "fbx", source: source.source },
             });
         } catch (error) {
-            throw new Error(`The "${this.name}" block failed to convert "${source.source}" to Universal: ${error instanceof Error ? error.message : String(error)}`, {
+            conversionError = new Error(`The "${this.name}" block failed to convert "${source.source}" to Universal: ${error instanceof Error ? error.message : String(error)}`, {
                 cause: error,
             });
-        } finally {
+        }
+
+        const cleanupErrors: unknown[] = [];
+        if (container) {
             try {
-                container?.dispose();
-            } finally {
-                try {
-                    scene.dispose();
-                } finally {
-                    engine.dispose();
-                }
+                container.dispose();
+            } catch (error) {
+                cleanupErrors.push(error);
             }
+        }
+        try {
+            scene.dispose();
+        } catch (error) {
+            cleanupErrors.push(error);
+        }
+        try {
+            engine.dispose();
+        } catch (error) {
+            cleanupErrors.push(error);
+        }
+
+        if (conversionError) {
+            if (cleanupErrors.length > 0) {
+                throw new AggregateError([conversionError, ...cleanupErrors], `${conversionError.message} FBX resource cleanup also failed.`, { cause: conversionError });
+            }
+            throw conversionError;
+        }
+        if (cleanupErrors.length > 0) {
+            throw new AggregateError(cleanupErrors, `The "${this.name}" block failed to dispose FBX conversion resources.`, { cause: cleanupErrors[0] });
         }
     }
 }

--- a/packages/dev/node-assets/src/Blocks/fbxToUniversalBlock.ts
+++ b/packages/dev/node-assets/src/Blocks/fbxToUniversalBlock.ts
@@ -1,0 +1,81 @@
+import { type AssetContainer } from "core/assetContainer";
+import { NullEngine } from "core/Engines/nullEngine";
+import { Scene } from "core/scene";
+import { FBXFileLoader } from "loaders/FBX/fbxFileLoader.pure";
+import { GLTF2Export } from "serializers/glTF/2.0/glTFSerializer";
+
+import { RegisterBlock } from "../blockFoundation/blockRegistry";
+import { NodeAssetBlock } from "../blockFoundation/nodeAssetBlock";
+import { type NodeAssetConnectionPoint } from "../connection/nodeAssetConnectionPoint";
+import { NodeAssetConnectionPointType } from "../connection/nodeAssetConnectionPointType";
+import { type NodeAsset } from "../nodeAsset";
+import { IsFBXSource } from "../representations/fbxSource";
+import { GltfAsset } from "../representations/gltfAsset";
+
+/** Parses an FBX source payload and explicitly crosses into Universal. */
+export class FBXToUniversalBlock extends NodeAssetBlock {
+    /** The class name, used for identification and safe under minification. */
+    public static override ClassName = "FBXToUniversalBlock";
+
+    /** The immutable FBX source payload. */
+    public readonly input: NodeAssetConnectionPoint;
+
+    /** The Universal working payload. */
+    public readonly output: NodeAssetConnectionPoint;
+
+    /**
+     * Creates an FBX-to-Universal transcoder.
+     * @param name The display name.
+     * @param nodeAsset The owning graph.
+     */
+    public constructor(name: string, nodeAsset: NodeAsset) {
+        super(name, nodeAsset);
+        this.input = this._registerInput("input", NodeAssetConnectionPointType.FBX_SOURCE);
+        this.output = this._registerOutput("output", NodeAssetConnectionPointType.UNIVERSAL);
+    }
+
+    /** Loads FBX content with the pure loader, exports it to GLB, and wraps the Universal document. */
+    public override async _buildBlockAsync(): Promise<void> {
+        if (!IsFBXSource(this.input.value)) {
+            throw new Error(`The "${this.name}" block did not receive an FBX source payload.`);
+        }
+
+        const source = this.input.value;
+        const engine = new NullEngine();
+        const scene = new Scene(engine);
+        let container: AssetContainer | undefined;
+        try {
+            const loader = new FBXFileLoader();
+            container = await loader.loadAssetContainerAsync(scene, source.data, source.rootUrl, undefined, source.source);
+            container.addAllToScene();
+
+            const glbData = await GLTF2Export.GLBAsync(scene, "fbx-universal", { exportWithoutWaitingForScene: true });
+            const glb = glbData.files["fbx-universal.glb"];
+            const bytes = glb instanceof Blob ? new Uint8Array(await glb.arrayBuffer()) : new TextEncoder().encode(glb);
+            const { WebIO } = await import("@gltf-transform/core");
+            const { ALL_EXTENSIONS } = await import("@gltf-transform/extensions");
+            const document = await new WebIO().registerExtensions(ALL_EXTENSIONS).readBinary(bytes);
+            this.output.value = new GltfAsset(document, {
+                identity: source.source,
+                revision: 0,
+                manifest: { format: "universal", importedFrom: "fbx", source: source.source },
+            });
+        } catch (error) {
+            throw new Error(`The "${this.name}" block failed to convert "${source.source}" to Universal: ${error instanceof Error ? error.message : String(error)}`, {
+                cause: error,
+            });
+        } finally {
+            try {
+                container?.dispose();
+            } finally {
+                try {
+                    scene.dispose();
+                } finally {
+                    engine.dispose();
+                }
+            }
+        }
+    }
+}
+
+RegisterBlock(FBXToUniversalBlock.ClassName, (name, nodeAsset) => new FBXToUniversalBlock(name, nodeAsset));

--- a/packages/dev/node-assets/src/Blocks/importFBXAggregateBlock.ts
+++ b/packages/dev/node-assets/src/Blocks/importFBXAggregateBlock.ts
@@ -1,0 +1,76 @@
+import { AggregateBlock } from "../blockFoundation/aggregateBlock";
+import { RegisterBlock } from "../blockFoundation/blockRegistry";
+import { type NodeAssetConnectionPoint } from "../connection/nodeAssetConnectionPoint";
+import { type NodeAsset } from "../nodeAsset";
+import { FBXToUniversalBlock } from "./fbxToUniversalBlock";
+import { ReadFBXBlock, type FBXSourceKind } from "./readFBXBlock";
+
+/** Built-in `Read FBX -> FBX to Universal` aggregate. */
+export class ImportFBXAggregateBlock extends AggregateBlock {
+    /** The class name, used for identification and safe under minification. */
+    public static override ClassName = "ImportFBXAggregateBlock";
+
+    /** The aggregate's Universal output. */
+    public readonly output: NodeAssetConnectionPoint;
+
+    /**
+     * Creates the built-in FBX import aggregate.
+     * @param name The display name.
+     * @param nodeAsset The owning graph.
+     */
+    public constructor(name: string, nodeAsset: NodeAsset) {
+        super(name, nodeAsset);
+        const read = new ReadFBXBlock("Read FBX", this.subgraph);
+        const transcoder = new FBXToUniversalBlock("FBX \u2192 Universal", this.subgraph);
+        read.output.connectTo(transcoder.input);
+        this.output = this._exposeOutput(transcoder.output, "output");
+    }
+
+    /** The owned Read FBX primitive. */
+    public get readBlock(): ReadFBXBlock {
+        const block = this.subgraph.attachedBlocks.find((candidate): candidate is ReadFBXBlock => candidate instanceof ReadFBXBlock);
+        if (!block) {
+            throw new Error(`The "${this.name}" aggregate has no ReadFBXBlock.`);
+        }
+        return block;
+    }
+
+    /** Uploaded source bytes forwarded to the Read FBX primitive. */
+    public get data(): Uint8Array | null {
+        return this.readBlock.data;
+    }
+
+    public set data(value: Uint8Array | null) {
+        this.readBlock.data = value?.slice() ?? null;
+    }
+
+    /** Active source label forwarded to the Read FBX primitive. */
+    public get source(): string | null {
+        return this.readBlock.source;
+    }
+
+    public set source(value: string | null) {
+        this.readBlock.source = value;
+    }
+
+    /** Active source kind forwarded to the Read FBX primitive. */
+    public get sourceKind(): FBXSourceKind | null {
+        return this.readBlock.sourceKind;
+    }
+
+    /**
+     * Makes uploaded bytes the active child source.
+     * @param data The uploaded `.fbx` bytes.
+     * @param fileName The uploaded file name.
+     */
+    public setUploadedSource(data: Uint8Array, fileName: string): void {
+        this.readBlock.setUploadedSource(data, fileName);
+    }
+
+    /** Clears the active child source. */
+    public clearSource(): void {
+        this.readBlock.clearSource();
+    }
+}
+
+RegisterBlock(ImportFBXAggregateBlock.ClassName, (name, nodeAsset) => new ImportFBXAggregateBlock(name, nodeAsset));

--- a/packages/dev/node-assets/src/Blocks/readFBXBlock.ts
+++ b/packages/dev/node-assets/src/Blocks/readFBXBlock.ts
@@ -13,6 +13,34 @@ import { GetSerializedNullableString, GetSerializedStringUnion, type NodeAssetBl
 /** The active source kind for a Read FBX block. */
 export type FBXSourceKind = "upload";
 
+function InvalidFBXSourceState(): TypeError {
+    return new TypeError("Invalid serialized FBX source state.");
+}
+
+function ValidateFBXSourceState(data: Nullable<Uint8Array>, source: Nullable<string>, sourceKind: Nullable<FBXSourceKind>): void {
+    if (data === null && source === null && sourceKind === null) {
+        return;
+    }
+    if (data !== null && source !== null && source.length > 0 && sourceKind === "upload") {
+        return;
+    }
+    throw InvalidFBXSourceState();
+}
+
+function DecodeSerializedFBXData(value: Nullable<string>): Nullable<Uint8Array> {
+    if (value === null) {
+        return null;
+    }
+    if (!/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(value)) {
+        throw InvalidFBXSourceState();
+    }
+    const data = new Uint8Array(DecodeBase64ToBinary(value));
+    if (EncodeArrayBufferToBase64(data) !== value) {
+        throw InvalidFBXSourceState();
+    }
+    return data;
+}
+
 /** Resolves uploaded `.fbx` bytes into an immutable FBX source payload. */
 export class ReadFBXBlock extends NodeAssetBlock {
     /** The class name, used for identification and safe under minification. */
@@ -77,9 +105,10 @@ export class ReadFBXBlock extends NodeAssetBlock {
      * @returns The serialized block.
      */
     public override serialize(): NodeAssetBlockSerialization {
+        ValidateFBXSourceState(this.data, this.source, this.sourceKind);
         return {
             ...super.serialize(),
-            data: this.data ? EncodeArrayBufferToBase64(this.data) : null,
+            data: this.data === null ? null : EncodeArrayBufferToBase64(this.data),
             source: this.source,
             sourceKind: this.sourceKind ?? "",
         };
@@ -91,10 +120,13 @@ export class ReadFBXBlock extends NodeAssetBlock {
      */
     public override _deserialize(serializationObject: NodeAssetBlockSerialization): void {
         super._deserialize(serializationObject);
-        const data = GetSerializedNullableString(serializationObject, "data");
-        this.data = data ? new Uint8Array(DecodeBase64ToBinary(data)) : null;
-        this.source = GetSerializedNullableString(serializationObject, "source");
-        this.sourceKind = GetSerializedStringUnion(serializationObject, "sourceKind", ["upload", ""] as const, "") || null;
+        const data = DecodeSerializedFBXData(GetSerializedNullableString(serializationObject, "data"));
+        const source = GetSerializedNullableString(serializationObject, "source");
+        const sourceKind = GetSerializedStringUnion(serializationObject, "sourceKind", ["upload", ""] as const, "") || null;
+        ValidateFBXSourceState(data, source, sourceKind);
+        this.data = data;
+        this.source = source;
+        this.sourceKind = sourceKind;
     }
 }
 

--- a/packages/dev/node-assets/src/Blocks/readFBXBlock.ts
+++ b/packages/dev/node-assets/src/Blocks/readFBXBlock.ts
@@ -1,0 +1,101 @@
+import { DecodeBase64ToBinary, EncodeArrayBufferToBase64 } from "core/Misc/stringTools";
+import { type Nullable } from "core/types";
+
+import { RegisterBlock } from "../blockFoundation/blockRegistry";
+import { NodeAssetBlock } from "../blockFoundation/nodeAssetBlock";
+import { type NodeAssetConnectionPoint } from "../connection/nodeAssetConnectionPoint";
+import { NodeAssetConnectionPointType } from "../connection/nodeAssetConnectionPointType";
+import { type BuildScope } from "../evaluation/buildScope";
+import { type NodeAsset } from "../nodeAsset";
+import { FBXSource } from "../representations/fbxSource";
+import { GetSerializedNullableString, GetSerializedStringUnion, type NodeAssetBlockSerialization } from "../serialization/nodeAssetSerialization";
+
+/** The active source kind for a Read FBX block. */
+export type FBXSourceKind = "upload";
+
+/** Resolves uploaded `.fbx` bytes into an immutable FBX source payload. */
+export class ReadFBXBlock extends NodeAssetBlock {
+    /** The class name, used for identification and safe under minification. */
+    public static override ClassName = "ReadFBXBlock";
+
+    /** Uploaded `.fbx` bytes. */
+    public data: Nullable<Uint8Array> = null;
+
+    /** The uploaded file name. */
+    public source: Nullable<string> = null;
+
+    /** Whether the active source was uploaded. */
+    public sourceKind: Nullable<FBXSourceKind> = null;
+
+    /** The immutable FBX source payload. */
+    public readonly output: NodeAssetConnectionPoint;
+
+    /**
+     * Creates an FBX read block.
+     * @param name The display name.
+     * @param nodeAsset The owning graph.
+     */
+    public constructor(name: string, nodeAsset: NodeAsset) {
+        super(name, nodeAsset);
+        this.output = this._registerOutput("output", NodeAssetConnectionPointType.FBX_SOURCE);
+    }
+
+    /**
+     * Makes uploaded bytes the active source.
+     * @param data The uploaded `.fbx` bytes.
+     * @param fileName The uploaded file name.
+     */
+    public setUploadedSource(data: Uint8Array, fileName: string): void {
+        this.data = data.slice();
+        this.source = fileName;
+        this.sourceKind = "upload";
+    }
+
+    /** Clears the uploaded source state. */
+    public clearSource(): void {
+        this.data = null;
+        this.source = null;
+        this.sourceKind = null;
+    }
+
+    /**
+     * Emits the uploaded source without parsing the FBX document.
+     * @param scope The build scope used to account source bytes.
+     */
+    public override async _buildBlockAsync(scope?: BuildScope): Promise<void> {
+        const data = this.data;
+        const source = this.source;
+        if (!data || !source || this.sourceKind !== "upload") {
+            throw new Error(`The "${this.name}" read block has no FBX source. Upload a .fbx file before building.`);
+        }
+        scope?.accountSourceBytes(data.byteLength);
+        this.output.value = new FBXSource(data, source);
+    }
+
+    /**
+     * Serializes the uploaded source bytes and active source state.
+     * @returns The serialized block.
+     */
+    public override serialize(): NodeAssetBlockSerialization {
+        return {
+            ...super.serialize(),
+            data: this.data ? EncodeArrayBufferToBase64(this.data) : null,
+            source: this.source,
+            sourceKind: this.sourceKind ?? "",
+        };
+    }
+
+    /**
+     * Restores the uploaded source bytes and active source state.
+     * @param serializationObject The serialized block.
+     */
+    public override _deserialize(serializationObject: NodeAssetBlockSerialization): void {
+        super._deserialize(serializationObject);
+        const data = GetSerializedNullableString(serializationObject, "data");
+        this.data = data ? new Uint8Array(DecodeBase64ToBinary(data)) : null;
+        this.source = GetSerializedNullableString(serializationObject, "source");
+        this.sourceKind = GetSerializedStringUnion(serializationObject, "sourceKind", ["upload", ""] as const, "") || null;
+    }
+}
+
+RegisterBlock(ReadFBXBlock.ClassName, (name, nodeAsset) => new ReadFBXBlock(name, nodeAsset));

--- a/packages/dev/node-assets/src/connection/nodeAssetConnectionPointType.ts
+++ b/packages/dev/node-assets/src/connection/nodeAssetConnectionPointType.ts
@@ -54,4 +54,7 @@ export enum NodeAssetConnectionPointType {
 
     /** Lightweight resolved USD source bytes consumed only by USD-to-Universal transcoding. */
     USD_SOURCE = 10,
+
+    /** Immutable uploaded FBX source bytes consumed only by FBX-to-Universal transcoding. */
+    FBX_SOURCE = 12,
 }

--- a/packages/dev/node-assets/src/connection/nodeAssetValueMap.ts
+++ b/packages/dev/node-assets/src/connection/nodeAssetValueMap.ts
@@ -1,6 +1,7 @@
 import { type ImagePayload } from "../Blocks/imagePayload";
 import { type BabylonAsset } from "../representations/babylonAsset";
 import { type BabylonSource } from "../representations/babylonSource";
+import { type FBXSource } from "../representations/fbxSource";
 import { type GltfAsset } from "../representations/gltfAsset";
 import { type NodeGeometryAsset } from "../representations/nodeGeometryAsset";
 import { type NodeGeometrySource } from "../representations/nodeGeometrySource";
@@ -74,4 +75,5 @@ export type NodeAssetValueMap = {
     [NodeAssetConnectionPointType.UNIVERSAL]: GltfAsset;
     [NodeAssetConnectionPointType.BABYLON_SOURCE]: BabylonSource;
     [NodeAssetConnectionPointType.USD_SOURCE]: UsdSourceAsset;
+    [NodeAssetConnectionPointType.FBX_SOURCE]: FBXSource;
 };

--- a/packages/dev/node-assets/src/index.ts
+++ b/packages/dev/node-assets/src/index.ts
@@ -43,6 +43,7 @@ export { type IUsdAssetMetadata, IsUsdAsset, UsdAsset } from "./representations/
 export { IsUsdSourceAsset, UsdSourceAsset, type USDSourceKind } from "./representations/usdSourceAsset";
 export { BabylonAsset, type IBabylonAssetMetadata, IsBabylonAsset } from "./representations/babylonAsset";
 export { BabylonSource, IsBabylonSource } from "./representations/babylonSource";
+export { FBXSource, IsFBXSource } from "./representations/fbxSource";
 export { type INodeGeometryAssetMetadata, IsNodeGeometryAsset, NodeGeometryAsset } from "./representations/nodeGeometryAsset";
 export { type INodeGeometrySourceMetadata, IsNodeGeometrySource, NodeGeometrySource, type NodeGeometrySourceKind } from "./representations/nodeGeometrySource";
 export {
@@ -62,6 +63,9 @@ export { ExportGLTFAggregateBlock } from "./Blocks/exportGLTFAggregateBlock";
 export { type BabylonSourceFetcher, type BabylonSourceKind, type IBabylonSourceResponse, ReadBabylonBlock } from "./Blocks/readBabylonBlock";
 export { BabylonToUniversalBlock } from "./Blocks/babylonToUniversalBlock";
 export { ImportBabylonAggregateBlock } from "./Blocks/importBabylonAggregateBlock";
+export { type FBXSourceKind, ReadFBXBlock } from "./Blocks/readFBXBlock";
+export { FBXToUniversalBlock } from "./Blocks/fbxToUniversalBlock";
+export { ImportFBXAggregateBlock } from "./Blocks/importFBXAggregateBlock";
 export { type IUSDSourceResponse, ReadUSDBlock, type USDSourceFetcher } from "./Blocks/readUSDBlock";
 export { USDToUniversalBlock } from "./Blocks/usdToUniversalBlock";
 export { ImportUSDAggregateBlock } from "./Blocks/importUSDAggregateBlock";

--- a/packages/dev/node-assets/src/representations/fbxSource.ts
+++ b/packages/dev/node-assets/src/representations/fbxSource.ts
@@ -1,0 +1,36 @@
+/** Immutable uploaded `.fbx` source carried only from Read FBX to FBX to Universal. */
+export class FBXSource {
+    private readonly _data: Uint8Array;
+
+    /** The uploaded file name. */
+    public readonly source: string;
+
+    /** The URL base used to resolve external FBX resources. */
+    public readonly rootUrl: string;
+
+    /**
+     * Creates an immutable FBX source payload.
+     * @param data The uploaded `.fbx` bytes.
+     * @param source The uploaded file name.
+     * @param rootUrl The URL base used to resolve external resources.
+     */
+    public constructor(data: Uint8Array, source: string, rootUrl = "") {
+        this._data = data.slice();
+        this.source = source;
+        this.rootUrl = rootUrl;
+    }
+
+    /** A defensive copy of the uploaded FBX bytes. */
+    public get data(): Uint8Array {
+        return this._data.slice();
+    }
+}
+
+/**
+ * Tests whether a runtime value is an immutable FBX source payload.
+ * @param value The value to test.
+ * @returns Whether the value is an {@link FBXSource}.
+ */
+export function IsFBXSource(value: unknown): value is FBXSource {
+    return value instanceof FBXSource;
+}

--- a/packages/dev/node-assets/test/unit/blockRegistry.test.ts
+++ b/packages/dev/node-assets/test/unit/blockRegistry.test.ts
@@ -24,6 +24,7 @@ import {
     ExportGLTFAggregateBlock,
     ExportGLTFBlock,
     ExportImageBlock,
+    FBXToUniversalBlock,
     ExtractTexture,
     FixFaceWindingBlock,
     FlattenBlock,
@@ -37,6 +38,7 @@ import {
     GLTFToUniversalBlock,
     ImportBabylonBlock,
     ImportBabylonAggregateBlock,
+    ImportFBXAggregateBlock,
     ImportGLTFBlock,
     ImportGLTFAggregateBlock,
     ImportNodeGeometryAggregateBlock,
@@ -81,6 +83,7 @@ import {
     ReadGLTFBlock,
     ReadNodeGeometryBlock,
     ReadBabylonBlock,
+    ReadFBXBlock,
     ReuseIdenticalMeshesBlock,
     ReadUSDBlock,
     USDToUniversalBlock,
@@ -269,12 +272,15 @@ describe("block self-registration", () => {
                     ReadBabylonBlock.ClassName,
                     BabylonToUniversalBlock.ClassName,
                     ImportBabylonAggregateBlock.ClassName,
+                    ReadFBXBlock.ClassName,
+                    FBXToUniversalBlock.ClassName,
+                    ImportFBXAggregateBlock.ClassName,
                     ReadUSDBlock.ClassName,
                     USDToUniversalBlock.ClassName,
                     ImportUSDAggregateBlock.ClassName,
                 ])
             );
-            expect(registeredClassNames).toHaveLength(80);
+            expect(registeredClassNames).toHaveLength(83);
         });
 
         it.each(registeredClassNames)("round-trips %s through serialize/Parse", (className) => {

--- a/packages/dev/node-assets/test/unit/fbxDependencySafety.test.ts
+++ b/packages/dev/node-assets/test/unit/fbxDependencySafety.test.ts
@@ -1,0 +1,36 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+function ReadJson(path: URL): {
+    readonly dependencies?: Readonly<Record<string, string>>;
+    readonly devDependencies?: Readonly<Record<string, string>>;
+    readonly references?: ReadonlyArray<{ readonly path?: string }>;
+} {
+    return JSON.parse(readFileSync(path, "utf8")) as {
+        readonly dependencies?: Readonly<Record<string, string>>;
+        readonly devDependencies?: Readonly<Record<string, string>>;
+        readonly references?: ReadonlyArray<{ readonly path?: string }>;
+    };
+}
+
+describe("FBX dependency safety", () => {
+    it("adds only the acyclic Node Assets to Loaders runtime direction and build reference", () => {
+        const nodeAssetsPackage = ReadJson(new URL("../../package.json", import.meta.url));
+        const nodeAssetsTsconfig = ReadJson(new URL("../../tsconfig.build.json", import.meta.url));
+        const loadersPackage = ReadJson(new URL("../../../loaders/package.json", import.meta.url));
+
+        expect(nodeAssetsPackage.dependencies?.["@dev/loaders"]).toBe("^1.0.0");
+        expect(nodeAssetsTsconfig.references).toContainEqual({ path: "../loaders/tsconfig.build.json" });
+        expect(loadersPackage.dependencies?.["@dev/node-assets"]).toBeUndefined();
+        expect(loadersPackage.devDependencies?.["@dev/node-assets"]).toBeUndefined();
+    });
+
+    it("imports the pure FBX loader directly without registration or a side-effectful barrel", () => {
+        const source = readFileSync(new URL("../../src/Blocks/fbxToUniversalBlock.ts", import.meta.url), "utf8");
+
+        expect(source).toContain('from "loaders/FBX/fbxFileLoader.pure"');
+        expect(source).not.toContain('from "loaders/FBX"');
+        expect(source).not.toContain("RegisterFBXFileLoader");
+        expect(source).not.toContain("RegisterSceneLoaderPlugin");
+    });
+});

--- a/packages/dev/node-assets/test/unit/fbxUniversalFunnel.test.ts
+++ b/packages/dev/node-assets/test/unit/fbxUniversalFunnel.test.ts
@@ -1,0 +1,126 @@
+import { WebIO } from "@gltf-transform/core";
+import { ALL_EXTENSIONS } from "@gltf-transform/extensions";
+import { describe, expect, it, vi } from "vitest";
+
+import { ExportGLTFAggregateBlock } from "../../src/Blocks/exportGLTFAggregateBlock";
+import { FBXToUniversalBlock } from "../../src/Blocks/fbxToUniversalBlock";
+import { ImportFBXAggregateBlock } from "../../src/Blocks/importFBXAggregateBlock";
+import { ReadFBXBlock } from "../../src/Blocks/readFBXBlock";
+import { NodeAssetBlock } from "../../src/blockFoundation/nodeAssetBlock";
+import { type NodeAssetConnectionPoint } from "../../src/connection/nodeAssetConnectionPoint";
+import { NodeAssetConnectionPointType } from "../../src/connection/nodeAssetConnectionPointType";
+import { NodeAsset } from "../../src/nodeAsset";
+import { GetGltfAsset, type GltfAsset } from "../../src/representations/gltfAsset";
+import { CreateAsciiFbx74TriangleFixture } from "./testFbxSource";
+
+vi.mock("draco3dgltf", async () => await vi.importActual("draco3dgltf"));
+
+class CaptureUniversalManifestBlock extends NodeAssetBlock {
+    public static override ClassName = "CaptureUniversalManifestBlock";
+
+    public readonly input: NodeAssetConnectionPoint;
+    public readonly output: NodeAssetConnectionPoint;
+    public manifest: GltfAsset["manifest"] | undefined;
+
+    public constructor(name: string, nodeAsset: NodeAsset) {
+        super(name, nodeAsset);
+        this.input = this._registerInput("input", NodeAssetConnectionPointType.UNIVERSAL);
+        this.output = this._registerOutput("output", NodeAssetConnectionPointType.UNIVERSAL);
+    }
+
+    public override async _buildBlockAsync(): Promise<void> {
+        const asset = GetGltfAsset(this.input.value, this.input.name);
+        this.manifest = asset.manifest;
+        this.output.value = asset;
+    }
+}
+
+async function ReadStableMeshFactsAsync(glb: Uint8Array): Promise<{
+    readonly meshCount: number;
+    readonly nodeNames: readonly string[];
+    readonly positionCount: number;
+    readonly indexCount: number;
+}> {
+    const document = await new WebIO().registerExtensions(ALL_EXTENSIONS).readBinary(glb);
+    const primitive = document.getRoot().listMeshes()[0]?.listPrimitives()[0];
+    return {
+        meshCount: document.getRoot().listMeshes().length,
+        nodeNames: document
+            .getRoot()
+            .listNodes()
+            .map((node) => node.getName()),
+        positionCount: primitive?.getAttribute("POSITION")?.getCount() ?? 0,
+        indexCount: primitive?.getIndices()?.getCount() ?? 0,
+    };
+}
+
+describe("FBX Universal funnel", () => {
+    it("builds an uploaded ASCII FBX through saved aggregate and primitive funnels without fetching", async () => {
+        const source = CreateAsciiFbx74TriangleFixture();
+
+        const serializedAsset = new NodeAsset("serialized-fbx-funnel");
+        const serializedImporter = new ImportFBXAggregateBlock("Import FBX", serializedAsset);
+        serializedImporter.setUploadedSource(source, "triangle.fbx");
+        const serialization = JSON.parse(JSON.stringify(serializedAsset.serialize()));
+        expect(serialization.blocks[0]).toMatchObject({
+            customType: ImportFBXAggregateBlock.ClassName,
+            aggregateVersion: 1,
+            subgraph: {
+                blocks: [
+                    {
+                        customType: ReadFBXBlock.ClassName,
+                        source: "triangle.fbx",
+                        sourceKind: "upload",
+                    },
+                    { customType: FBXToUniversalBlock.ClassName },
+                ],
+            },
+        });
+
+        const aggregateAsset = NodeAsset.Parse(serialization);
+        const aggregateImporter = aggregateAsset.attachedBlocks[0] as ImportFBXAggregateBlock;
+        const aggregateCapture = new CaptureUniversalManifestBlock("Capture aggregate manifest", aggregateAsset);
+        const aggregateExport = new ExportGLTFAggregateBlock("Export aggregate glTF", aggregateAsset);
+        aggregateImporter.output.connectTo(aggregateCapture.input);
+        aggregateCapture.output.connectTo(aggregateExport.input);
+
+        const primitiveAsset = new NodeAsset("primitive-fbx-funnel");
+        const read = new ReadFBXBlock("Read FBX", primitiveAsset);
+        read.setUploadedSource(source, "triangle.fbx");
+        const toUniversal = new FBXToUniversalBlock("FBX \u2192 Universal", primitiveAsset);
+        const primitiveCapture = new CaptureUniversalManifestBlock("Capture primitive manifest", primitiveAsset);
+        const primitiveExport = new ExportGLTFAggregateBlock("Export primitive glTF", primitiveAsset);
+        read.output.connectTo(toUniversal.input);
+        toUniversal.output.connectTo(primitiveCapture.input);
+        primitiveCapture.output.connectTo(primitiveExport.input);
+
+        const fetchSpy = vi.fn(() => {
+            throw new Error("Uploaded FBX builds must not fetch.");
+        });
+        vi.stubGlobal("fetch", fetchSpy);
+        try {
+            const aggregateGlb = await aggregateAsset.buildAsync();
+            const primitiveGlb = await primitiveAsset.buildAsync();
+            const expectedFacts = {
+                meshCount: 1,
+                nodeNames: ["Triangle"],
+                positionCount: 3,
+                indexCount: 3,
+            };
+
+            expect(aggregateGlb.subarray(0, 4)).toEqual(new TextEncoder().encode("glTF"));
+            expect(aggregateGlb.byteLength).toBeGreaterThan(20);
+            expect(await ReadStableMeshFactsAsync(aggregateGlb)).toEqual(expectedFacts);
+            expect(await ReadStableMeshFactsAsync(primitiveGlb)).toEqual(expectedFacts);
+            expect(aggregateCapture.manifest).toEqual({
+                format: "universal",
+                importedFrom: "fbx",
+                source: "triangle.fbx",
+            });
+            expect(primitiveCapture.manifest).toEqual(aggregateCapture.manifest);
+            expect(fetchSpy).not.toHaveBeenCalled();
+        } finally {
+            vi.unstubAllGlobals();
+        }
+    });
+});

--- a/packages/dev/node-assets/test/unit/fbxUniversalFunnel.test.ts
+++ b/packages/dev/node-assets/test/unit/fbxUniversalFunnel.test.ts
@@ -199,4 +199,72 @@ describe("FBX Universal funnel", () => {
 
         expect(() => NodeAsset.Parse(serialization)).toThrow('Invalid serialized block property "sourceKind"');
     });
+
+    it("round-trips empty uploaded bytes without producing a partial active source", () => {
+        const asset = new NodeAsset("empty-fbx-source");
+        const read = new ReadFBXBlock("Read FBX", asset);
+        read.setUploadedSource(new Uint8Array(), "empty.fbx");
+
+        const parsed = NodeAsset.Parse(JSON.parse(JSON.stringify(asset.serialize())));
+        const parsedRead = parsed.attachedBlocks[0] as ReadFBXBlock;
+
+        expect(parsedRead.data).toEqual(new Uint8Array());
+        expect(parsedRead.source).toBe("empty.fbx");
+        expect(parsedRead.sourceKind).toBe("upload");
+    });
+
+    it.each([
+        { data: null, source: "triangle.fbx", sourceKind: "upload" },
+        { data: "", source: null, sourceKind: "upload" },
+        { data: "", source: "triangle.fbx", sourceKind: "" },
+        { data: null, source: "", sourceKind: "" },
+        { data: "not canonical base64", source: "triangle.fbx", sourceKind: "upload" },
+    ])("rejects partial or non-canonical serialized source state: %j", (sourceState) => {
+        const asset = new NodeAsset("invalid-fbx-state");
+        const read = new ReadFBXBlock("Read FBX", asset);
+        const serialization = JSON.parse(JSON.stringify(asset.serialize())) as {
+            blocks: Array<{ data: string | null; source: string | null; sourceKind: string }>;
+        };
+        Object.assign(serialization.blocks[0], sourceState);
+
+        expect(() => NodeAsset.Parse(serialization)).toThrow(/Invalid serialized FBX source state/);
+    });
+
+    it("preserves the conversion failure when every cleanup step also fails", async () => {
+        const exportFailure = new Error("forced conversion failure");
+        const containerCleanupFailure = new Error("forced container cleanup failure");
+        const sceneCleanupFailure = new Error("forced scene cleanup failure");
+        const engineCleanupFailure = new Error("forced engine cleanup failure");
+        const containerDispose = vi.spyOn(AssetContainer.prototype, "dispose").mockImplementationOnce(() => {
+            throw containerCleanupFailure;
+        });
+        const sceneDispose = vi.spyOn(Scene.prototype, "dispose").mockImplementationOnce(() => {
+            throw sceneCleanupFailure;
+        });
+        const engineDispose = vi.spyOn(NullEngine.prototype, "dispose").mockImplementationOnce(() => {
+            throw engineCleanupFailure;
+        });
+        vi.spyOn(GLTF2Export, "GLBAsync").mockRejectedValueOnce(exportFailure);
+
+        try {
+            const error = await CreateExportingAsset(CreateAsciiFbx74TriangleFixture())
+                .buildAsync()
+                .catch((reason: unknown) => reason);
+
+            expect(error).toBeInstanceOf(AggregateError);
+            expect((error as AggregateError).message).toMatch(/failed to convert "triangle\.fbx" to Universal/);
+            expect((error as AggregateError).cause).toMatchObject({ cause: exportFailure });
+            expect((error as AggregateError).errors).toEqual([
+                expect.objectContaining({ cause: exportFailure }),
+                containerCleanupFailure,
+                sceneCleanupFailure,
+                engineCleanupFailure,
+            ]);
+            expect(containerDispose).toHaveBeenCalled();
+            expect(sceneDispose).toHaveBeenCalled();
+            expect(engineDispose).toHaveBeenCalled();
+        } finally {
+            vi.restoreAllMocks();
+        }
+    });
 });

--- a/packages/dev/node-assets/test/unit/fbxUniversalFunnel.test.ts
+++ b/packages/dev/node-assets/test/unit/fbxUniversalFunnel.test.ts
@@ -14,257 +14,345 @@ import { NodeAssetBlock } from "../../src/blockFoundation/nodeAssetBlock";
 import { type NodeAssetConnectionPoint } from "../../src/connection/nodeAssetConnectionPoint";
 import { NodeAssetConnectionPointType } from "../../src/connection/nodeAssetConnectionPointType";
 import { NodeAsset } from "../../src/nodeAsset";
-import { GetGltfAsset, type GltfAsset } from "../../src/representations/gltfAsset";
+import {
+  GetGltfAsset,
+  type GltfAsset,
+} from "../../src/representations/gltfAsset";
 import { CreateAsciiFbx74TriangleFixture } from "./testFbxSource";
 
 vi.mock("draco3dgltf", async () => await vi.importActual("draco3dgltf"));
 
 class CaptureUniversalManifestBlock extends NodeAssetBlock {
-    public static override ClassName = "CaptureUniversalManifestBlock";
+  public static override ClassName = "CaptureUniversalManifestBlock";
 
-    public readonly input: NodeAssetConnectionPoint;
-    public readonly output: NodeAssetConnectionPoint;
-    public manifest: GltfAsset["manifest"] | undefined;
+  public readonly input: NodeAssetConnectionPoint;
+  public readonly output: NodeAssetConnectionPoint;
+  public manifest: GltfAsset["manifest"] | undefined;
 
-    public constructor(name: string, nodeAsset: NodeAsset) {
-        super(name, nodeAsset);
-        this.input = this._registerInput("input", NodeAssetConnectionPointType.UNIVERSAL);
-        this.output = this._registerOutput("output", NodeAssetConnectionPointType.UNIVERSAL);
-    }
+  public constructor(name: string, nodeAsset: NodeAsset) {
+    super(name, nodeAsset);
+    this.input = this._registerInput(
+      "input",
+      NodeAssetConnectionPointType.UNIVERSAL,
+    );
+    this.output = this._registerOutput(
+      "output",
+      NodeAssetConnectionPointType.UNIVERSAL,
+    );
+  }
 
-    public override async _buildBlockAsync(): Promise<void> {
-        const asset = GetGltfAsset(this.input.value, this.input.name);
-        this.manifest = asset.manifest;
-        this.output.value = asset;
-    }
+  public override async _buildBlockAsync(): Promise<void> {
+    const asset = GetGltfAsset(this.input.value, this.input.name);
+    this.manifest = asset.manifest;
+    this.output.value = asset;
+  }
 }
 
 async function ReadStableMeshFactsAsync(glb: Uint8Array): Promise<{
-    readonly meshCount: number;
-    readonly nodeNames: readonly string[];
-    readonly positionCount: number;
-    readonly indexCount: number;
+  readonly meshCount: number;
+  readonly nodeNames: readonly string[];
+  readonly positionCount: number;
+  readonly indexCount: number;
 }> {
-    const document = await new WebIO().registerExtensions(ALL_EXTENSIONS).readBinary(glb);
-    const primitive = document.getRoot().listMeshes()[0]?.listPrimitives()[0];
-    return {
-        meshCount: document.getRoot().listMeshes().length,
-        nodeNames: document
-            .getRoot()
-            .listNodes()
-            .map((node) => node.getName()),
-        positionCount: primitive?.getAttribute("POSITION")?.getCount() ?? 0,
-        indexCount: primitive?.getIndices()?.getCount() ?? 0,
-    };
+  const document = await new WebIO()
+    .registerExtensions(ALL_EXTENSIONS)
+    .readBinary(glb);
+  const primitive = document.getRoot().listMeshes()[0]?.listPrimitives()[0];
+  return {
+    meshCount: document.getRoot().listMeshes().length,
+    nodeNames: document
+      .getRoot()
+      .listNodes()
+      .map((node) => node.getName()),
+    positionCount: primitive?.getAttribute("POSITION")?.getCount() ?? 0,
+    indexCount: primitive?.getIndices()?.getCount() ?? 0,
+  };
 }
 
 describe("FBX Universal funnel", () => {
-    function CreateExportingAsset(data?: Uint8Array): NodeAsset {
-        const asset = new NodeAsset("fbx-errors");
-        const read = new ReadFBXBlock("Read FBX", asset);
-        if (data) {
-            read.setUploadedSource(data, "triangle.fbx");
-        }
-        const toUniversal = new FBXToUniversalBlock("FBX \u2192 Universal", asset);
-        const exporter = new ExportGLTFAggregateBlock("Export glTF", asset);
-        read.output.connectTo(toUniversal.input);
-        toUniversal.output.connectTo(exporter.input);
-        return asset;
+  function CreateExportingAsset(data?: Uint8Array): NodeAsset {
+    const asset = new NodeAsset("fbx-errors");
+    const read = new ReadFBXBlock("Read FBX", asset);
+    if (data) {
+      read.setUploadedSource(data, "triangle.fbx");
     }
+    const toUniversal = new FBXToUniversalBlock("FBX \u2192 Universal", asset);
+    const exporter = new ExportGLTFAggregateBlock("Export glTF", asset);
+    read.output.connectTo(toUniversal.input);
+    toUniversal.output.connectTo(exporter.input);
+    return asset;
+  }
 
-    it("builds an uploaded ASCII FBX through saved aggregate and primitive funnels without fetching", async () => {
-        const source = CreateAsciiFbx74TriangleFixture();
+  it("builds an uploaded ASCII FBX through saved aggregate and primitive funnels without fetching", async () => {
+    const source = CreateAsciiFbx74TriangleFixture();
 
-        const serializedAsset = new NodeAsset("serialized-fbx-funnel");
-        const serializedImporter = new ImportFBXAggregateBlock("Import FBX", serializedAsset);
-        serializedImporter.setUploadedSource(source, "triangle.fbx");
-        const serialization = JSON.parse(JSON.stringify(serializedAsset.serialize()));
-        expect(serialization.blocks[0]).toMatchObject({
-            customType: ImportFBXAggregateBlock.ClassName,
-            aggregateVersion: 1,
-            subgraph: {
-                blocks: [
-                    {
-                        customType: ReadFBXBlock.ClassName,
-                        source: "triangle.fbx",
-                        sourceKind: "upload",
-                    },
-                    { customType: FBXToUniversalBlock.ClassName },
-                ],
-            },
-        });
-
-        const aggregateAsset = NodeAsset.Parse(serialization);
-        const aggregateImporter = aggregateAsset.attachedBlocks[0] as ImportFBXAggregateBlock;
-        const aggregateCapture = new CaptureUniversalManifestBlock("Capture aggregate manifest", aggregateAsset);
-        const aggregateExport = new ExportGLTFAggregateBlock("Export aggregate glTF", aggregateAsset);
-        aggregateImporter.output.connectTo(aggregateCapture.input);
-        aggregateCapture.output.connectTo(aggregateExport.input);
-
-        const primitiveAsset = new NodeAsset("primitive-fbx-funnel");
-        const read = new ReadFBXBlock("Read FBX", primitiveAsset);
-        read.setUploadedSource(source, "triangle.fbx");
-        const toUniversal = new FBXToUniversalBlock("FBX \u2192 Universal", primitiveAsset);
-        const primitiveCapture = new CaptureUniversalManifestBlock("Capture primitive manifest", primitiveAsset);
-        const primitiveExport = new ExportGLTFAggregateBlock("Export primitive glTF", primitiveAsset);
-        read.output.connectTo(toUniversal.input);
-        toUniversal.output.connectTo(primitiveCapture.input);
-        primitiveCapture.output.connectTo(primitiveExport.input);
-
-        const fetchSpy = vi.fn(() => {
-            throw new Error("Uploaded FBX builds must not fetch.");
-        });
-        vi.stubGlobal("fetch", fetchSpy);
-        try {
-            const aggregateGlb = await aggregateAsset.buildAsync();
-            const primitiveGlb = await primitiveAsset.buildAsync();
-            const expectedFacts = {
-                meshCount: 1,
-                nodeNames: ["Triangle"],
-                positionCount: 3,
-                indexCount: 3,
-            };
-
-            expect(aggregateGlb.subarray(0, 4)).toEqual(new TextEncoder().encode("glTF"));
-            expect(aggregateGlb.byteLength).toBeGreaterThan(20);
-            expect(await ReadStableMeshFactsAsync(aggregateGlb)).toEqual(expectedFacts);
-            expect(await ReadStableMeshFactsAsync(primitiveGlb)).toEqual(expectedFacts);
-            expect(aggregateCapture.manifest).toEqual({
-                format: "universal",
-                importedFrom: "fbx",
-                source: "triangle.fbx",
-            });
-            expect(primitiveCapture.manifest).toEqual(aggregateCapture.manifest);
-            expect(fetchSpy).not.toHaveBeenCalled();
-        } finally {
-            vi.unstubAllGlobals();
-        }
+    const serializedAsset = new NodeAsset("serialized-fbx-funnel");
+    const serializedImporter = new ImportFBXAggregateBlock(
+      "Import FBX",
+      serializedAsset,
+    );
+    serializedImporter.setUploadedSource(source, "triangle.fbx");
+    const serialization = JSON.parse(
+      JSON.stringify(serializedAsset.serialize()),
+    );
+    expect(serialization.blocks[0]).toMatchObject({
+      customType: ImportFBXAggregateBlock.ClassName,
+      aggregateVersion: 1,
+      subgraph: {
+        blocks: [
+          {
+            customType: ReadFBXBlock.ClassName,
+            source: "triangle.fbx",
+            sourceKind: "upload",
+          },
+          { customType: FBXToUniversalBlock.ClassName },
+        ],
+      },
     });
 
-    it("accounts uploaded bytes and rejects a missing source before parsing", async () => {
-        await expect(CreateExportingAsset().buildAsync()).rejects.toThrow(/Upload a \.fbx file before building/);
+    const aggregateAsset = NodeAsset.Parse(serialization);
+    const aggregateImporter = aggregateAsset
+      .attachedBlocks[0] as ImportFBXAggregateBlock;
+    const aggregateCapture = new CaptureUniversalManifestBlock(
+      "Capture aggregate manifest",
+      aggregateAsset,
+    );
+    const aggregateExport = new ExportGLTFAggregateBlock(
+      "Export aggregate glTF",
+      aggregateAsset,
+    );
+    aggregateImporter.output.connectTo(aggregateCapture.input);
+    aggregateCapture.output.connectTo(aggregateExport.input);
 
-        const source = CreateAsciiFbx74TriangleFixture();
-        await expect(CreateExportingAsset(source).buildAsync({ limits: { maxSourceAssetBytes: source.byteLength - 1 } })).rejects.toMatchObject({
-            code: "NODE_ASSET_LIMIT_SOURCE_BYTES",
-            actual: source.byteLength,
-        });
+    const primitiveAsset = new NodeAsset("primitive-fbx-funnel");
+    const read = new ReadFBXBlock("Read FBX", primitiveAsset);
+    read.setUploadedSource(source, "triangle.fbx");
+    const toUniversal = new FBXToUniversalBlock(
+      "FBX \u2192 Universal",
+      primitiveAsset,
+    );
+    const primitiveCapture = new CaptureUniversalManifestBlock(
+      "Capture primitive manifest",
+      primitiveAsset,
+    );
+    const primitiveExport = new ExportGLTFAggregateBlock(
+      "Export primitive glTF",
+      primitiveAsset,
+    );
+    read.output.connectTo(toUniversal.input);
+    toUniversal.output.connectTo(primitiveCapture.input);
+    primitiveCapture.output.connectTo(primitiveExport.input);
+
+    const fetchSpy = vi.fn(() => {
+      throw new Error("Uploaded FBX builds must not fetch.");
     });
+    vi.stubGlobal("fetch", fetchSpy);
+    try {
+      const aggregateGlb = await aggregateAsset.buildAsync();
+      const primitiveGlb = await primitiveAsset.buildAsync();
+      const expectedFacts = {
+        meshCount: 1,
+        nodeNames: ["Triangle"],
+        positionCount: 3,
+        indexCount: 3,
+      };
 
-    it("rejects malformed FBX contextually while retaining the parser cause", async () => {
-        const error = await CreateExportingAsset(new TextEncoder().encode("not an FBX document")).buildAsync().catch((reason: unknown) => reason);
+      expect(aggregateGlb.subarray(0, 4)).toEqual(
+        new TextEncoder().encode("glTF"),
+      );
+      expect(aggregateGlb.byteLength).toBeGreaterThan(20);
+      expect(await ReadStableMeshFactsAsync(aggregateGlb)).toEqual(
+        expectedFacts,
+      );
+      expect(await ReadStableMeshFactsAsync(primitiveGlb)).toEqual(
+        expectedFacts,
+      );
+      expect(aggregateCapture.manifest).toEqual({
+        format: "universal",
+        importedFrom: "fbx",
+        source: "triangle.fbx",
+      });
+      expect(primitiveCapture.manifest).toEqual(aggregateCapture.manifest);
+      expect(fetchSpy).not.toHaveBeenCalled();
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
 
-        expect(error).toBeInstanceOf(Error);
-        expect((error as Error).message).toMatch(/failed to convert "triangle\.fbx" to Universal/);
-        expect((error as Error).cause).toBeInstanceOf(Error);
+  it("accounts uploaded bytes and rejects a missing source before parsing", async () => {
+    await expect(CreateExportingAsset().buildAsync()).rejects.toThrow(
+      /Upload a \.fbx file before building/,
+    );
+
+    const source = CreateAsciiFbx74TriangleFixture();
+    await expect(
+      CreateExportingAsset(source).buildAsync({
+        limits: { maxSourceAssetBytes: source.byteLength - 1 },
+      }),
+    ).rejects.toMatchObject({
+      code: "NODE_ASSET_LIMIT_SOURCE_BYTES",
+      actual: source.byteLength,
     });
+  });
 
-    it("disposes the FBX container, scene, and engine on success and export failure", async () => {
-        const containerDispose = vi.spyOn(AssetContainer.prototype, "dispose");
-        const sceneDispose = vi.spyOn(Scene.prototype, "dispose");
-        const engineDispose = vi.spyOn(NullEngine.prototype, "dispose");
-        try {
-            await expect(CreateExportingAsset(CreateAsciiFbx74TriangleFixture()).buildAsync()).resolves.toBeInstanceOf(Uint8Array);
-            expect(containerDispose).toHaveBeenCalled();
-            expect(sceneDispose).toHaveBeenCalled();
-            expect(engineDispose).toHaveBeenCalled();
+  it("rejects malformed FBX contextually while retaining the parser cause", async () => {
+    const error = await CreateExportingAsset(
+      new TextEncoder().encode("not an FBX document"),
+    )
+      .buildAsync()
+      .catch((reason: unknown) => reason);
 
-            containerDispose.mockClear();
-            sceneDispose.mockClear();
-            engineDispose.mockClear();
-            const exportFailure = new Error("forced FBX export failure");
-            vi.spyOn(GLTF2Export, "GLBAsync").mockRejectedValueOnce(exportFailure);
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toMatch(
+      /failed to convert "triangle\.fbx" to Universal/,
+    );
+    expect((error as Error).cause).toBeInstanceOf(Error);
+  });
 
-            const error = await CreateExportingAsset(CreateAsciiFbx74TriangleFixture())
-                .buildAsync()
-                .catch((reason: unknown) => reason);
-            expect(error).toBeInstanceOf(Error);
-            expect((error as Error).cause).toBe(exportFailure);
-            expect(containerDispose).toHaveBeenCalled();
-            expect(sceneDispose).toHaveBeenCalled();
-            expect(engineDispose).toHaveBeenCalled();
-        } finally {
-            vi.restoreAllMocks();
-        }
-    });
+  it("disposes the FBX container, scene, and engine on success and export failure", async () => {
+    const containerDispose = vi.spyOn(AssetContainer.prototype, "dispose");
+    const sceneDispose = vi.spyOn(Scene.prototype, "dispose");
+    const engineDispose = vi.spyOn(NullEngine.prototype, "dispose");
+    try {
+      await expect(
+        CreateExportingAsset(CreateAsciiFbx74TriangleFixture()).buildAsync(),
+      ).resolves.toBeInstanceOf(Uint8Array);
+      expect(containerDispose).toHaveBeenCalled();
+      expect(sceneDispose).toHaveBeenCalled();
+      expect(engineDispose).toHaveBeenCalled();
 
-    it("rejects non-upload source kinds during strict graph parsing", () => {
-        const asset = new NodeAsset("strict-fbx-state");
-        const importer = new ImportFBXAggregateBlock("Import FBX", asset);
-        importer.setUploadedSource(CreateAsciiFbx74TriangleFixture(), "triangle.fbx");
-        const serialization = JSON.parse(JSON.stringify(asset.serialize())) as {
-            blocks: Array<{ subgraph: { blocks: Array<{ sourceKind?: string }> } }>;
-        };
-        serialization.blocks[0].subgraph.blocks[0].sourceKind = "url";
+      containerDispose.mockClear();
+      sceneDispose.mockClear();
+      engineDispose.mockClear();
+      const exportFailure = new Error("forced FBX export failure");
+      vi.spyOn(GLTF2Export, "GLBAsync").mockRejectedValueOnce(exportFailure);
 
-        expect(() => NodeAsset.Parse(serialization)).toThrow('Invalid serialized block property "sourceKind"');
-    });
+      const error = await CreateExportingAsset(
+        CreateAsciiFbx74TriangleFixture(),
+      )
+        .buildAsync()
+        .catch((reason: unknown) => reason);
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).cause).toBe(exportFailure);
+      expect(containerDispose).toHaveBeenCalled();
+      expect(sceneDispose).toHaveBeenCalled();
+      expect(engineDispose).toHaveBeenCalled();
+    } finally {
+      vi.restoreAllMocks();
+    }
+  });
 
-    it("round-trips empty uploaded bytes without producing a partial active source", () => {
-        const asset = new NodeAsset("empty-fbx-source");
-        const read = new ReadFBXBlock("Read FBX", asset);
-        read.setUploadedSource(new Uint8Array(), "empty.fbx");
+  it("rejects non-upload source kinds during strict graph parsing", () => {
+    const asset = new NodeAsset("strict-fbx-state");
+    const importer = new ImportFBXAggregateBlock("Import FBX", asset);
+    importer.setUploadedSource(
+      CreateAsciiFbx74TriangleFixture(),
+      "triangle.fbx",
+    );
+    const serialization = JSON.parse(JSON.stringify(asset.serialize())) as {
+      blocks: Array<{ subgraph: { blocks: Array<{ sourceKind?: string }> } }>;
+    };
+    serialization.blocks[0].subgraph.blocks[0].sourceKind = "url";
 
-        const parsed = NodeAsset.Parse(JSON.parse(JSON.stringify(asset.serialize())));
-        const parsedRead = parsed.attachedBlocks[0] as ReadFBXBlock;
+    expect(() => NodeAsset.Parse(serialization)).toThrow(
+      'Invalid serialized block property "sourceKind"',
+    );
+  });
 
-        expect(parsedRead.data).toEqual(new Uint8Array());
-        expect(parsedRead.source).toBe("empty.fbx");
-        expect(parsedRead.sourceKind).toBe("upload");
-    });
+  it("round-trips empty uploaded bytes without producing a partial active source", () => {
+    const asset = new NodeAsset("empty-fbx-source");
+    const read = new ReadFBXBlock("Read FBX", asset);
+    read.setUploadedSource(new Uint8Array(), "empty.fbx");
 
-    it.each([
-        { data: null, source: "triangle.fbx", sourceKind: "upload" },
-        { data: "", source: null, sourceKind: "upload" },
-        { data: "", source: "triangle.fbx", sourceKind: "" },
-        { data: null, source: "", sourceKind: "" },
-        { data: "not canonical base64", source: "triangle.fbx", sourceKind: "upload" },
-    ])("rejects partial or non-canonical serialized source state: %j", (sourceState) => {
-        const asset = new NodeAsset("invalid-fbx-state");
-        const read = new ReadFBXBlock("Read FBX", asset);
-        const serialization = JSON.parse(JSON.stringify(asset.serialize())) as {
-            blocks: Array<{ data: string | null; source: string | null; sourceKind: string }>;
-        };
-        Object.assign(serialization.blocks[0], sourceState);
+    const parsed = NodeAsset.Parse(
+      JSON.parse(JSON.stringify(asset.serialize())),
+    );
+    const parsedRead = parsed.attachedBlocks[0] as ReadFBXBlock;
 
-        expect(() => NodeAsset.Parse(serialization)).toThrow(/Invalid serialized FBX source state/);
-    });
+    expect(parsedRead.data).toEqual(new Uint8Array());
+    expect(parsedRead.source).toBe("empty.fbx");
+    expect(parsedRead.sourceKind).toBe("upload");
+  });
 
-    it("preserves the conversion failure when every cleanup step also fails", async () => {
-        const exportFailure = new Error("forced conversion failure");
-        const containerCleanupFailure = new Error("forced container cleanup failure");
-        const sceneCleanupFailure = new Error("forced scene cleanup failure");
-        const engineCleanupFailure = new Error("forced engine cleanup failure");
-        const containerDispose = vi.spyOn(AssetContainer.prototype, "dispose").mockImplementationOnce(() => {
-            throw containerCleanupFailure;
-        });
-        const sceneDispose = vi.spyOn(Scene.prototype, "dispose").mockImplementationOnce(() => {
-            throw sceneCleanupFailure;
-        });
-        const engineDispose = vi.spyOn(NullEngine.prototype, "dispose").mockImplementationOnce(() => {
-            throw engineCleanupFailure;
-        });
-        vi.spyOn(GLTF2Export, "GLBAsync").mockRejectedValueOnce(exportFailure);
+  it.each([
+    { data: null, source: "triangle.fbx", sourceKind: "upload" },
+    { data: "", source: null, sourceKind: "upload" },
+    { data: "", source: "triangle.fbx", sourceKind: "" },
+    { data: null, source: "", sourceKind: "" },
+    {
+      data: "not canonical base64",
+      source: "triangle.fbx",
+      sourceKind: "upload",
+    },
+  ])(
+    "rejects partial or non-canonical serialized source state: %j",
+    (sourceState) => {
+      const asset = new NodeAsset("invalid-fbx-state");
+      const read = new ReadFBXBlock("Read FBX", asset);
+      const serialization = JSON.parse(JSON.stringify(asset.serialize())) as {
+        blocks: Array<{
+          data: string | null;
+          source: string | null;
+          sourceKind: string;
+        }>;
+      };
+      Object.assign(serialization.blocks[0], sourceState);
 
-        try {
-            const error = await CreateExportingAsset(CreateAsciiFbx74TriangleFixture())
-                .buildAsync()
-                .catch((reason: unknown) => reason);
+      expect(() => NodeAsset.Parse(serialization)).toThrow(
+        /Invalid serialized FBX source state/,
+      );
+    },
+  );
 
-            expect(error).toBeInstanceOf(AggregateError);
-            expect((error as AggregateError).message).toMatch(/failed to convert "triangle\.fbx" to Universal/);
-            expect((error as AggregateError).cause).toMatchObject({ cause: exportFailure });
-            expect((error as AggregateError).errors).toEqual([
-                expect.objectContaining({ cause: exportFailure }),
-                containerCleanupFailure,
-                sceneCleanupFailure,
-                engineCleanupFailure,
-            ]);
-            expect(containerDispose).toHaveBeenCalled();
-            expect(sceneDispose).toHaveBeenCalled();
-            expect(engineDispose).toHaveBeenCalled();
-        } finally {
-            vi.restoreAllMocks();
-        }
-    });
+  it("preserves the conversion failure when every cleanup step also fails", async () => {
+    const exportFailure = new Error("forced conversion failure");
+    const containerCleanupFailure = new Error(
+      "forced container cleanup failure",
+    );
+    const sceneCleanupFailure = new Error("forced scene cleanup failure");
+    const engineCleanupFailure = new Error("forced engine cleanup failure");
+    const containerDispose = vi
+      .spyOn(AssetContainer.prototype, "dispose")
+      .mockImplementationOnce(() => {
+        throw containerCleanupFailure;
+      });
+    const sceneDispose = vi
+      .spyOn(Scene.prototype, "dispose")
+      .mockImplementationOnce(() => {
+        throw sceneCleanupFailure;
+      });
+    const engineDispose = vi
+      .spyOn(NullEngine.prototype, "dispose")
+      .mockImplementationOnce(() => {
+        throw engineCleanupFailure;
+      });
+    vi.spyOn(GLTF2Export, "GLBAsync").mockRejectedValueOnce(exportFailure);
+
+    try {
+      const error = await CreateExportingAsset(
+        CreateAsciiFbx74TriangleFixture(),
+      )
+        .buildAsync()
+        .catch((reason: unknown) => reason);
+
+      expect(error).toBeInstanceOf(AggregateError);
+      expect((error as AggregateError).message).toMatch(
+        /failed to convert "triangle\.fbx" to Universal/,
+      );
+      expect((error as AggregateError).cause).toMatchObject({
+        cause: exportFailure,
+      });
+      expect((error as AggregateError).errors).toEqual([
+        expect.objectContaining({ cause: exportFailure }),
+        containerCleanupFailure,
+        sceneCleanupFailure,
+        engineCleanupFailure,
+      ]);
+      expect(containerDispose).toHaveBeenCalled();
+      expect(sceneDispose).toHaveBeenCalled();
+      expect(engineDispose).toHaveBeenCalled();
+    } finally {
+      vi.restoreAllMocks();
+    }
+  });
 });

--- a/packages/dev/node-assets/test/unit/fbxUniversalFunnel.test.ts
+++ b/packages/dev/node-assets/test/unit/fbxUniversalFunnel.test.ts
@@ -1,5 +1,9 @@
 import { WebIO } from "@gltf-transform/core";
 import { ALL_EXTENSIONS } from "@gltf-transform/extensions";
+import { AssetContainer } from "core/assetContainer";
+import { NullEngine } from "core/Engines/nullEngine";
+import { Scene } from "core/scene";
+import { GLTF2Export } from "serializers/glTF/2.0/glTFSerializer";
 import { describe, expect, it, vi } from "vitest";
 
 import { ExportGLTFAggregateBlock } from "../../src/Blocks/exportGLTFAggregateBlock";
@@ -55,6 +59,19 @@ async function ReadStableMeshFactsAsync(glb: Uint8Array): Promise<{
 }
 
 describe("FBX Universal funnel", () => {
+    function CreateExportingAsset(data?: Uint8Array): NodeAsset {
+        const asset = new NodeAsset("fbx-errors");
+        const read = new ReadFBXBlock("Read FBX", asset);
+        if (data) {
+            read.setUploadedSource(data, "triangle.fbx");
+        }
+        const toUniversal = new FBXToUniversalBlock("FBX \u2192 Universal", asset);
+        const exporter = new ExportGLTFAggregateBlock("Export glTF", asset);
+        read.output.connectTo(toUniversal.input);
+        toUniversal.output.connectTo(exporter.input);
+        return asset;
+    }
+
     it("builds an uploaded ASCII FBX through saved aggregate and primitive funnels without fetching", async () => {
         const source = CreateAsciiFbx74TriangleFixture();
 
@@ -122,5 +139,64 @@ describe("FBX Universal funnel", () => {
         } finally {
             vi.unstubAllGlobals();
         }
+    });
+
+    it("accounts uploaded bytes and rejects a missing source before parsing", async () => {
+        await expect(CreateExportingAsset().buildAsync()).rejects.toThrow(/Upload a \.fbx file before building/);
+
+        const source = CreateAsciiFbx74TriangleFixture();
+        await expect(CreateExportingAsset(source).buildAsync({ limits: { maxSourceAssetBytes: source.byteLength - 1 } })).rejects.toMatchObject({
+            code: "NODE_ASSET_LIMIT_SOURCE_BYTES",
+            actual: source.byteLength,
+        });
+    });
+
+    it("rejects malformed FBX contextually while retaining the parser cause", async () => {
+        const error = await CreateExportingAsset(new TextEncoder().encode("not an FBX document")).buildAsync().catch((reason: unknown) => reason);
+
+        expect(error).toBeInstanceOf(Error);
+        expect((error as Error).message).toMatch(/failed to convert "triangle\.fbx" to Universal/);
+        expect((error as Error).cause).toBeInstanceOf(Error);
+    });
+
+    it("disposes the FBX container, scene, and engine on success and export failure", async () => {
+        const containerDispose = vi.spyOn(AssetContainer.prototype, "dispose");
+        const sceneDispose = vi.spyOn(Scene.prototype, "dispose");
+        const engineDispose = vi.spyOn(NullEngine.prototype, "dispose");
+        try {
+            await expect(CreateExportingAsset(CreateAsciiFbx74TriangleFixture()).buildAsync()).resolves.toBeInstanceOf(Uint8Array);
+            expect(containerDispose).toHaveBeenCalled();
+            expect(sceneDispose).toHaveBeenCalled();
+            expect(engineDispose).toHaveBeenCalled();
+
+            containerDispose.mockClear();
+            sceneDispose.mockClear();
+            engineDispose.mockClear();
+            const exportFailure = new Error("forced FBX export failure");
+            vi.spyOn(GLTF2Export, "GLBAsync").mockRejectedValueOnce(exportFailure);
+
+            const error = await CreateExportingAsset(CreateAsciiFbx74TriangleFixture())
+                .buildAsync()
+                .catch((reason: unknown) => reason);
+            expect(error).toBeInstanceOf(Error);
+            expect((error as Error).cause).toBe(exportFailure);
+            expect(containerDispose).toHaveBeenCalled();
+            expect(sceneDispose).toHaveBeenCalled();
+            expect(engineDispose).toHaveBeenCalled();
+        } finally {
+            vi.restoreAllMocks();
+        }
+    });
+
+    it("rejects non-upload source kinds during strict graph parsing", () => {
+        const asset = new NodeAsset("strict-fbx-state");
+        const importer = new ImportFBXAggregateBlock("Import FBX", asset);
+        importer.setUploadedSource(CreateAsciiFbx74TriangleFixture(), "triangle.fbx");
+        const serialization = JSON.parse(JSON.stringify(asset.serialize())) as {
+            blocks: Array<{ subgraph: { blocks: Array<{ sourceKind?: string }> } }>;
+        };
+        serialization.blocks[0].subgraph.blocks[0].sourceKind = "url";
+
+        expect(() => NodeAsset.Parse(serialization)).toThrow('Invalid serialized block property "sourceKind"');
     });
 });

--- a/packages/dev/node-assets/test/unit/testFbxSource.ts
+++ b/packages/dev/node-assets/test/unit/testFbxSource.ts
@@ -1,0 +1,49 @@
+/**
+ * Creates a deterministic repository-owned ASCII FBX 7.4 triangle.
+ *
+ * The fixture is hand-authored from the ASCII FBX grammar exercised by Babylon.js loader tests. It
+ * contains no Autodesk SDK output or third-party asset content.
+ * @returns The UTF-8 encoded `.fbx` source bytes.
+ */
+export function CreateAsciiFbx74TriangleFixture(): Uint8Array {
+    return new TextEncoder().encode(
+        [
+            "; FBX 7.4.0 project file",
+            "GlobalSettings: {",
+            "    Version: 1000",
+            "    Properties70: {",
+            '        P: "UpAxis", "int", "Integer", "",1',
+            '        P: "UpAxisSign", "int", "Integer", "",1',
+            '        P: "FrontAxis", "int", "Integer", "",2',
+            '        P: "FrontAxisSign", "int", "Integer", "",1',
+            '        P: "CoordAxis", "int", "Integer", "",0',
+            '        P: "CoordAxisSign", "int", "Integer", "",1',
+            '        P: "UnitScaleFactor", "double", "Number", "",1',
+            "    }",
+            "}",
+            "Objects: {",
+            '    Geometry: 1, "Geometry::Triangle", "Mesh" {',
+            "        Vertices: *9 {",
+            "            a: 0,0,0,1,0,0,0,1,0",
+            "        }",
+            "        PolygonVertexIndex: *3 {",
+            "            a: 0,1,-3",
+            "        }",
+            "        LayerElementNormal: 0 {",
+            '            MappingInformationType: "ByControlPoint"',
+            '            ReferenceInformationType: "Direct"',
+            "            Normals: *9 {",
+            "                a: 0,0,1,0,0,1,0,0,1",
+            "            }",
+            "        }",
+            "    }",
+            '    Model: 2, "Model::Triangle", "Mesh" {',
+            "    }",
+            "}",
+            "Connections: {",
+            '    C: "OO", 1, 2',
+            '    C: "OO", 2, 0',
+            "}",
+        ].join("\n")
+    );
+}

--- a/packages/dev/node-assets/test/unit/typedRepresentations.test.ts
+++ b/packages/dev/node-assets/test/unit/typedRepresentations.test.ts
@@ -9,6 +9,7 @@ import { describe, expect, expectTypeOf, it } from "vitest";
 import { NodeAssetConnectionPointType } from "../../src/connection/nodeAssetConnectionPointType";
 import { type NodeAssetJsonValue, type NodeAssetValueMap } from "../../src/connection/nodeAssetValueMap";
 import { BabylonAsset, IsBabylonAsset } from "../../src/representations/babylonAsset";
+import { FBXSource, IsFBXSource } from "../../src/representations/fbxSource";
 import { GltfAsset, IsGltfAsset } from "../../src/representations/gltfAsset";
 import { IsNodeGeometryAsset, NodeGeometryAsset } from "../../src/representations/nodeGeometryAsset";
 import { IsUsdAsset, UsdAsset } from "../../src/representations/usdAsset";
@@ -104,6 +105,8 @@ describe("typed representations", () => {
         expect(NodeAssetConnectionPointType.NODE_GEOMETRY).toBe(7);
         expect(NodeAssetConnectionPointType.UNIVERSAL).toBe(8);
         expect(NodeAssetConnectionPointType.USD_SOURCE).toBe(10);
+        expect(NodeAssetConnectionPointType[11]).toBeUndefined();
+        expect(NodeAssetConnectionPointType.FBX_SOURCE).toBe(12);
         expect("REPRESENTATION" in NodeAssetConnectionPointType).toBe(false);
         expect(NodeAssetConnectionPointType[NodeAssetConnectionPointType.GLTF_DOCUMENT]).toBe("GLTF_DOCUMENT");
     });
@@ -112,11 +115,26 @@ describe("typed representations", () => {
         expectTypeOf<NodeAssetValueMap[NodeAssetConnectionPointType.GLTF_DOCUMENT]>().toEqualTypeOf<GltfAsset>();
         expectTypeOf<NodeAssetValueMap[NodeAssetConnectionPointType.USD_STAGE]>().toEqualTypeOf<UsdAsset>();
         expectTypeOf<NodeAssetValueMap[NodeAssetConnectionPointType.USD_SOURCE]>().toEqualTypeOf<UsdSourceAsset>();
+        expectTypeOf<NodeAssetValueMap[NodeAssetConnectionPointType.FBX_SOURCE]>().toEqualTypeOf<FBXSource>();
         expectTypeOf<NodeAssetValueMap[NodeAssetConnectionPointType.BABYLON_SCENE]>().toEqualTypeOf<BabylonAsset>();
         expectTypeOf<NodeAssetValueMap[NodeAssetConnectionPointType.NODE_GEOMETRY]>().toEqualTypeOf<NodeGeometryAsset>();
         expectTypeOf<NodeAssetValueMap[NodeAssetConnectionPointType.NUMBER]>().toEqualTypeOf<number>();
         expectTypeOf<NodeAssetValueMap[NodeAssetConnectionPointType.STRING]>().toEqualTypeOf<string>();
         expectTypeOf<NodeAssetValueMap[NodeAssetConnectionPointType.JSON]>().toEqualTypeOf<NodeAssetJsonValue>();
+    });
+
+    it("keeps FBX source bytes immutable and exposes their source context", () => {
+        const original = new Uint8Array([1, 2, 3]);
+        const source = new FBXSource(original, "triangle.fbx", "/models/");
+        original[0] = 9;
+        const exposed = source.data;
+        exposed[1] = 8;
+
+        expect(source.data).toEqual(new Uint8Array([1, 2, 3]));
+        expect(source.source).toBe("triangle.fbx");
+        expect(source.rootUrl).toBe("/models/");
+        expect(IsFBXSource(source)).toBe(true);
+        expect(IsFBXSource(original)).toBe(false);
     });
 
     it.each(MetadataConstructors)("validates explicit metadata for $name", ({ construct }) => {

--- a/packages/dev/node-assets/tsconfig.build.json
+++ b/packages/dev/node-assets/tsconfig.build.json
@@ -8,6 +8,12 @@
         "rootDir": "./src"
     },
 
+    "references": [
+        {
+            "path": "../loaders/tsconfig.build.json"
+        }
+    ],
+
     "include": ["./src/**/*.ts", "./src/**/*.tsx"],
     "exclude": ["**/node_modules", "**/dist"]
 }

--- a/packages/tools/nodeAssetsEditor/src/nodeAssets/blockCatalog.ts
+++ b/packages/tools/nodeAssetsEditor/src/nodeAssets/blockCatalog.ts
@@ -93,6 +93,9 @@ export const UsdStagePortColor = "#C4A265";
 /** Data-driven dot color for BABYLON_SCENE-typed ports. */
 export const BabylonScenePortColor = "#4A90D9";
 
+/** Palette header and source-port color for the FBX source lane. */
+export const FBXHeaderColor = "#D97706";
+
 /** Data-driven dot color for NODE_GEOMETRY-typed ports. */
 export const NodeGeometryPortColor = "#7B68EE";
 

--- a/packages/tools/nodeAssetsEditor/src/nodeAssets/blockDescriptors/fbxToUniversalBlockDescriptor.ts
+++ b/packages/tools/nodeAssetsEditor/src/nodeAssets/blockDescriptors/fbxToUniversalBlockDescriptor.ts
@@ -1,0 +1,15 @@
+import { FBXToUniversalBlock } from "node-assets/Blocks/fbxToUniversalBlock";
+
+import { FBXHeaderColor, RegisterBlockDescriptor } from "../blockCatalog";
+
+RegisterBlockDescriptor({
+    paletteItemId: "fbx-to-universal",
+    label: "FBX \u2192 Universal",
+    description: "Parse an FBX source and cross into Universal.",
+    keywords: ["convert", "transcode", "fbx", "Universal"],
+    category: "FBX",
+    headerColor: FBXHeaderColor,
+    className: FBXToUniversalBlock.ClassName,
+    abstractedBy: "import-fbx",
+    create: (nodeAsset) => new FBXToUniversalBlock("FBX \u2192 Universal", nodeAsset),
+});

--- a/packages/tools/nodeAssetsEditor/src/nodeAssets/blockDescriptors/importFBXAggregateBlockDescriptor.ts
+++ b/packages/tools/nodeAssetsEditor/src/nodeAssets/blockDescriptors/importFBXAggregateBlockDescriptor.ts
@@ -1,0 +1,15 @@
+import { ImportFBXAggregateBlock } from "node-assets/Blocks/importFBXAggregateBlock";
+
+import { AggregateImportsFamily, ConfigureBlockForEditor, FBXHeaderColor, RegisterBlockDescriptor } from "../blockCatalog";
+
+RegisterBlockDescriptor({
+    paletteItemId: "import-fbx",
+    label: "Import FBX",
+    description: "Read an uploaded .fbx source and cross into Universal.",
+    keywords: ["open", "load", "source", "fbx", "Universal"],
+    category: "Inputs",
+    family: AggregateImportsFamily,
+    headerColor: FBXHeaderColor,
+    className: ImportFBXAggregateBlock.ClassName,
+    create: (nodeAsset) => ConfigureBlockForEditor(new ImportFBXAggregateBlock("Import FBX", nodeAsset)),
+});

--- a/packages/tools/nodeAssetsEditor/src/nodeAssets/blockDescriptors/index.ts
+++ b/packages/tools/nodeAssetsEditor/src/nodeAssets/blockDescriptors/index.ts
@@ -7,6 +7,7 @@
 import "./importGLTFBlockDescriptor";
 import "./importUSDBlockDescriptor";
 import "./importBabylonAggregateBlockDescriptor";
+import "./importFBXAggregateBlockDescriptor";
 import "./importNodeGeometryBlockDescriptor";
 
 import "./universalToGLTFBlockDescriptor";
@@ -35,11 +36,13 @@ import "./exportGLTFBlockDescriptor";
 import "./readGLTFBlockDescriptor";
 import "./readUSDBlockDescriptor";
 import "./readBabylonBlockDescriptor";
+import "./readFBXBlockDescriptor";
 import "./readNodeGeometryBlockDescriptor";
 import "./gltfToUniversalBlockDescriptor";
 import "./writeGLTFBlockDescriptor";
 import "./usdToUniversalBlockDescriptor";
 import "./babylonToUniversalBlockDescriptor";
+import "./fbxToUniversalBlockDescriptor";
 import "./nodeGeometryToUniversalBlockDescriptor";
 
 import "./legacyImportGLTFBlockDescriptor";

--- a/packages/tools/nodeAssetsEditor/src/nodeAssets/blockDescriptors/readFBXBlockDescriptor.ts
+++ b/packages/tools/nodeAssetsEditor/src/nodeAssets/blockDescriptors/readFBXBlockDescriptor.ts
@@ -1,0 +1,94 @@
+import { ReadFBXBlock } from "node-assets/Blocks/readFBXBlock";
+
+import { type IPropertySection } from "../../nodeGraph/propertyModel";
+import { FBXHeaderColor, ConfigureBlockForEditor, type IPropertySectionContext, RegisterBlockDescriptor } from "../blockCatalog";
+import { PromptForFileAsync } from "../browserFiles";
+
+const SourceErrors = new WeakMap<ReadFBXBlock, string>();
+const PendingSourceRequests = new WeakMap<ReadFBXBlock, Promise<unknown>>();
+
+async function PromptForFBXAsync(block: ReadFBXBlock, context: IPropertySectionContext): Promise<void> {
+    const file = await PromptForFileAsync(".fbx");
+    if (!file) {
+        return;
+    }
+    const authoredBlock = context.prepareEdit(block);
+    if (!authoredBlock) {
+        return;
+    }
+    const request = file.arrayBuffer();
+    PendingSourceRequests.set(authoredBlock, request);
+    try {
+        const data = new Uint8Array(await request);
+        if (context.prepareEdit(authoredBlock) !== authoredBlock || PendingSourceRequests.get(authoredBlock) !== request) {
+            return;
+        }
+        authoredBlock.setUploadedSource(data, file.name);
+        SourceErrors.delete(authoredBlock);
+    } catch (error) {
+        if (context.prepareEdit(authoredBlock) === authoredBlock && PendingSourceRequests.get(authoredBlock) === request) {
+            SourceErrors.set(authoredBlock, error instanceof Error ? error.message : String(error));
+        }
+    } finally {
+        if (PendingSourceRequests.get(authoredBlock) === request) {
+            PendingSourceRequests.delete(authoredBlock);
+        }
+    }
+    if (context.prepareEdit(authoredBlock) === authoredBlock) {
+        context.refresh();
+    }
+}
+
+/**
+ * Builds the source controls shared by Read FBX and Import FBX.
+ * @param block The owned Read FBX primitive.
+ * @param context Editor property actions.
+ * @param title Child-attributed section title.
+ * @returns The shared property section.
+ */
+export function CreateReadFBXPropertySection(block: ReadFBXBlock, context: IPropertySectionContext, title = "SOURCE"): IPropertySection {
+    const sourceError = SourceErrors.get(block);
+    return {
+        title,
+        properties: [
+            {
+                kind: "text",
+                label: "Active source",
+                value: block.source ?? "No source loaded",
+                disabled: true,
+                onChange: () => undefined,
+            },
+            {
+                kind: "button",
+                label: "Upload FBX\u2026",
+                onClick: () => {
+                    void PromptForFBXAsync(block, context);
+                },
+            },
+            ...(sourceError
+                ? ([
+                      {
+                          kind: "text",
+                          label: "Source error",
+                          value: sourceError,
+                          disabled: true,
+                          onChange: () => undefined,
+                      },
+                  ] as const)
+                : []),
+        ],
+    };
+}
+
+RegisterBlockDescriptor({
+    paletteItemId: "read-fbx",
+    label: "Read FBX",
+    description: "Read an uploaded .fbx source.",
+    keywords: ["open", "load", "upload", "fbx"],
+    category: "Inputs",
+    headerColor: FBXHeaderColor,
+    className: ReadFBXBlock.ClassName,
+    abstractedBy: "import-fbx",
+    create: (nodeAsset) => ConfigureBlockForEditor(new ReadFBXBlock("Read FBX", nodeAsset)),
+    getPropertySection: (block, context) => CreateReadFBXPropertySection(block as ReadFBXBlock, context),
+});

--- a/packages/tools/nodeAssetsEditor/src/nodeAssets/blockNodeMapping.ts
+++ b/packages/tools/nodeAssetsEditor/src/nodeAssets/blockNodeMapping.ts
@@ -14,6 +14,7 @@ import { type NodeAssetConnectionPoint } from "node-assets/connection/nodeAssetC
 import { type IGraphNode, type IGraphPort, type Vec2 } from "../nodeGraph/graphModel";
 import {
     BabylonScenePortColor,
+    FBXHeaderColor,
     ImagePortColor,
     JsonPortColor,
     NodeGeometryPortColor,
@@ -67,6 +68,7 @@ const PortStyleByType: Partial<Record<NodeAssetConnectionPointType, { readonly n
     [NodeAssetConnectionPointType.NODE_GEOMETRY]: { name: "Node Geometry", color: NodeGeometryPortColor },
     [NodeAssetConnectionPointType.UNIVERSAL]: { name: "Universal", color: UniversalPortColor },
     [NodeAssetConnectionPointType.BABYLON_SOURCE]: { name: "Babylon", color: BabylonScenePortColor },
+    [NodeAssetConnectionPointType.FBX_SOURCE]: { name: "FBX", color: FBXHeaderColor },
 };
 
 /**

--- a/packages/tools/nodeAssetsEditor/test/unit/blockNodeMapping.test.ts
+++ b/packages/tools/nodeAssetsEditor/test/unit/blockNodeMapping.test.ts
@@ -4,7 +4,15 @@ import { NodeAsset } from "node-assets/nodeAsset";
 import { NodeAssetBlock } from "node-assets/blockFoundation/nodeAssetBlock";
 import { NodeAssetConnectionPointType } from "node-assets/connection/nodeAssetConnectionPointType";
 
-import { NumberPortColor, ScenePortColor, UsdStagePortColor, BabylonScenePortColor, NodeGeometryPortColor, type IBlockDescriptor } from "../../src/nodeAssets/blockCatalog";
+import {
+    BabylonScenePortColor,
+    FBXHeaderColor,
+    NodeGeometryPortColor,
+    NumberPortColor,
+    ScenePortColor,
+    UsdStagePortColor,
+    type IBlockDescriptor,
+} from "../../src/nodeAssets/blockCatalog";
 import { BlockToNode, NodeIdForBlock, PointToPort, PortIdForPoint } from "../../src/nodeAssets/blockNodeMapping";
 
 class MappingTestBlock extends NodeAssetBlock {
@@ -24,6 +32,7 @@ class RepresentationMappingTestBlock extends NodeAssetBlock {
     public readonly babylon = this._registerOutput("babylon", NodeAssetConnectionPointType.BABYLON_SCENE);
     public readonly nodeGeometry = this._registerOutput("nodeGeometry", NodeAssetConnectionPointType.NODE_GEOMETRY);
     public readonly usdSource = this._registerOutput("usdSource", NodeAssetConnectionPointType.USD_SOURCE);
+    public readonly fbxSource = this._registerOutput("fbxSource", NodeAssetConnectionPointType.FBX_SOURCE);
 
     public override async _buildBlockAsync(): Promise<void> {}
 }
@@ -74,6 +83,7 @@ describe("blockNodeMapping", () => {
         expect(PointToPort(block, block.babylon).color).toBe(BabylonScenePortColor);
         expect(PointToPort(block, block.nodeGeometry).color).toBe(NodeGeometryPortColor);
         expect(PointToPort(block, block.usdSource)).toMatchObject({ name: "USD", color: UsdStagePortColor });
+        expect(PointToPort(block, block.fbxSource)).toMatchObject({ name: "FBX", color: FBXHeaderColor });
     });
 
     it("builds a node with input ports before output ports", () => {

--- a/packages/tools/nodeAssetsEditor/test/unit/blockPropertySections.test.ts
+++ b/packages/tools/nodeAssetsEditor/test/unit/blockPropertySections.test.ts
@@ -97,6 +97,25 @@ describe("block property sections (unified descriptor path)", () => {
         }
     });
 
+    it("forwards the uploaded Read FBX source controls from the aggregate", () => {
+        const controller = new NodeAssetGraphController();
+        try {
+            const importNode = AddPaletteNode(controller, "import-fbx");
+            const section = FindSection(controller, importNode, "READ FBX");
+
+            expect(section.properties.map((property) => property.label)).toEqual(["Active source", "Upload FBX\u2026"]);
+            expect(FindProperty(controller, importNode, "Active source", "text").value).toBe("No source loaded");
+            expect(FindProperty(controller, importNode, "Upload FBX\u2026", "button")).toBeDefined();
+
+            const paletteLabels = controller.getPaletteCategories().flatMap((category) => category.items.map((item) => item.label));
+            expect(paletteLabels).toContain("Import FBX");
+            expect(paletteLabels).not.toContain("Read FBX");
+            expect(paletteLabels).not.toContain("FBX \u2192 Universal");
+        } finally {
+            controller.dispose();
+        }
+    });
+
     it("fires an export request from the EXPORT section button", () => {
         const controller = new NodeAssetGraphController();
         let exportRequests = 0;

--- a/packages/tools/nodeAssetsEditor/test/unit/importExportFields.test.ts
+++ b/packages/tools/nodeAssetsEditor/test/unit/importExportFields.test.ts
@@ -21,6 +21,7 @@ vi.mock("../../src/nodeAssets/browserFiles", () => ({
 
 const ImportFileButtonLabel = "Upload glTF\u2026";
 const BabylonImportFileButtonLabel = "Upload Babylon\u2026";
+const FBXImportFileButtonLabel = "Upload FBX\u2026";
 const UploadUSDButtonLabel = "Upload USD\u2026";
 
 function FindNode(controller: NodeAssetGraphController, title: string): IGraphNode {
@@ -952,6 +953,40 @@ describe("Import block source label", () => {
                 reloaded.load(controller.serialize());
                 const reloadedImport = FindNode(reloaded, "Import Babylon");
                 expect(FindPropertyInSection(reloaded, reloadedImport, "READ BABYLON", "Active source", "text").value).toBe("myScene.babylon");
+            } finally {
+                reloaded.dispose();
+            }
+        } finally {
+            controller.dispose();
+        }
+    });
+
+    it("shares the uploaded FBX source across compact, expanded, and reloaded editor surfaces", async () => {
+        const controller = new NodeAssetGraphController();
+        try {
+            const importNode = AddPaletteNode(controller, "import-fbx");
+            expect(FindPropertyInSection(controller, importNode, "READ FBX", "Active source", "text").value).toBe("No source loaded");
+
+            vi.mocked(PromptForFileAsync).mockResolvedValue({
+                name: "triangle.fbx",
+                arrayBuffer: async () => new TextEncoder().encode("; FBX 7.4.0 project file").buffer,
+            } as unknown as File);
+
+            FindPropertyInSection(controller, importNode, "READ FBX", FBXImportFileButtonLabel, "button").onClick();
+            await vi.waitFor(() => {
+                expect(FindPropertyInSection(controller, importNode, "READ FBX", "Active source", "text").value).toBe("triangle.fbx");
+            });
+
+            controller.setAggregateExpanded(importNode.id, true);
+            const readNode = FindNode(controller, "Read FBX");
+            expect(FindPropertyInSection(controller, readNode, "SOURCE", "Active source", "text").value).toBe("triangle.fbx");
+            expect(FindPropertyInSection(controller, readNode, "SOURCE", FBXImportFileButtonLabel, "button")).toBeDefined();
+
+            const reloaded = new NodeAssetGraphController();
+            try {
+                reloaded.load(controller.serialize());
+                const reloadedImport = FindNode(reloaded, "Import FBX");
+                expect(FindPropertyInSection(reloaded, reloadedImport, "READ FBX", "Active source", "text").value).toBe("triangle.fbx");
             } finally {
                 reloaded.dispose();
             }

--- a/packages/tools/nodeAssetsEditor/test/unit/nodeAssetBuildWorkerRegistration.test.ts
+++ b/packages/tools/nodeAssetsEditor/test/unit/nodeAssetBuildWorkerRegistration.test.ts
@@ -95,6 +95,9 @@ const ExpectedBlockClassNames = [
     "ReadBabylonBlock",
     "BabylonToUniversalBlock",
     "ImportBabylonAggregateBlock",
+    "ReadFBXBlock",
+    "FBXToUniversalBlock",
+    "ImportFBXAggregateBlock",
 ] as const;
 
 const DefaultPipelineClassNames = ["ImportGLTFAggregateBlock", "WeldVerticesBlock", "RemoveUnusedResourcesBlock", "ExportGLTFAggregateBlock"] as const;

--- a/packages/tools/nodeAssetsEditor/test/unit/paletteCategories.test.ts
+++ b/packages/tools/nodeAssetsEditor/test/unit/paletteCategories.test.ts
@@ -18,84 +18,42 @@ function Descriptor(
 }
 
 describe("BuildPaletteCategories", () => {
-    it("publishes the exact default product palette in canonical category, family, and item order", () => {
-        const projection = BuildPaletteCategories(GetAllBlockDescriptors()).map((category) => ({
-            category: category.label,
-            items: category.items.map((item) => ({
-                family: item.family ?? null,
-                label: item.label,
-            })),
-        }));
+    it("places the FBX aggregate between Babylon and Node Geometry without pinning palette totals", () => {
+        const inputs = BuildPaletteCategories(GetAllBlockDescriptors())
+            .find((category) => category.label === "Inputs")
+            ?.items.map((item) => item.label);
+        if (!inputs) {
+            throw new Error("The Inputs palette category was not registered.");
+        }
 
-        expect(projection).toEqual([
-            {
-                category: "Inputs",
-                items: [
-                    { family: "Aggregate imports", label: "Import glTF" },
-                    { family: "Aggregate imports", label: "Import USD" },
-                    { family: "Aggregate imports", label: "Import Babylon" },
-                    { family: "Aggregate imports", label: "Import Node Geometry" },
-                ],
-            },
-            {
-                category: "Universal",
-                items: [
-                    { family: "Cleanup", label: "Weld Vertices" },
-                    { family: "Cleanup", label: "Deduplicate Resources" },
-                    { family: "Cleanup", label: "Remove Unused Resources" },
-                    { family: "Cleanup", label: "Remove Degenerate Geometry" },
-                    { family: "Cleanup", label: "Fix Face Winding" },
-                    { family: "Reduction", label: "Quantize Attributes" },
-                    { family: "Reduction", label: "Simplify Meshes" },
-                    { family: "Structure", label: "Flatten Hierarchy" },
-                    { family: "Structure", label: "Join Meshes" },
-                    { family: "Structure", label: "Split Meshes by Material" },
-                    { family: "Structure", label: "Merge Scenes" },
-                    { family: "Structure", label: "Transform Scene" },
-                    { family: "Structure", label: "Center Scene" },
-                    { family: "Attributes", label: "Recompute Normals" },
-                    { family: "Attributes", label: "Generate Tangents" },
-                    { family: "Attributes", label: "Strip Attributes" },
-                    { family: "Textures", label: "Resize Textures" },
-                ],
-            },
-            {
-                category: "glTF",
-                items: [
-                    { family: "Encoding/output", label: "Compress Geometry (Draco)" },
-                    { family: "Encoding/output", label: "Compress Textures (KTX2)" },
-                    { family: "Encoding/output", label: "Export glTF" },
-                ],
-            },
-        ]);
+        expect(inputs).toEqual(expect.arrayContaining(["Import glTF", "Import USD", "Import Babylon", "Import FBX", "Import Node Geometry"]));
+        expect(inputs.indexOf("Import Babylon")).toBeLessThan(inputs.indexOf("Import FBX"));
+        expect(inputs.indexOf("Import FBX")).toBeLessThan(inputs.indexOf("Import Node Geometry"));
+        for (const label of ["Import Babylon", "Import FBX", "Import Node Geometry"]) {
+            expect(
+                BuildPaletteCategories(GetAllBlockDescriptors())
+                    .find((category) => category.label === "Inputs")
+                    ?.items.find((item) => item.label === label)?.family
+            ).toBe("Aggregate imports");
+        }
     });
 
-    it("adds exactly the canonical primitives after the default product palette", () => {
+    it("hides FBX primitives by default and preserves source-lane order when primitives are shown", () => {
         const defaultCategories = BuildPaletteCategories(GetAllBlockDescriptors());
         const primitiveCategories = BuildPaletteCategories(GetAllBlockDescriptors(), { showPrimitives: true });
-        const additions = primitiveCategories.map((category) => {
-            const defaultItemIds = new Set(defaultCategories.find((candidate) => candidate.label === category.label)?.items.map((item) => item.id) ?? []);
-            return {
-                category: category.label,
-                items: category.items.filter((item) => !defaultItemIds.has(item.id)).map((item) => item.label),
-            };
-        });
+        const defaultLabels = defaultCategories.flatMap((category) => category.items.map((item) => item.label));
+        const primitiveLabels = primitiveCategories.flatMap((category) => category.items.map((item) => item.label));
+        const categoryLabels = primitiveCategories.map((category) => category.label);
+        const inputLabels = primitiveCategories.find((category) => category.label === "Inputs")?.items.map((item) => item.label) ?? [];
 
-        expect(primitiveCategories.map((category) => category.label)).toEqual(["Inputs", "Universal", "glTF", "USD", "Babylon", "Node Geometry"]);
-        for (const defaultCategory of defaultCategories) {
-            expect(primitiveCategories.find((category) => category.label === defaultCategory.label)?.items.slice(0, defaultCategory.items.length)).toEqual(defaultCategory.items);
-        }
-        expect(additions).toEqual([
-            { category: "Inputs", items: ["Read glTF", "Read USD", "Read Babylon", "Read Node Geometry"] },
-            {
-                category: "Universal",
-                items: ["Universal → glTF", "Deduplicate Materials", "Deduplicate Textures", "Reuse Identical Meshes", "Deduplicate Data"],
-            },
-            { category: "glTF", items: ["glTF → Universal", "Write glTF"] },
-            { category: "USD", items: ["USD → Universal"] },
-            { category: "Babylon", items: ["Babylon → Universal"] },
-            { category: "Node Geometry", items: ["Node Geometry → Universal"] },
-        ]);
+        expect(defaultLabels).not.toContain("Read FBX");
+        expect(defaultLabels).not.toContain("FBX \u2192 Universal");
+        expect(primitiveLabels).toEqual(expect.arrayContaining(["Read FBX", "FBX \u2192 Universal"]));
+        expect(categoryLabels).toEqual(expect.arrayContaining(["Babylon", "FBX", "Node Geometry"]));
+        expect(categoryLabels.indexOf("Babylon")).toBeLessThan(categoryLabels.indexOf("FBX"));
+        expect(categoryLabels.indexOf("FBX")).toBeLessThan(categoryLabels.indexOf("Node Geometry"));
+        expect(inputLabels.indexOf("Read Babylon")).toBeLessThan(inputLabels.indexOf("Read FBX"));
+        expect(inputLabels.indexOf("Read FBX")).toBeLessThan(inputLabels.indexOf("Read Node Geometry"));
     });
 
     it("uses the filtered product catalog for search", () => {
@@ -104,6 +62,13 @@ describe("BuildPaletteCategories", () => {
         expect(BuildPaletteCategories(GetAllBlockDescriptors(), { filter: "Write glTF", showPrimitives: true })).toMatchObject([
             { label: "glTF", items: [{ label: "Write glTF" }] },
         ]);
+    });
+
+    it("finds the FBX aggregate by default and its primitives only when requested", () => {
+        expect(BuildPaletteCategories(GetAllBlockDescriptors(), { filter: "fbx" }).flatMap((category) => category.items.map((item) => item.label))).toEqual(["Import FBX"]);
+        expect(BuildPaletteCategories(GetAllBlockDescriptors(), { filter: "fbx", showPrimitives: true }).flatMap((category) => category.items.map((item) => item.label))).toEqual(
+            expect.arrayContaining(["Import FBX", "Read FBX", "FBX \u2192 Universal"])
+        );
     });
 
     it("returns no categories for an empty descriptor list", () => {


### PR DESCRIPTION
## Summary

- Add the typed uploaded FBX source lane: `Read FBX` -> `FBX → Universal` -> existing Universal/glTF output blocks.
- Use the pure `FBXFileLoader` directly with build-scoped Babylon resources, strict source persistence, provenance metadata, and cause-preserving cleanup.
- Add `Import FBX` editor descriptors, upload properties, FBX port styling, worker registration, and canonical palette placement.
- Cover generated ASCII FBX aggregate/primitive graph builds, serialization/reload, valid GLB facts, failures, lifecycle, dependency safety, and editor authoring.

## Validation

- `npx vitest run --project=unit --reporter=verbose <10 focused Node Assets/Editor files>` - 281 passed.
- `npx prettier --check <changed TS/TSX/JSON files>` - passed.
- `npx eslint --quiet <13 changed source files>` - passed.
- `npm run compile:source -w @dev/node-assets` - passed.
- `npm run build:viewer -w @tools/node-assets-editor` - passed.
- `npm run build:deployment -w @tools/node-assets-editor` - passed.

## Review

The review pass found empty/mixed source-state round-trip and cleanup-error masking edge cases. Both were fixed with regression coverage.
