### PR TITLE
[NAE] Add drag-to-pan graph canvas navigation

### DIFF
--- a/.scratch/graph-canvas-panning/PRD.md
+++ b/.scratch/graph-canvas-panning/PRD.md
@@ -1,4 +1,4 @@
-Status: in-progress
+Status: ready-for-agent
 
 ## Problem Statement
 Authors working on a NodeAssets graph need to reposition the viewport frequently. The canvas already has a camera and pan gesture, but normal primary-button dragging on empty canvas does not invoke it. Requiring a middle button or a Space chord is hard to discover, unavailable on many touch devices, and inconsistent with Babylon's other graph editors.

--- a/.scratch/graph-canvas-panning/PRD.md
+++ b/.scratch/graph-canvas-panning/PRD.md
@@ -1,0 +1,59 @@
+Status: ready-for-agent
+
+## Problem Statement
+Authors working on a NodeAssets graph need to reposition the viewport frequently. The canvas already has a camera and pan gesture, but normal primary-button dragging on empty canvas does not invoke it. Requiring a middle button or a Space chord is hard to discover, unavailable on many touch devices, and inconsistent with Babylon's other graph editors.
+
+## Solution
+Dragging the empty canvas surface with the primary pointer moves the camera by the pointer's viewport-space delta. Modified primary drags retain marquee selection, while middle-button and Space-plus-primary panning remain supported. The active gesture owns one pointer until completion or cancellation, and the canvas provides grab/grabbing feedback without changing graph data.
+
+## User Stories
+1. As a graph author, I want to drag empty canvas with the primary mouse button, so that I can move to another part of a large graph without learning a hidden chord.
+2. As a touch or pen user, I want a primary drag on empty canvas to move the viewport, so that panning does not require a middle mouse button.
+3. As an experienced Babylon graph-editor user, I want the Node Assets Editor to follow the established drag-empty-space-to-pan convention, so that navigation feels familiar.
+4. As a graph author, I want the canvas to follow my pointer one screen pixel per screen pixel at every zoom level, so that panning feels stable and predictable.
+5. As a graph author, I want dragging to continue when my pointer temporarily leaves the canvas, so that long pans do not stop at the viewport edge.
+6. As a graph author, I want a canceled pointer gesture to release cleanly, so that the canvas never remains stuck in a dragging state.
+7. As a graph author, I want only the pointer that began a pan to control it, so that a second touch or unrelated pointer cannot jump the camera.
+8. As a graph author, I want modified primary dragging to retain marquee selection, so that I can still select multiple nodes by region.
+9. As a graph author, I want a primary click without movement on empty canvas to retain the current clear-selection behavior, so that navigation does not remove a familiar selection affordance.
+10. As a graph author, I want dragging a node to continue moving the node rather than the camera, so that graph editing remains reliable.
+11. As a graph author, I want dragging a frame to continue moving the frame and its member nodes rather than the camera, so that grouping workflows remain reliable.
+12. As a graph author, I want dragging from a port to continue previewing and creating a wire, so that connection editing remains reliable.
+13. As a graph author, I want selecting a wire to remain distinct from panning, so that wire actions are not accidentally converted into camera movement.
+14. As a graph author, I want minimap navigation to remain distinct from canvas panning, so that clicking or dragging the minimap keeps its existing behavior.
+15. As a graph author, I want wheel zoom to keep the world point under the cursor fixed after panning, so that navigation remains spatially coherent.
+16. As a keyboard user, I want existing focus and keyboard shortcuts to remain unchanged, so that adding pointer navigation does not disrupt non-pointer workflows.
+17. As a graph author, I want grab/grabbing cursor feedback over the pannable surface, so that the interaction is discoverable and its active state is clear.
+
+## Implementation Decisions
+- The pure gesture interpreter remains the source of truth for whether a background pointer press begins panning or marquee selection.
+- An unmodified primary-button press on empty canvas begins a pan. A middle-button press and Space-plus-primary press remain pan aliases.
+- A primary-button press with Shift, Control, or Command begins the existing additive marquee gesture.
+- A pan records whether any non-zero movement occurred. Completing an unmoved primary-background pan clears selection; completing a moved pan does not alter selection.
+- Camera translation uses viewport-local pixel deltas so movement remains one-to-one and independent of zoom.
+- Child interactions keep priority: node, frame, and port handlers claim their gesture before the background handler; wire and minimap handlers keep their existing propagation behavior.
+- The canvas tracks the initiating pointer identity and ignores move/up/cancel events from other pointers until the gesture ends.
+- Pointer cancellation resets transient gesture state without committing a marquee or wire and safely closes any bracketed node/frame interaction.
+- The canvas surface shows `grab` while idle and `grabbing` during an active pan. Existing child cursors retain precedence.
+- Panning remains view-only state and does not mutate nodes, wires, frames, undo history, build scheduling, or persisted NodeAssets graph data.
+- Wheel zoom, zoom-to-fit, initial fit, minimap navigation, keyboard shortcuts, and form-control exclusions remain unchanged.
+
+## Testing Decisions
+- Use the existing pure gesture-interpreter unit seam for deterministic tests of background routing, pan movement latching, no-movement selection clearing, completion, and cancellation.
+- Use the existing Node Assets Editor Playwright seam for the highest-level regression: primary drag on verified empty canvas moves rendered graph content by the drag delta without changing node world positions or selection, then node dragging and wheel zoom still work.
+- Exercise modified-drag marquee behavior at the interpreter seam and, where stable, at the browser seam.
+- Cover pointer ownership/cancellation at the narrowest stable seam and avoid timing-based assertions.
+- Follow existing package Vitest and Playwright conventions and run the smallest scoped checks that cover the change.
+
+## Out of Scope
+- Inertial or momentum panning.
+- Pinch-to-zoom or multi-touch camera gestures.
+- Trackpad two-finger scroll-to-pan; wheel remains zoom.
+- Keyboard camera panning or new toolbar controls.
+- Camera persistence.
+- Zoom-limit, sensitivity, zoom-to-fit, initial-fit, or minimap-layout changes.
+- Replacing the NAE canvas with the shared legacy graph canvas.
+- Unrelated node, frame, port, wire, palette, or context-menu changes.
+
+## Further Notes
+The branch already contains camera pan actions, viewport-space delta math, middle-button/Space panning, window-level pointer continuation, and focused unit seams. The narrow change is input routing and gesture lifecycle, with browser coverage proving it does not steal graph-editing gestures.

--- a/.scratch/graph-canvas-panning/PRD.md
+++ b/.scratch/graph-canvas-panning/PRD.md
@@ -39,11 +39,21 @@ Dragging the empty canvas surface with the primary pointer moves the camera by t
 - Wheel zoom, zoom-to-fit, initial fit, minimap navigation, keyboard shortcuts, and form-control exclusions remain unchanged.
 
 ## Testing Decisions
+
 - Use the existing pure gesture-interpreter unit seam for deterministic tests of background routing, pan movement latching, no-movement selection clearing, completion, and cancellation.
 - Use the existing Node Assets Editor Playwright seam for the highest-level regression: primary drag on verified empty canvas moves rendered graph content by the drag delta without changing node world positions or selection, then node dragging and wheel zoom still work.
 - Exercise modified-drag marquee behavior at the interpreter seam and, where stable, at the browser seam.
 - Cover pointer ownership/cancellation at the narrowest stable seam and avoid timing-based assertions.
 - Follow existing package Vitest and Playwright conventions and run the smallest scoped checks that cover the change.
+
+## Delivery Status
+
+The feature and ownership fixes are assembled on the PR #22 branch, but this PRD intentionally remains `Status: ready-for-agent` until the corrected lifecycle tests land and root completes independent validation and integration.
+
+- PR #29's implementation head `2ccafbede2b3379b99c861b69c1829b0d31c38a2` merged into `fix/nae/graph-canvas-pan-owner-gates` as `a577d18736b7ad77e48b768b074c141eafcf5d97`; this is branch-level assembly, not final product integration.
+- The PR #29 worker reported RED on exact base `f5a284ded5b1176fbfb75faf97cafd2ecc929dfd` (ownership Playwright: one retained pass and three expected failures; ContextMenu unit: one expected failure), followed by GREEN at `2ccafbede2b3379b99c861b69c1829b0d31c38a2` (38/38 focused units and 5/5 focused Playwright, plus deployment build and lint/format checks).
+- The worker also reported a clean issue-level dual-lens `/code-review`. PR #29 itself has no GitHub check runs or reviews, so those results remain worker-reported evidence rather than GitHub-hosted evidence.
+- An independent exact-range audit then rejected the prior browser proof because several synthetic pointer streams were not physically complete. The focused test/docs follow-up replaces those streams without changing production source and passed its automatic dual-lens review; root's independent final gates and integration remain pending.
 
 ## Out of Scope
 - Inertial or momentum panning.
@@ -56,4 +66,5 @@ Dragging the empty canvas surface with the primary pointer moves the camera by t
 - Unrelated node, frame, port, wire, palette, or context-menu changes.
 
 ## Further Notes
-The branch already contains camera pan actions, viewport-space delta math, middle-button/Space panning, window-level pointer continuation, and focused unit seams. The narrow change is input routing and gesture lifecycle, with browser coverage proving it does not steal graph-editing gestures.
+
+The branch contains camera pan actions, viewport-space delta math, middle-button/Space panning, window-level pointer continuation, focused unit seams, and active-owner gates. The remaining work is to land acceptance-grade lifecycle coverage and complete root validation; no section above claims the feature has landed.

--- a/.scratch/graph-canvas-panning/PRD.md
+++ b/.scratch/graph-canvas-panning/PRD.md
@@ -1,4 +1,4 @@
-Status: ready-for-agent
+Status: in-progress
 
 ## Problem Statement
 Authors working on a NodeAssets graph need to reposition the viewport frequently. The canvas already has a camera and pan gesture, but normal primary-button dragging on empty canvas does not invoke it. Requiring a middle button or a Space chord is hard to discover, unavailable on many touch devices, and inconsistent with Babylon's other graph editors.

--- a/.scratch/graph-canvas-panning/issues/01-pan-empty-canvas.md
+++ b/.scratch/graph-canvas-panning/issues/01-pan-empty-canvas.md
@@ -1,4 +1,4 @@
-Status: in-progress
+Status: ready-for-agent
 
 ## Parent
 

--- a/.scratch/graph-canvas-panning/issues/01-pan-empty-canvas.md
+++ b/.scratch/graph-canvas-panning/issues/01-pan-empty-canvas.md
@@ -1,12 +1,15 @@
 Status: resolved
 
 ## Parent
+
 `.scratch/graph-canvas-panning/PRD.md`
 
 ## What to build
+
 Make the Node Assets Editor graph camera move when an author drags empty canvas with an unmodified primary pointer. Preserve modified-drag marquee selection, empty-canvas click deselection, middle-button and Space-plus-primary pan aliases, and all child graph interactions. The gesture must remain predictable across zoom levels, pointer types, canvas boundaries, cancellation, and multiple simultaneous pointers, with grab/grabbing feedback. Keep the change inside the existing generic node-graph interaction and camera seams. Panning is view state only and must not mutate NodeAssets graph data, create undo entries, or trigger builds.
 
 ## Acceptance criteria
+
 - [x] Unmodified primary drag beginning on empty canvas pans rendered nodes, wires, frames, grid, and minimap viewport by the viewport-pixel pointer delta at every supported zoom.
 - [x] Primary touch and pen drags use the same behavior; the initiating pointer exclusively owns the gesture until completion/cancellation.
 - [x] Middle-button and Space-plus-primary pan aliases remain.
@@ -21,6 +24,7 @@ Make the Node Assets Editor graph camera move when an author drags empty canvas 
 - [x] `/code-review` has no unresolved high-confidence findings.
 
 ## Blocked by
+
 None - can start immediately.
 
 ## Answer

--- a/.scratch/graph-canvas-panning/issues/01-pan-empty-canvas.md
+++ b/.scratch/graph-canvas-panning/issues/01-pan-empty-canvas.md
@@ -11,30 +11,45 @@ Make the Node Assets Editor graph camera move when an author drags empty canvas 
 ## Acceptance criteria
 
 - [x] Unmodified primary drag beginning on empty canvas pans rendered nodes, wires, frames, grid, and minimap viewport by the viewport-pixel pointer delta at every supported zoom.
-- [ ] Primary touch and pen drags use the same behavior; the initiating pointer exclusively owns the gesture until completion/cancellation.
+- [x] Primary touch and pen drags use the same behavior; the initiating pointer exclusively owns the gesture until completion/cancellation.
 - [x] Middle-button and Space-plus-primary pan aliases remain.
 - [x] Shift/Control/Command primary drag retains additive marquee selection.
 - [x] Primary click without movement on empty canvas clears selection; moved pan preserves selection.
-- [ ] Node drag, frame drag, port-to-wire drag, wire selection, context menus, palette drop, minimap navigation, initial fit, zoom-to-fit, and wheel zoom keep their behavior.
+- [x] Node drag, frame drag, port-to-wire drag, wire selection, context menus, palette drop, minimap navigation, initial fit, zoom-to-fit, and wheel zoom keep their behavior.
 - [x] Pan continues outside the canvas and cancellation clears transient state without committing marquee/wire or leaving an editor interaction open.
 - [x] Canvas uses `grab` idle and `grabbing` during pan without overriding child cursors.
-- [ ] Regression tests are written first at the gesture seam for routing, latching, completion, cancellation, and applicable pointer ownership.
+- [x] Regression tests cover the gesture seam for routing, latching, completion, cancellation, and applicable pointer ownership; PR #29's RED-before-GREEN evidence is worker-reported rather than independently reproduced from GitHub history.
 - [x] Playwright proves rendered primary-drag panning and representative node-drag + wheel-zoom behavior afterward.
-- [ ] Scoped unit tests, focused Playwright, package type-check/build, and applicable lint/format checks pass.
-- [ ] `/code-review` has no unresolved high-confidence findings.
+- [x] Scoped units, focused Playwright, the Node Assets Editor deployment build, and applicable lint/format checks pass; the standalone package type-check baseline limitation is documented below.
+- [x] `/code-review` has no unresolved high-confidence findings.
+- [ ] The corrected lifecycle follow-up lands and root completes independent final validation and integration.
 
-## Outcome (landed)
+## Delivery status (pending integration)
 
-Done as a docs follow-up on `feat/nae/graph-canvas-pan`.
+The implementation is assembled on the PR #22 branch, but the issue remains `Status: ready-for-agent`. Root will set `Status: resolved` only after the corrected lifecycle follow-up lands and the final integration gates pass.
 
-- The ticket is now `Status: resolved`.
-- The implementation PR landed as `2858fcff583192ddd14218f81dc7eab6cbbcb63c` on `feat/nae/graph-canvas-pan`.
-- Worker-reported evidence: targeted unit tests `35/35`, Playwright `2/2`, ESLint/Prettier/build/precommit pass, and clean `/code-review`.
+- PR #15 placed the initial implementation commit `2858fcff583192ddd14218f81dc7eab6cbbcb63c` on `feat/nae/graph-canvas-pan`; that feature-branch merge was not final product integration.
+- PR #29 placed the ownership implementation head `2ccafbede2b3379b99c861b69c1829b0d31c38a2` on `fix/nae/graph-canvas-pan-owner-gates` through merge commit `a577d18736b7ad77e48b768b074c141eafcf5d97`.
+- The current focused follow-up changes tests and tracker documentation only. Production-source changes are not part of this correction.
 
 ## Comments
 
-Implemented in [PR #15](https://github.com/alexchuber/Babylon.js/pull/15) at `2858fcff583192ddd14218f81dc7eab6cbbcb63c`. Verification passed with gesture unit tests `35/35`, focused Playwright `2/2`, targeted ESLint and Prettier, the Node Assets Editor deployment build, and precommit checks. Both `/code-review` lenses finished with no unresolved high-confidence findings. The standalone package-wide `tsc` baseline remains blocked by unrelated existing core/dependency diagnostics, including missing `XRHandedness`; no changed-file diagnostics were reported.
+### Initial implementation slice
 
-### Follow-up: active gesture ownership
+[PR #15](https://github.com/alexchuber/Babylon.js/pull/15) added the initial implementation at `2858fcff583192ddd14218f81dc7eab6cbbcb63c`. Its worker reported gesture units `35/35`, focused Playwright `2/2`, targeted ESLint and Prettier, the Node Assets Editor deployment build, precommit checks, and clean dual-lens `/code-review`. The standalone package-wide `tsc` baseline was reported blocked by unrelated existing core/dependency diagnostics, including missing `XRHandedness`, with no changed-file diagnostics.
 
-Reopened by root's PR #19 blocker after review found that minimap navigation, wire selection, and context-menu selection could bypass the active gesture's pointer ownership. RED is pending the local test lease against exact base `f5f366f643890ea35e62514d80f9f09af74f9a73`; the focused command will run the existing `"pans empty canvas without mutating graph layout and preserves node drag and wheel zoom"` Playwright scenario with the regression test present and the ownership gate absent. GREEN, code review, and final resolution remain pending.
+### Active gesture ownership slice
+
+Root reopened the issue after review found that minimap navigation, wire selection, and context-menu selection could bypass the active gesture owner. [PR #29](https://github.com/alexchuber/Babylon.js/pull/29) addressed those escapes.
+
+- Worker-reported RED on exact base `f5a284ded5b1176fbfb75faf97cafd2ecc929dfd`: the four ownership Playwright cases produced one retained pass and three expected failures (ordinary node collapse, aggregate expansion, and visible/actionable context menus), and the ContextMenu unit produced one expected failure because disabling left an open menu visible.
+- Worker-reported GREEN at `2ccafbede2b3379b99c861b69c1829b0d31c38a2`: focused units `38/38`, focused ownership/existing-pan Playwright `5/5` with `--workers=1 --retries=0`, Node Assets Editor deployment build, full format/lint, and changed-file Prettier/ESLint/diff checks passed.
+- The PR #29 worker reported automatic dual-lens `/code-review` clean after fixing a stale-element assertion and a React-portal pointer-routing escape. GitHub records no PR #29 check runs or reviews, so the RED/GREEN and review results above are explicitly worker-reported.
+- The PR #29 worker also reported that standalone Node Assets Editor `tsc -b` was baseline-blocked by 23 missing built GUI/serializer/viewer modules, with no changed-file diagnostics; that probe was not reported as GREEN.
+- PR #29 merged into the PR #22 branch as `a577d18736b7ad77e48b768b074c141eafcf5d97`; it did not resolve this tracker issue or complete root integration.
+
+### Corrected lifecycle proof
+
+An independent exact-range audit of `a577d18736b7ad77e48b768b074c141eafcf5d97` found that the browser tests used an orphan foreign touch move, mixed a real mouse stream with synthetic cancellation for an assumed pointer ID, and treated lost capture as a terminal event. The focused follow-up now uses complete, distinct streams: a synthetic touch owner; real foreign mouse down/move/up actions; separate touch pointerup and pointercancel cases; and lost capture with the owner button still down followed by the owner's inert eventual pointerup.
+
+The corrected five-case Playwright command passed `5/5` with `--workers=1 --retries=0`; the gesture and ContextMenu units passed `36/36`; changed-test Prettier, ESLint, and the CRLF-aware diff check passed. The first local Playwright invocation discovered zero tests because `@tools/test-tools` had not yet been built; after building that prerequisite, the complete five-case rerun passed and is the only browser result counted here. Automatic dual-lens `/code-review` found no actionable Critical or Warning issues. Root's independent final validation/integration remains pending.

--- a/.scratch/graph-canvas-panning/issues/01-pan-empty-canvas.md
+++ b/.scratch/graph-canvas-panning/issues/01-pan-empty-canvas.md
@@ -9,6 +9,7 @@ Status: resolved
 Make the Node Assets Editor graph camera move when an author drags empty canvas with an unmodified primary pointer. Preserve modified-drag marquee selection, empty-canvas click deselection, middle-button and Space-plus-primary pan aliases, and all child graph interactions. The gesture must remain predictable across zoom levels, pointer types, canvas boundaries, cancellation, and multiple simultaneous pointers, with grab/grabbing feedback. Keep the change inside the existing generic node-graph interaction and camera seams. Panning is view state only and must not mutate NodeAssets graph data, create undo entries, or trigger builds.
 
 ## Acceptance criteria
+
 - [x] Unmodified primary drag beginning on empty canvas pans rendered nodes, wires, frames, grid, and minimap viewport by the viewport-pixel pointer delta at every supported zoom.
 - [x] Primary touch and pen drags use the same behavior; the initiating pointer exclusively owns the gesture until completion/cancellation.
 - [x] Middle-button and Space-plus-primary pan aliases remain.

--- a/.scratch/graph-canvas-panning/issues/01-pan-empty-canvas.md
+++ b/.scratch/graph-canvas-panning/issues/01-pan-empty-canvas.md
@@ -1,4 +1,4 @@
-Status: ready-for-agent
+Status: resolved
 
 ## Parent
 `.scratch/graph-canvas-panning/PRD.md`
@@ -7,18 +7,23 @@ Status: ready-for-agent
 Make the Node Assets Editor graph camera move when an author drags empty canvas with an unmodified primary pointer. Preserve modified-drag marquee selection, empty-canvas click deselection, middle-button and Space-plus-primary pan aliases, and all child graph interactions. The gesture must remain predictable across zoom levels, pointer types, canvas boundaries, cancellation, and multiple simultaneous pointers, with grab/grabbing feedback. Keep the change inside the existing generic node-graph interaction and camera seams. Panning is view state only and must not mutate NodeAssets graph data, create undo entries, or trigger builds.
 
 ## Acceptance criteria
-- [ ] Unmodified primary drag beginning on empty canvas pans rendered nodes, wires, frames, grid, and minimap viewport by the viewport-pixel pointer delta at every supported zoom.
-- [ ] Primary touch and pen drags use the same behavior; the initiating pointer exclusively owns the gesture until completion/cancellation.
-- [ ] Middle-button and Space-plus-primary pan aliases remain.
-- [ ] Shift/Control/Command primary drag retains additive marquee selection.
-- [ ] Primary click without movement on empty canvas clears selection; moved pan preserves selection.
-- [ ] Node drag, frame drag, port-to-wire drag, wire selection, context menus, palette drop, minimap navigation, initial fit, zoom-to-fit, and wheel zoom keep their behavior.
-- [ ] Pan continues outside the canvas and cancellation clears transient state without committing marquee/wire or leaving an editor interaction open.
-- [ ] Canvas uses `grab` idle and `grabbing` during pan without overriding child cursors.
-- [ ] Regression tests are written first at the gesture seam for routing, latching, completion, cancellation, and applicable pointer ownership.
-- [ ] Playwright proves rendered primary-drag panning and representative node-drag + wheel-zoom behavior afterward.
-- [ ] Scoped unit tests, focused Playwright, package type-check/build, and applicable lint/format checks pass.
-- [ ] `/code-review` has no unresolved high-confidence findings.
+- [x] Unmodified primary drag beginning on empty canvas pans rendered nodes, wires, frames, grid, and minimap viewport by the viewport-pixel pointer delta at every supported zoom.
+- [x] Primary touch and pen drags use the same behavior; the initiating pointer exclusively owns the gesture until completion/cancellation.
+- [x] Middle-button and Space-plus-primary pan aliases remain.
+- [x] Shift/Control/Command primary drag retains additive marquee selection.
+- [x] Primary click without movement on empty canvas clears selection; moved pan preserves selection.
+- [x] Node drag, frame drag, port-to-wire drag, wire selection, context menus, palette drop, minimap navigation, initial fit, zoom-to-fit, and wheel zoom keep their behavior.
+- [x] Pan continues outside the canvas and cancellation clears transient state without committing marquee/wire or leaving an editor interaction open.
+- [x] Canvas uses `grab` idle and `grabbing` during pan without overriding child cursors.
+- [x] Regression tests are written first at the gesture seam for routing, latching, completion, cancellation, and applicable pointer ownership.
+- [x] Playwright proves rendered primary-drag panning and representative node-drag + wheel-zoom behavior afterward.
+- [x] Scoped unit tests, focused Playwright, package type-check/build, and applicable lint/format checks pass.
+- [x] `/code-review` has no unresolved high-confidence findings.
 
-## Blocked by
-None - can start immediately.
+## Outcome (landed)
+
+Done as a docs follow-up on `feat/nae/graph-canvas-pan`.
+
+- The ticket is now `Status: resolved`.
+- The implementation PR landed as `2858fcff583192ddd14218f81dc7eab6cbbcb63c` on `feat/nae/graph-canvas-pan`.
+- Worker-reported evidence: targeted unit tests `35/35`, Playwright `2/2`, ESLint/Prettier/build/precommit pass, and clean `/code-review`.

--- a/.scratch/graph-canvas-panning/issues/01-pan-empty-canvas.md
+++ b/.scratch/graph-canvas-panning/issues/01-pan-empty-canvas.md
@@ -1,4 +1,4 @@
-Status: resolved
+Status: ready-for-agent
 
 ## Parent
 
@@ -11,17 +11,17 @@ Make the Node Assets Editor graph camera move when an author drags empty canvas 
 ## Acceptance criteria
 
 - [x] Unmodified primary drag beginning on empty canvas pans rendered nodes, wires, frames, grid, and minimap viewport by the viewport-pixel pointer delta at every supported zoom.
-- [x] Primary touch and pen drags use the same behavior; the initiating pointer exclusively owns the gesture until completion/cancellation.
+- [ ] Primary touch and pen drags use the same behavior; the initiating pointer exclusively owns the gesture until completion/cancellation.
 - [x] Middle-button and Space-plus-primary pan aliases remain.
 - [x] Shift/Control/Command primary drag retains additive marquee selection.
 - [x] Primary click without movement on empty canvas clears selection; moved pan preserves selection.
-- [x] Node drag, frame drag, port-to-wire drag, wire selection, context menus, palette drop, minimap navigation, initial fit, zoom-to-fit, and wheel zoom keep their behavior.
+- [ ] Node drag, frame drag, port-to-wire drag, wire selection, context menus, palette drop, minimap navigation, initial fit, zoom-to-fit, and wheel zoom keep their behavior.
 - [x] Pan continues outside the canvas and cancellation clears transient state without committing marquee/wire or leaving an editor interaction open.
 - [x] Canvas uses `grab` idle and `grabbing` during pan without overriding child cursors.
-- [x] Regression tests are written first at the gesture seam for routing, latching, completion, cancellation, and applicable pointer ownership.
+- [ ] Regression tests are written first at the gesture seam for routing, latching, completion, cancellation, and applicable pointer ownership.
 - [x] Playwright proves rendered primary-drag panning and representative node-drag + wheel-zoom behavior afterward.
-- [x] Scoped unit tests, focused Playwright, package type-check/build, and applicable lint/format checks pass.
-- [x] `/code-review` has no unresolved high-confidence findings.
+- [ ] Scoped unit tests, focused Playwright, package type-check/build, and applicable lint/format checks pass.
+- [ ] `/code-review` has no unresolved high-confidence findings.
 
 ## Outcome (landed)
 
@@ -34,3 +34,7 @@ Done as a docs follow-up on `feat/nae/graph-canvas-pan`.
 ## Comments
 
 Implemented in [PR #15](https://github.com/alexchuber/Babylon.js/pull/15) at `2858fcff583192ddd14218f81dc7eab6cbbcb63c`. Verification passed with gesture unit tests `35/35`, focused Playwright `2/2`, targeted ESLint and Prettier, the Node Assets Editor deployment build, and precommit checks. Both `/code-review` lenses finished with no unresolved high-confidence findings. The standalone package-wide `tsc` baseline remains blocked by unrelated existing core/dependency diagnostics, including missing `XRHandedness`; no changed-file diagnostics were reported.
+
+### Follow-up: active gesture ownership
+
+Reopened after root review found that minimap navigation, wire selection, and context-menu selection could bypass the active gesture's pointer ownership. The owner-aware gate and browser regression are pending validation under the local test lease.

--- a/.scratch/graph-canvas-panning/issues/01-pan-empty-canvas.md
+++ b/.scratch/graph-canvas-panning/issues/01-pan-empty-canvas.md
@@ -1,0 +1,24 @@
+Status: ready-for-agent
+
+## Parent
+`.scratch/graph-canvas-panning/PRD.md`
+
+## What to build
+Make the Node Assets Editor graph camera move when an author drags empty canvas with an unmodified primary pointer. Preserve modified-drag marquee selection, empty-canvas click deselection, middle-button and Space-plus-primary pan aliases, and all child graph interactions. The gesture must remain predictable across zoom levels, pointer types, canvas boundaries, cancellation, and multiple simultaneous pointers, with grab/grabbing feedback. Keep the change inside the existing generic node-graph interaction and camera seams. Panning is view state only and must not mutate NodeAssets graph data, create undo entries, or trigger builds.
+
+## Acceptance criteria
+- [ ] Unmodified primary drag beginning on empty canvas pans rendered nodes, wires, frames, grid, and minimap viewport by the viewport-pixel pointer delta at every supported zoom.
+- [ ] Primary touch and pen drags use the same behavior; the initiating pointer exclusively owns the gesture until completion/cancellation.
+- [ ] Middle-button and Space-plus-primary pan aliases remain.
+- [ ] Shift/Control/Command primary drag retains additive marquee selection.
+- [ ] Primary click without movement on empty canvas clears selection; moved pan preserves selection.
+- [ ] Node drag, frame drag, port-to-wire drag, wire selection, context menus, palette drop, minimap navigation, initial fit, zoom-to-fit, and wheel zoom keep their behavior.
+- [ ] Pan continues outside the canvas and cancellation clears transient state without committing marquee/wire or leaving an editor interaction open.
+- [ ] Canvas uses `grab` idle and `grabbing` during pan without overriding child cursors.
+- [ ] Regression tests are written first at the gesture seam for routing, latching, completion, cancellation, and applicable pointer ownership.
+- [ ] Playwright proves rendered primary-drag panning and representative node-drag + wheel-zoom behavior afterward.
+- [ ] Scoped unit tests, focused Playwright, package type-check/build, and applicable lint/format checks pass.
+- [ ] `/code-review` has no unresolved high-confidence findings.
+
+## Blocked by
+None - can start immediately.

--- a/.scratch/graph-canvas-panning/issues/01-pan-empty-canvas.md
+++ b/.scratch/graph-canvas-panning/issues/01-pan-empty-canvas.md
@@ -30,3 +30,7 @@ Done as a docs follow-up on `feat/nae/graph-canvas-pan`.
 - The ticket is now `Status: resolved`.
 - The implementation PR landed as `2858fcff583192ddd14218f81dc7eab6cbbcb63c` on `feat/nae/graph-canvas-pan`.
 - Worker-reported evidence: targeted unit tests `35/35`, Playwright `2/2`, ESLint/Prettier/build/precommit pass, and clean `/code-review`.
+
+## Comments
+
+Implemented in [PR #15](https://github.com/alexchuber/Babylon.js/pull/15) at `2858fcff583192ddd14218f81dc7eab6cbbcb63c`. Verification passed with gesture unit tests `35/35`, focused Playwright `2/2`, targeted ESLint and Prettier, the Node Assets Editor deployment build, and precommit checks. Both `/code-review` lenses finished with no unresolved high-confidence findings. The standalone package-wide `tsc` baseline remains blocked by unrelated existing core/dependency diagnostics, including missing `XRHandedness`; no changed-file diagnostics were reported.

--- a/.scratch/graph-canvas-panning/issues/01-pan-empty-canvas.md
+++ b/.scratch/graph-canvas-panning/issues/01-pan-empty-canvas.md
@@ -1,4 +1,4 @@
-Status: ready-for-agent
+Status: in-progress
 
 ## Parent
 
@@ -37,4 +37,4 @@ Implemented in [PR #15](https://github.com/alexchuber/Babylon.js/pull/15) at `28
 
 ### Follow-up: active gesture ownership
 
-Reopened after root review found that minimap navigation, wire selection, and context-menu selection could bypass the active gesture's pointer ownership. The owner-aware gate and browser regression are pending validation under the local test lease.
+Reopened by root's PR #19 blocker after review found that minimap navigation, wire selection, and context-menu selection could bypass the active gesture's pointer ownership. RED is pending the local test lease against exact base `f5f366f643890ea35e62514d80f9f09af74f9a73`; the focused command will run the existing `"pans empty canvas without mutating graph layout and preserves node drag and wheel zoom"` Playwright scenario with the regression test present and the ownership gate absent. GREEN, code review, and final resolution remain pending.

--- a/.scratch/graph-canvas-panning/issues/01-pan-empty-canvas.md
+++ b/.scratch/graph-canvas-panning/issues/01-pan-empty-canvas.md
@@ -1,4 +1,4 @@
-Status: ready-for-agent
+Status: resolved
 
 ## Parent
 `.scratch/graph-canvas-panning/PRD.md`
@@ -7,18 +7,24 @@ Status: ready-for-agent
 Make the Node Assets Editor graph camera move when an author drags empty canvas with an unmodified primary pointer. Preserve modified-drag marquee selection, empty-canvas click deselection, middle-button and Space-plus-primary pan aliases, and all child graph interactions. The gesture must remain predictable across zoom levels, pointer types, canvas boundaries, cancellation, and multiple simultaneous pointers, with grab/grabbing feedback. Keep the change inside the existing generic node-graph interaction and camera seams. Panning is view state only and must not mutate NodeAssets graph data, create undo entries, or trigger builds.
 
 ## Acceptance criteria
-- [ ] Unmodified primary drag beginning on empty canvas pans rendered nodes, wires, frames, grid, and minimap viewport by the viewport-pixel pointer delta at every supported zoom.
-- [ ] Primary touch and pen drags use the same behavior; the initiating pointer exclusively owns the gesture until completion/cancellation.
-- [ ] Middle-button and Space-plus-primary pan aliases remain.
-- [ ] Shift/Control/Command primary drag retains additive marquee selection.
-- [ ] Primary click without movement on empty canvas clears selection; moved pan preserves selection.
-- [ ] Node drag, frame drag, port-to-wire drag, wire selection, context menus, palette drop, minimap navigation, initial fit, zoom-to-fit, and wheel zoom keep their behavior.
-- [ ] Pan continues outside the canvas and cancellation clears transient state without committing marquee/wire or leaving an editor interaction open.
-- [ ] Canvas uses `grab` idle and `grabbing` during pan without overriding child cursors.
-- [ ] Regression tests are written first at the gesture seam for routing, latching, completion, cancellation, and applicable pointer ownership.
-- [ ] Playwright proves rendered primary-drag panning and representative node-drag + wheel-zoom behavior afterward.
-- [ ] Scoped unit tests, focused Playwright, package type-check/build, and applicable lint/format checks pass.
-- [ ] `/code-review` has no unresolved high-confidence findings.
+- [x] Unmodified primary drag beginning on empty canvas pans rendered nodes, wires, frames, grid, and minimap viewport by the viewport-pixel pointer delta at every supported zoom.
+- [x] Primary touch and pen drags use the same behavior; the initiating pointer exclusively owns the gesture until completion/cancellation.
+- [x] Middle-button and Space-plus-primary pan aliases remain.
+- [x] Shift/Control/Command primary drag retains additive marquee selection.
+- [x] Primary click without movement on empty canvas clears selection; moved pan preserves selection.
+- [x] Node drag, frame drag, port-to-wire drag, wire selection, context menus, palette drop, minimap navigation, initial fit, zoom-to-fit, and wheel zoom keep their behavior.
+- [x] Pan continues outside the canvas and cancellation clears transient state without committing marquee/wire or leaving an editor interaction open.
+- [x] Canvas uses `grab` idle and `grabbing` during pan without overriding child cursors.
+- [x] Regression tests are written first at the gesture seam for routing, latching, completion, cancellation, and applicable pointer ownership.
+- [x] Playwright proves rendered primary-drag panning and representative node-drag + wheel-zoom behavior afterward.
+- [x] Scoped unit tests, focused Playwright, package type-check/build, and applicable lint/format checks pass.
+- [x] `/code-review` has no unresolved high-confidence findings.
 
 ## Blocked by
 None - can start immediately.
+
+## Answer
+
+Implemented unmodified primary-pointer panning through the existing gesture interpreter and graph camera seams. The initiating pointer owns every active gesture through completion or cancellation, background clicks retain deselection, modified drags retain marquee selection, middle-button and Space aliases remain, and pointer capture/lost-capture cleanup prevents stuck interactions. The canvas now exposes grab/grabbing feedback without changing graph data.
+
+Verification completed with 35 focused gesture unit tests, focused rendered panning and existing port-to-wire Playwright regressions, targeted ESLint and Prettier checks, and the Node Assets Editor deployment build. The standalone package TypeScript command remains blocked by unrelated pre-existing core diagnostics, with no diagnostics in the changed files. Both code-review lenses have no unresolved high-confidence findings.

--- a/packages/dev/sharedUiComponents/src/fluent/primitives/contextMenu.tsx
+++ b/packages/dev/sharedUiComponents/src/fluent/primitives/contextMenu.tsx
@@ -1,4 +1,4 @@
-import { type ReactElement, type ReactNode, forwardRef, useState } from "react";
+import { type ReactElement, type ReactNode, forwardRef, useEffect, useState } from "react";
 import {
     Menu,
     MenuTrigger,
@@ -185,12 +185,22 @@ export const ContextMenu = forwardRef<HTMLButtonElement, ContextMenuProps>((prop
     const classes = useStyles();
 
     const handleOpenChange = (_: unknown, data: { open: boolean }) => {
+        if (disabled && data.open) {
+            return;
+        }
         setOpen(data.open);
         onOpenChange?.(data.open);
     };
 
+    useEffect(() => {
+        if (disabled && open) {
+            setOpen(false);
+            onOpenChange?.(false);
+        }
+    }, [disabled, open, onOpenChange]);
+
     return (
-        <Menu openOnContext open={open} onOpenChange={handleOpenChange}>
+        <Menu openOnContext open={disabled ? false : open} onOpenChange={handleOpenChange}>
             <MenuTrigger disableButtonEnhancement>
                 {props.trigger ?? (
                     <Button

--- a/packages/dev/sharedUiComponents/test/unit/fluent/contextMenu.test.tsx
+++ b/packages/dev/sharedUiComponents/test/unit/fluent/contextMenu.test.tsx
@@ -1,0 +1,64 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { describe, expect, it, vi } from "vitest";
+
+import { ContextMenu } from "../../../src/fluent/primitives/contextMenu";
+
+describe("ContextMenu", () => {
+    it("closes an open custom-trigger menu and suppresses reopening when disabled", async () => {
+        Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true, NodeFilter: window.NodeFilter });
+        const container = document.createElement("div");
+        document.body.appendChild(container);
+        const root = createRoot(container);
+        const onClick = vi.fn();
+        const render = (disabled: boolean) => (
+            <ContextMenu disabled={disabled} items={[{ key: "action", label: "Action", onClick }]} trigger={<div data-testid="custom-context-trigger">Trigger</div>} />
+        );
+
+        await act(async () => {
+            root.render(render(false));
+        });
+        const trigger = container.querySelector('[data-testid="custom-context-trigger"]');
+        if (!trigger) {
+            throw new Error("The custom context-menu trigger did not render.");
+        }
+
+        await act(async () => {
+            trigger.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true }));
+        });
+        expect(document.body.querySelector('[role="menu"]')).not.toBeNull();
+
+        await act(async () => {
+            root.render(render(true));
+        });
+        expect(document.body.querySelector('[role="menu"]')).toBeNull();
+
+        await act(async () => {
+            trigger.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true }));
+        });
+        expect(document.body.querySelector('[role="menu"]')).toBeNull();
+        expect(onClick).not.toHaveBeenCalled();
+
+        await act(async () => {
+            root.render(render(false));
+        });
+        await act(async () => {
+            trigger.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true }));
+        });
+        const menuItem = document.body.querySelector('[role="menuitem"]');
+        if (!menuItem) {
+            throw new Error("The custom context-menu action did not render after re-enabling.");
+        }
+        await act(async () => {
+            menuItem.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+        });
+        expect(onClick).toHaveBeenCalledOnce();
+
+        await act(async () => {
+            root.unmount();
+        });
+        container.remove();
+    });
+});

--- a/packages/tools/nodeAssetsEditor/src/nodeGraph/components/GraphCanvas.tsx
+++ b/packages/tools/nodeAssetsEditor/src/nodeGraph/components/GraphCanvas.tsx
@@ -21,6 +21,7 @@ import { FindNearestConnectablePort, FindNodesInRegion } from "../canvasHitTest"
 import {
     type Gesture,
     type GestureAction,
+    type GestureResult,
     type MarqueeRect,
     type PendingWire,
     BeginBackgroundGesture,
@@ -28,6 +29,7 @@ import {
     BeginFrameGesture,
     BeginPortGesture,
     AdvanceGesture,
+    CancelGesture,
     CompleteGesture,
 } from "../gestureInterpreter";
 import { type ContextMenuTarget, type CanvasContextValue, CanvasContextProvider } from "./canvasContext";
@@ -102,6 +104,7 @@ export const GraphCanvas: FunctionComponent<{ context: EditorContextValue }> = (
     const [size, setSize] = useState({ width: 0, height: 0 });
     const [pendingWire, setPendingWire] = useState<PendingWire | null>(null);
     const [marquee, setMarquee] = useState<MarqueeRect | null>(null);
+    const [isPanning, setIsPanning] = useState(false);
     const [contextTarget, setContextTarget] = useState<ContextMenuTarget>({ kind: "canvas" });
 
     const setCamera = useCallback((next: Camera | ((current: Camera) => Camera)) => {
@@ -220,17 +223,74 @@ export const GraphCanvas: FunctionComponent<{ context: EditorContextValue }> = (
         [state, setCamera, attemptConnect]
     );
 
+    const applyGestureResult = useCallback(
+        (result: GestureResult) => {
+            const wasPanning = gestureRef.current.kind === "pan";
+            const willPan = result.gesture.kind === "pan";
+            gestureRef.current = result.gesture;
+            if (wasPanning !== willPan) {
+                setIsPanning(willPan);
+            }
+            executeActions(result.actions);
+        },
+        [executeActions]
+    );
+
+    const capturePointer = useCallback((pointerId: number) => {
+        const element = containerRef.current;
+        if (element && !element.hasPointerCapture(pointerId)) {
+            element.setPointerCapture(pointerId);
+        }
+    }, []);
+
+    const releasePointer = useCallback((pointerId: number) => {
+        const element = containerRef.current;
+        if (element?.hasPointerCapture(pointerId)) {
+            element.releasePointerCapture(pointerId);
+        }
+    }, []);
+
+    const startGesture = useCallback(
+        (event: ReactPointerEvent, result: GestureResult) => {
+            if (gestureRef.current.kind !== "none" || result.gesture.kind === "none") {
+                return;
+            }
+            capturePointer(event.pointerId);
+            applyGestureResult(result);
+        },
+        [capturePointer, applyGestureResult]
+    );
+
+    const cancelGesture = useCallback(
+        (pointerId: number, releaseCapture: boolean) => {
+            const current = gestureRef.current;
+            if (current.kind === "none" || current.pointerId !== pointerId) {
+                return;
+            }
+            applyGestureResult(CancelGesture(current, { pointerId }));
+            if (releaseCapture) {
+                releasePointer(pointerId);
+            }
+        },
+        [applyGestureResult, releasePointer]
+    );
+
     // Persistent window listeners drive the active gesture so dragging continues outside the canvas.
     useEffect(() => {
         const onPointerMove = (event: PointerEvent) => {
+            const current = gestureRef.current;
+            if (current.kind === "none" || current.pointerId !== event.pointerId) {
+                return;
+            }
             const { world, local } = pointerCoords(event.clientX, event.clientY);
-            const { gesture, actions } = AdvanceGesture(gestureRef.current, { world, local });
-            gestureRef.current = gesture;
-            executeActions(actions);
+            applyGestureResult(AdvanceGesture(current, { pointerId: event.pointerId, world, local }));
         };
 
         const onPointerUp = (event: PointerEvent) => {
             const current = gestureRef.current;
+            if (current.kind === "none" || current.pointerId !== event.pointerId) {
+                return;
+            }
             const world = screenToWorld(event.clientX, event.clientY);
             let resolvedTargetPortId: string | undefined;
             if (current.kind === "wire") {
@@ -248,18 +308,21 @@ export const GraphCanvas: FunctionComponent<{ context: EditorContextValue }> = (
                         canConnect: (from, to) => state.canConnect(from, to),
                     });
             }
-            const { gesture, actions } = CompleteGesture(current, { world, resolvedTargetPortId });
-            gestureRef.current = gesture;
-            executeActions(actions);
+            applyGestureResult(CompleteGesture(current, { pointerId: event.pointerId, world, resolvedTargetPortId }));
+            releasePointer(event.pointerId);
         };
+
+        const onPointerCancel = (event: PointerEvent) => cancelGesture(event.pointerId, true);
 
         window.addEventListener("pointermove", onPointerMove);
         window.addEventListener("pointerup", onPointerUp);
+        window.addEventListener("pointercancel", onPointerCancel);
         return () => {
             window.removeEventListener("pointermove", onPointerMove);
             window.removeEventListener("pointerup", onPointerUp);
+            window.removeEventListener("pointercancel", onPointerCancel);
         };
-    }, [state, screenToWorld, pointerCoords, executeActions]);
+    }, [state, screenToWorld, pointerCoords, applyGestureResult, releasePointer, cancelGesture]);
 
     // Keyboard shortcuts (ignored while typing in a form control so the panes keep working).
     useEffect(() => {
@@ -351,29 +414,36 @@ export const GraphCanvas: FunctionComponent<{ context: EditorContextValue }> = (
         () => ({
             editor: context,
             beginNodeInteraction: (nodeId, event) => {
-                const { gesture, actions } = BeginNodeGesture({
-                    nodeId,
-                    additive: event.shiftKey || event.ctrlKey || event.metaKey,
-                    isSelected: state.isNodeSelected(nodeId),
-                    world: screenToWorld(event.clientX, event.clientY),
-                });
-                executeActions(actions);
-                gestureRef.current = gesture;
+                if (gestureRef.current.kind !== "none") {
+                    return;
+                }
+                startGesture(
+                    event,
+                    BeginNodeGesture({
+                        pointerId: event.pointerId,
+                        nodeId,
+                        additive: event.shiftKey || event.ctrlKey || event.metaKey,
+                        isSelected: state.isNodeSelected(nodeId),
+                        world: screenToWorld(event.clientX, event.clientY),
+                    })
+                );
             },
             beginFrameInteraction: (frameId, event) => {
-                const { gesture, actions } = BeginFrameGesture({ frameId, world: screenToWorld(event.clientX, event.clientY) });
-                executeActions(actions);
-                gestureRef.current = gesture;
+                if (gestureRef.current.kind !== "none") {
+                    return;
+                }
+                startGesture(event, BeginFrameGesture({ pointerId: event.pointerId, frameId, world: screenToWorld(event.clientX, event.clientY) }));
             },
             beginPortInteraction: (portId, event) => {
+                if (gestureRef.current.kind !== "none") {
+                    return;
+                }
                 const node = state.getPortNode(portId);
                 const anchor = node ? GetPortAnchor(node, portId) : undefined;
                 if (!anchor) {
                     return;
                 }
-                const { gesture, actions } = BeginPortGesture({ portId, anchor, world: screenToWorld(event.clientX, event.clientY) });
-                executeActions(actions);
-                gestureRef.current = gesture;
+                startGesture(event, BeginPortGesture({ pointerId: event.pointerId, portId, anchor, world: screenToWorld(event.clientX, event.clientY) }));
             },
             selectWire: (wireId) => state.selectWire(wireId),
             openContextMenu: (target) => {
@@ -383,7 +453,7 @@ export const GraphCanvas: FunctionComponent<{ context: EditorContextValue }> = (
                 setContextTarget(target);
             },
         }),
-        [context, state, screenToWorld, executeActions]
+        [context, state, screenToWorld, startGesture]
     );
 
     const onBackgroundPointerDown = (event: ReactPointerEvent<HTMLDivElement>) => {
@@ -394,18 +464,18 @@ export const GraphCanvas: FunctionComponent<{ context: EditorContextValue }> = (
         containerRef.current?.focus();
 
         const { world, local } = pointerCoords(event.clientX, event.clientY);
-        const { gesture, actions } = BeginBackgroundGesture({
+        const result = BeginBackgroundGesture({
+            pointerId: event.pointerId,
             button: event.button,
             spaceHeld: spaceHeldRef.current,
             additive: event.shiftKey || event.ctrlKey || event.metaKey,
             world,
             local,
         });
-        if (gesture.kind === "pan") {
+        if (result.gesture.kind === "pan") {
             event.preventDefault();
         }
-        executeActions(actions);
-        gestureRef.current = gesture;
+        startGesture(event, result);
     };
 
     const onDragOver = (event: ReactDragEvent<HTMLDivElement>) => {
@@ -476,6 +546,7 @@ export const GraphCanvas: FunctionComponent<{ context: EditorContextValue }> = (
         backgroundImage: `radial-gradient(circle, ${tokens.colorNeutralStroke2} ${dotRadius}px, transparent ${dotRadius * 1.5}px)`,
         backgroundSize: `${gridSpacing}px ${gridSpacing}px`,
         backgroundPosition: `${camera.x}px ${camera.y}px`,
+        cursor: isPanning ? "grabbing" : "grab",
     };
 
     return (
@@ -486,7 +557,9 @@ export const GraphCanvas: FunctionComponent<{ context: EditorContextValue }> = (
             tabIndex={0}
             role="application"
             aria-label="Node graph canvas"
+            data-panning={isPanning ? "true" : undefined}
             onPointerDown={onBackgroundPointerDown}
+            onLostPointerCapture={(event) => cancelGesture(event.pointerId, false)}
             onDragOver={onDragOver}
             onDrop={onDrop}
         >

--- a/packages/tools/nodeAssetsEditor/src/nodeGraph/components/GraphCanvas.tsx
+++ b/packages/tools/nodeAssetsEditor/src/nodeGraph/components/GraphCanvas.tsx
@@ -2,6 +2,7 @@ import {
     type CSSProperties,
     type DragEvent as ReactDragEvent,
     type FunctionComponent,
+    type MouseEvent as ReactMouseEvent,
     type PointerEvent as ReactPointerEvent,
     useCallback,
     useEffect,
@@ -46,6 +47,11 @@ const GridSpacing = 24;
 const PasteOffset = 24;
 // Screen-space radius (px) within which a released wire snaps to the nearest compatible port.
 const ConnectSnapRadius = 28;
+
+type ActiveGestureOwner = {
+    readonly kind: Exclude<Gesture["kind"], "none">;
+    readonly pointerId: number;
+};
 
 const useStyles = makeStyles({
     root: {
@@ -104,8 +110,10 @@ export const GraphCanvas: FunctionComponent<{ context: EditorContextValue }> = (
     const [size, setSize] = useState({ width: 0, height: 0 });
     const [pendingWire, setPendingWire] = useState<PendingWire | null>(null);
     const [marquee, setMarquee] = useState<MarqueeRect | null>(null);
-    const [isPanning, setIsPanning] = useState(false);
+    const [activeGestureOwner, setActiveGestureOwner] = useState<ActiveGestureOwner | null>(null);
     const [contextTarget, setContextTarget] = useState<ContextMenuTarget>({ kind: "canvas" });
+    const isGestureActive = activeGestureOwner !== null;
+    const isPanning = activeGestureOwner?.kind === "pan";
 
     const setCamera = useCallback((next: Camera | ((current: Camera) => Camera)) => {
         const value = typeof next === "function" ? (next as (current: Camera) => Camera)(cameraRef.current) : next;
@@ -225,11 +233,12 @@ export const GraphCanvas: FunctionComponent<{ context: EditorContextValue }> = (
 
     const applyGestureResult = useCallback(
         (result: GestureResult) => {
-            const wasPanning = gestureRef.current.kind === "pan";
-            const willPan = result.gesture.kind === "pan";
+            const current = gestureRef.current;
+            const ownerChanged =
+                current.kind !== result.gesture.kind || (current.kind !== "none" && result.gesture.kind !== "none" && current.pointerId !== result.gesture.pointerId);
             gestureRef.current = result.gesture;
-            if (wasPanning !== willPan) {
-                setIsPanning(willPan);
+            if (ownerChanged) {
+                setActiveGestureOwner(result.gesture.kind === "none" ? null : { kind: result.gesture.kind, pointerId: result.gesture.pointerId });
             }
             executeActions(result.actions);
         },
@@ -275,7 +284,13 @@ export const GraphCanvas: FunctionComponent<{ context: EditorContextValue }> = (
         [applyGestureResult, releasePointer]
     );
 
-    const canHandleIndependentPointerAction = useCallback(() => gestureRef.current.kind === "none", []);
+    const runWhenIdle = useCallback((action: () => void): boolean => {
+        if (gestureRef.current.kind !== "none") {
+            return false;
+        }
+        action();
+        return true;
+    }, []);
 
     // Persistent window listeners drive the active gesture so dragging continues outside the canvas.
     useEffect(() => {
@@ -448,25 +463,52 @@ export const GraphCanvas: FunctionComponent<{ context: EditorContextValue }> = (
                 startGesture(event, BeginPortGesture({ pointerId: event.pointerId, portId, anchor, world: screenToWorld(event.clientX, event.clientY) }));
             },
             selectWire: (wireId) => {
-                if (!canHandleIndependentPointerAction()) {
-                    return;
-                }
-                state.selectWire(wireId);
+                runWhenIdle(() => state.selectWire(wireId));
             },
-            openContextMenu: (target) => {
-                if (!canHandleIndependentPointerAction()) {
-                    return;
+            openContextMenu: (target, event) => {
+                const handled = runWhenIdle(() => {
+                    if (target.kind === "node" && !state.isNodeSelected(target.nodeId)) {
+                        state.selectNodes([target.nodeId]);
+                    }
+                    setContextTarget(target);
+                });
+                if (!handled) {
+                    event.preventDefault();
+                    event.stopPropagation();
                 }
-                if (target.kind === "node" && !state.isNodeSelected(target.nodeId)) {
-                    state.selectNodes([target.nodeId]);
-                }
-                setContextTarget(target);
             },
+            runWhenIdle,
         }),
-        [context, state, screenToWorld, startGesture, canHandleIndependentPointerAction]
+        [context, state, screenToWorld, startGesture, runWhenIdle]
     );
 
+    const onPointerDownCapture = (event: ReactPointerEvent<HTMLDivElement>) => {
+        const current = gestureRef.current;
+        if (current.kind !== "none" && current.pointerId !== event.pointerId) {
+            event.preventDefault();
+            event.stopPropagation();
+        }
+    };
+
+    const onClickCapture = (event: ReactMouseEvent<HTMLDivElement>) => {
+        if (gestureRef.current.kind !== "none") {
+            event.preventDefault();
+            event.stopPropagation();
+        }
+    };
+
+    const onContextMenuCapture = (event: ReactMouseEvent<HTMLDivElement>) => {
+        const handled = runWhenIdle(() => setContextTarget({ kind: "canvas" }));
+        if (!handled) {
+            event.preventDefault();
+            event.stopPropagation();
+        }
+    };
+
     const onBackgroundPointerDown = (event: ReactPointerEvent<HTMLDivElement>) => {
+        if (!event.nativeEvent.composedPath().includes(event.currentTarget)) {
+            return;
+        }
         // A child view (node/port/frame) already claimed this gesture.
         if (gestureRef.current.kind !== "none") {
             return;
@@ -510,27 +552,35 @@ export const GraphCanvas: FunctionComponent<{ context: EditorContextValue }> = (
     const contextItems = useMemo<ContextMenuItem[]>(() => {
         if (contextTarget.kind === "wire") {
             const wireId = contextTarget.wireId;
-            return [{ key: "delete-wire", label: "Delete wire", onClick: () => state.removeWire(wireId) }];
+            return [{ key: "delete-wire", label: "Delete wire", onClick: () => runWhenIdle(() => state.removeWire(wireId)) }];
         }
         if (contextTarget.kind === "node") {
             const primary = state.primarySelectedNode;
             return [
-                { key: "copy", label: "Copy", onClick: () => (clipboardRef.current = state.copyNodes([...state.selectedNodeIds])) },
+                {
+                    key: "copy",
+                    label: "Copy",
+                    onClick: () =>
+                        runWhenIdle(() => {
+                            clipboardRef.current = state.copyNodes([...state.selectedNodeIds]);
+                        }),
+                },
                 {
                     key: "cut",
                     label: "Cut",
-                    onClick: () => {
-                        clipboardRef.current = state.copyNodes([...state.selectedNodeIds]);
-                        state.removeNodes([...state.selectedNodeIds]);
-                    },
+                    onClick: () =>
+                        runWhenIdle(() => {
+                            clipboardRef.current = state.copyNodes([...state.selectedNodeIds]);
+                            state.removeNodes([...state.selectedNodeIds]);
+                        }),
                 },
-                { key: "delete", label: "Delete", onClick: () => state.removeNodes([...state.selectedNodeIds]) },
+                { key: "delete", label: "Delete", onClick: () => runWhenIdle(() => state.removeNodes([...state.selectedNodeIds])) },
                 { key: "divider-1", type: "divider" },
                 {
                     key: "collapse",
                     label: primary?.collapsed ? "Expand" : "Collapse",
                     disabled: !primary,
-                    onClick: () => primary && state.setNodeCollapsed(primary.id, !primary.collapsed),
+                    onClick: () => runWhenIdle(() => primary && state.setNodeCollapsed(primary.id, !primary.collapsed)),
                 },
             ];
         }
@@ -539,11 +589,11 @@ export const GraphCanvas: FunctionComponent<{ context: EditorContextValue }> = (
                 key: "paste",
                 label: "Paste",
                 disabled: !clipboardRef.current,
-                onClick: () => clipboardRef.current && state.pasteNodes(clipboardRef.current, { x: PasteOffset, y: PasteOffset }),
+                onClick: () => runWhenIdle(() => clipboardRef.current && state.pasteNodes(clipboardRef.current, { x: PasteOffset, y: PasteOffset })),
             },
-            { key: "fit", label: "Zoom to fit", onClick: () => fitRef.current() },
+            { key: "fit", label: "Zoom to fit", onClick: () => runWhenIdle(() => fitRef.current()) },
         ];
-    }, [contextTarget, state]);
+    }, [contextTarget, state, runWhenIdle]);
 
     const worldStyle: CSSProperties = { transform: `translate(${camera.x}px, ${camera.y}px) scale(${camera.zoom})` };
     // The grid is locked to world space: both the dot spacing and the dot radius scale with zoom, so the
@@ -568,16 +618,20 @@ export const GraphCanvas: FunctionComponent<{ context: EditorContextValue }> = (
             role="application"
             aria-label="Node graph canvas"
             data-panning={isPanning ? "true" : undefined}
+            onPointerDownCapture={onPointerDownCapture}
             onPointerDown={onBackgroundPointerDown}
+            onClickCapture={onClickCapture}
+            onContextMenuCapture={onContextMenuCapture}
             onLostPointerCapture={(event) => cancelGesture(event.pointerId, false)}
             onDragOver={onDragOver}
             onDrop={onDrop}
         >
             <CanvasContextProvider value={canvasContextValue}>
                 <ContextMenu
+                    disabled={isGestureActive}
                     items={contextItems}
                     trigger={
-                        <div className={classes.trigger} onContextMenuCapture={() => setContextTarget({ kind: "canvas" })}>
+                        <div className={classes.trigger}>
                             <div className={classes.world} style={worldStyle}>
                                 {state.frames.map((frame) => (
                                     <GraphFrameView key={frame.id} frame={frame} />
@@ -595,10 +649,7 @@ export const GraphCanvas: FunctionComponent<{ context: EditorContextValue }> = (
                     camera={camera}
                     viewport={size}
                     onNavigate={(world) => {
-                        if (!canHandleIndependentPointerAction()) {
-                            return;
-                        }
-                        setCamera((current) => CenterCameraOn(world, size, current.zoom));
+                        runWhenIdle(() => setCamera((current) => CenterCameraOn(world, size, current.zoom)));
                     }}
                 />
             </CanvasContextProvider>

--- a/packages/tools/nodeAssetsEditor/src/nodeGraph/components/GraphCanvas.tsx
+++ b/packages/tools/nodeAssetsEditor/src/nodeGraph/components/GraphCanvas.tsx
@@ -275,6 +275,8 @@ export const GraphCanvas: FunctionComponent<{ context: EditorContextValue }> = (
         [applyGestureResult, releasePointer]
     );
 
+    const canHandleIndependentPointerAction = useCallback(() => gestureRef.current.kind === "none", []);
+
     // Persistent window listeners drive the active gesture so dragging continues outside the canvas.
     useEffect(() => {
         const onPointerMove = (event: PointerEvent) => {
@@ -445,15 +447,23 @@ export const GraphCanvas: FunctionComponent<{ context: EditorContextValue }> = (
                 }
                 startGesture(event, BeginPortGesture({ pointerId: event.pointerId, portId, anchor, world: screenToWorld(event.clientX, event.clientY) }));
             },
-            selectWire: (wireId) => state.selectWire(wireId),
+            selectWire: (wireId) => {
+                if (!canHandleIndependentPointerAction()) {
+                    return;
+                }
+                state.selectWire(wireId);
+            },
             openContextMenu: (target) => {
+                if (!canHandleIndependentPointerAction()) {
+                    return;
+                }
                 if (target.kind === "node" && !state.isNodeSelected(target.nodeId)) {
                     state.selectNodes([target.nodeId]);
                 }
                 setContextTarget(target);
             },
         }),
-        [context, state, screenToWorld, startGesture]
+        [context, state, screenToWorld, startGesture, canHandleIndependentPointerAction]
     );
 
     const onBackgroundPointerDown = (event: ReactPointerEvent<HTMLDivElement>) => {
@@ -581,7 +591,16 @@ export const GraphCanvas: FunctionComponent<{ context: EditorContextValue }> = (
                         </div>
                     }
                 />
-                <GraphMinimap camera={camera} viewport={size} onNavigate={(world) => setCamera((current) => CenterCameraOn(world, size, current.zoom))} />
+                <GraphMinimap
+                    camera={camera}
+                    viewport={size}
+                    onNavigate={(world) => {
+                        if (!canHandleIndependentPointerAction()) {
+                            return;
+                        }
+                        setCamera((current) => CenterCameraOn(world, size, current.zoom));
+                    }}
+                />
             </CanvasContextProvider>
         </div>
     );

--- a/packages/tools/nodeAssetsEditor/src/nodeGraph/components/GraphFrameView.tsx
+++ b/packages/tools/nodeAssetsEditor/src/nodeGraph/components/GraphFrameView.tsx
@@ -57,6 +57,7 @@ export const GraphFrameView: FunctionComponent<{ frame: IGraphFrame }> = (props)
     const { frame } = props;
     const classes = useStyles();
     const canvas = useCanvasContext();
+    const aggregateNodeId = frame.aggregateNodeId;
 
     const onPointerDown = (event: ReactPointerEvent) => {
         if (event.button !== 0) {
@@ -79,14 +80,14 @@ export const GraphFrameView: FunctionComponent<{ frame: IGraphFrame }> = (props)
             <div className={classes.fill} style={{ backgroundColor: frame.color }} />
             <div className={classes.header} style={{ backgroundColor: frame.color }}>
                 <Caption1 className={classes.headerLabel}>{frame.label}</Caption1>
-                {frame.kind === "aggregate" && frame.aggregateNodeId && (
+                {frame.kind === "aggregate" && aggregateNodeId && (
                     <Button
                         appearance="transparent"
                         icon={ChevronUpRegular}
                         title="Collapse aggregate"
                         ariaLabel="Collapse aggregate"
                         onPointerDown={onCollapsePointerDown}
-                        onClick={() => canvas.editor.aggregatePresentation?.setExpanded(frame.aggregateNodeId!, false)}
+                        onClick={() => canvas.runWhenIdle(() => canvas.editor.aggregatePresentation?.setExpanded(aggregateNodeId, false))}
                     />
                 )}
             </div>

--- a/packages/tools/nodeAssetsEditor/src/nodeGraph/components/GraphNodeView.tsx
+++ b/packages/tools/nodeAssetsEditor/src/nodeGraph/components/GraphNodeView.tsx
@@ -152,11 +152,13 @@ export const GraphNodeView: FunctionComponent<{ node: IGraphNode }> = (props) =>
 
     const onChevronClick = (event: ReactMouseEvent) => {
         event.stopPropagation();
-        if (isAggregate) {
-            canvas.editor.aggregatePresentation?.setExpanded(node.id, !node.aggregateExpanded);
-            return;
-        }
-        state.setNodeCollapsed(node.id, !node.collapsed);
+        canvas.runWhenIdle(() => {
+            if (isAggregate) {
+                canvas.editor.aggregatePresentation?.setExpanded(node.id, !node.aggregateExpanded);
+                return;
+            }
+            state.setNodeCollapsed(node.id, !node.collapsed);
+        });
     };
 
     // Note: intentionally does not stop propagation so the event reaches the canvas ContextMenu

--- a/packages/tools/nodeAssetsEditor/src/nodeGraph/components/canvasContext.ts
+++ b/packages/tools/nodeAssetsEditor/src/nodeGraph/components/canvasContext.ts
@@ -34,6 +34,8 @@ export type CanvasContextValue = {
     readonly selectWire: (wireId: string, event: ReactPointerEvent) => void;
     /** Opens a context menu for the given target at the pointer position. */
     readonly openContextMenu: (target: ContextMenuTarget, event: ReactMouseEvent) => void;
+    /** Runs a discrete canvas action only when no pointer gesture owns the canvas. */
+    readonly runWhenIdle: (action: () => void) => boolean;
 };
 
 const CanvasContext = createContext<CanvasContextValue | undefined>(undefined);

--- a/packages/tools/nodeAssetsEditor/src/nodeGraph/gestureInterpreter.ts
+++ b/packages/tools/nodeAssetsEditor/src/nodeGraph/gestureInterpreter.ts
@@ -40,11 +40,11 @@ export type MarqueeRect = {
  */
 export type Gesture =
     | { readonly kind: "none" }
-    | { readonly kind: "pan"; readonly lastLocal: Vec2 }
-    | { readonly kind: "marquee"; readonly startWorld: Vec2; readonly startLocal: Vec2; readonly additive: boolean }
-    | { readonly kind: "moveNodes"; readonly lastWorld: Vec2; readonly moved: boolean }
-    | { readonly kind: "moveFrame"; readonly frameId: string; readonly lastWorld: Vec2; readonly moved: boolean }
-    | { readonly kind: "wire"; readonly fromPortId: string; readonly fromAnchor: Vec2 };
+    | { readonly kind: "pan"; readonly pointerId: number; readonly lastLocal: Vec2; readonly moved: boolean; readonly clearSelectionOnClick: boolean }
+    | { readonly kind: "marquee"; readonly pointerId: number; readonly startWorld: Vec2; readonly startLocal: Vec2; readonly additive: boolean }
+    | { readonly kind: "moveNodes"; readonly pointerId: number; readonly lastWorld: Vec2; readonly moved: boolean }
+    | { readonly kind: "moveFrame"; readonly pointerId: number; readonly frameId: string; readonly lastWorld: Vec2; readonly moved: boolean }
+    | { readonly kind: "wire"; readonly pointerId: number; readonly fromPortId: string; readonly fromAnchor: Vec2 };
 
 /**
  * A discrete side effect the canvas component performs in response to a gesture transition. The
@@ -78,30 +78,32 @@ export type GestureResult = {
 const None: Gesture = { kind: "none" };
 
 /**
- * Begins a gesture from a pointer-down on the empty canvas background: middle-button or space+left starts
- * a pan; a plain left press starts a marquee (clearing the selection first unless it is additive).
- * @param input The pressed button, modifier state, and pointer position in world and viewport-local space.
+ * Begins a gesture from a pointer-down on the empty canvas background: middle-button, space+left, or an
+ * unmodified left press starts a pan; an additive left press starts a marquee.
+ * @param input The pointer identity, pressed button, modifier state, and position in world and viewport-local space.
  * @returns The started gesture and its initial actions.
  */
 export function BeginBackgroundGesture(input: {
+    readonly pointerId: number;
     readonly button: number;
     readonly spaceHeld: boolean;
     readonly additive: boolean;
     readonly world: Vec2;
     readonly local: Vec2;
 }): GestureResult {
-    const { button, spaceHeld, additive, world, local } = input;
-    const isPan = button === 1 || (button === 0 && spaceHeld);
+    const { pointerId, button, spaceHeld, additive, world, local } = input;
+    const isPan = button === 1 || (button === 0 && !additive);
     if (isPan) {
-        return { gesture: { kind: "pan", lastLocal: local }, actions: [] };
+        return {
+            gesture: { kind: "pan", pointerId, lastLocal: local, moved: false, clearSelectionOnClick: button === 0 && !spaceHeld && !additive },
+            actions: [],
+        };
     }
     if (button === 0) {
-        const actions: GestureAction[] = [];
-        if (!additive) {
-            actions.push({ kind: "clearSelection" });
-        }
-        actions.push({ kind: "setMarquee", rect: { x: local.x, y: local.y, width: 0, height: 0 } });
-        return { gesture: { kind: "marquee", startWorld: world, startLocal: local, additive }, actions };
+        return {
+            gesture: { kind: "marquee", pointerId, startWorld: world, startLocal: local, additive },
+            actions: [{ kind: "setMarquee", rect: { x: local.x, y: local.y, width: 0, height: 0 } }],
+        };
     }
     return { gesture: None, actions: [] };
 }
@@ -113,8 +115,14 @@ export function BeginBackgroundGesture(input: {
  * pointer position in world space.
  * @returns The move-nodes gesture and its selection/interaction actions.
  */
-export function BeginNodeGesture(input: { readonly nodeId: string; readonly additive: boolean; readonly isSelected: boolean; readonly world: Vec2 }): GestureResult {
-    const { nodeId, additive, isSelected, world } = input;
+export function BeginNodeGesture(input: {
+    readonly pointerId: number;
+    readonly nodeId: string;
+    readonly additive: boolean;
+    readonly isSelected: boolean;
+    readonly world: Vec2;
+}): GestureResult {
+    const { pointerId, nodeId, additive, isSelected, world } = input;
     const actions: GestureAction[] = [];
     if (additive) {
         actions.push({ kind: "toggleNodeSelection", nodeId });
@@ -122,7 +130,7 @@ export function BeginNodeGesture(input: { readonly nodeId: string; readonly addi
         actions.push({ kind: "selectNodes", nodeIds: [nodeId] });
     }
     actions.push({ kind: "beginInteraction" });
-    return { gesture: { kind: "moveNodes", lastWorld: world, moved: false }, actions };
+    return { gesture: { kind: "moveNodes", pointerId, lastWorld: world, moved: false }, actions };
 }
 
 /**
@@ -130,9 +138,9 @@ export function BeginNodeGesture(input: { readonly nodeId: string; readonly addi
  * @param input The frame id and the pointer position in world space.
  * @returns The move-frame gesture and its interaction action.
  */
-export function BeginFrameGesture(input: { readonly frameId: string; readonly world: Vec2 }): GestureResult {
-    const { frameId, world } = input;
-    return { gesture: { kind: "moveFrame", frameId, lastWorld: world, moved: false }, actions: [{ kind: "beginInteraction" }] };
+export function BeginFrameGesture(input: { readonly pointerId: number; readonly frameId: string; readonly world: Vec2 }): GestureResult {
+    const { pointerId, frameId, world } = input;
+    return { gesture: { kind: "moveFrame", pointerId, frameId, lastWorld: world, moved: false }, actions: [{ kind: "beginInteraction" }] };
 }
 
 /**
@@ -140,9 +148,9 @@ export function BeginFrameGesture(input: { readonly frameId: string; readonly wo
  * @param input The origin port id, its world-space anchor, and the pointer position in world space.
  * @returns The wire gesture and the initial pending-wire preview.
  */
-export function BeginPortGesture(input: { readonly portId: string; readonly anchor: Vec2; readonly world: Vec2 }): GestureResult {
-    const { portId, anchor, world } = input;
-    return { gesture: { kind: "wire", fromPortId: portId, fromAnchor: anchor }, actions: [{ kind: "setPendingWire", wire: { from: anchor, to: world } }] };
+export function BeginPortGesture(input: { readonly pointerId: number; readonly portId: string; readonly anchor: Vec2; readonly world: Vec2 }): GestureResult {
+    const { pointerId, portId, anchor, world } = input;
+    return { gesture: { kind: "wire", pointerId, fromPortId: portId, fromAnchor: anchor }, actions: [{ kind: "setPendingWire", wire: { from: anchor, to: world } }] };
 }
 
 /**
@@ -150,16 +158,22 @@ export function BeginPortGesture(input: { readonly portId: string; readonly anch
  * Node and frame moves ignore zero-length deltas and latch a `moved` flag so a click is distinguished
  * from a drag when the interaction is later committed.
  * @param gesture The active gesture.
- * @param input The pointer position in world and viewport-local space.
+ * @param input The pointer identity and position in world and viewport-local space.
  * @returns The updated gesture and the actions for this move.
  */
-export function AdvanceGesture(gesture: Gesture, input: { readonly world: Vec2; readonly local: Vec2 }): GestureResult {
-    const { world, local } = input;
+export function AdvanceGesture(gesture: Gesture, input: { readonly pointerId: number; readonly world: Vec2; readonly local: Vec2 }): GestureResult {
+    const { pointerId, world, local } = input;
+    if (gesture.kind !== "none" && gesture.pointerId !== pointerId) {
+        return { gesture, actions: [] };
+    }
     switch (gesture.kind) {
         case "pan": {
             const dx = local.x - gesture.lastLocal.x;
             const dy = local.y - gesture.lastLocal.y;
-            return { gesture: { kind: "pan", lastLocal: local }, actions: [{ kind: "panBy", dx, dy }] };
+            if (dx === 0 && dy === 0) {
+                return { gesture, actions: [] };
+            }
+            return { gesture: { ...gesture, lastLocal: local, moved: true }, actions: [{ kind: "panBy", dx, dy }] };
         }
         case "marquee": {
             const rect: MarqueeRect = {
@@ -175,7 +189,7 @@ export function AdvanceGesture(gesture: Gesture, input: { readonly world: Vec2; 
             if (delta.x === 0 && delta.y === 0) {
                 return { gesture, actions: [] };
             }
-            return { gesture: { kind: "moveNodes", lastWorld: world, moved: true }, actions: [{ kind: "translateSelectedNodes", delta }] };
+            return { gesture: { ...gesture, lastWorld: world, moved: true }, actions: [{ kind: "translateSelectedNodes", delta }] };
         }
         case "moveFrame": {
             const delta = { x: world.x - gesture.lastWorld.x, y: world.y - gesture.lastWorld.y };
@@ -183,7 +197,7 @@ export function AdvanceGesture(gesture: Gesture, input: { readonly world: Vec2; 
                 return { gesture, actions: [] };
             }
             return {
-                gesture: { kind: "moveFrame", frameId: gesture.frameId, lastWorld: world, moved: true },
+                gesture: { ...gesture, lastWorld: world, moved: true },
                 actions: [{ kind: "translateFrame", frameId: gesture.frameId, delta }],
             };
         }
@@ -196,17 +210,26 @@ export function AdvanceGesture(gesture: Gesture, input: { readonly world: Vec2; 
 }
 
 /**
- * Completes the active gesture on pointer-up and resets to no gesture. A marquee selects the nodes in its
- * region; a node/frame move ends its interaction (passing whether it actually moved); a wire connects to
- * the resolved target port when there is one and it differs from the origin.
+ * Completes the active gesture on pointer-up and resets to no gesture. An unmoved plain-primary pan clears
+ * selection; a marquee selects the nodes in its region; a node/frame move ends its interaction (passing
+ * whether it actually moved); a wire connects to the resolved target port when there is one and it differs
+ * from the origin.
  * @param gesture The active gesture.
- * @param input The pointer position in world space and, for wire gestures, the target port the caller
- * resolved from the drop position (a direct hit or the nearest connectable port), if any.
+ * @param input The pointer identity and position in world space and, for wire gestures, the target port the
+ * caller resolved from the drop position (a direct hit or the nearest connectable port), if any.
  * @returns The reset gesture and the actions that commit the gesture.
  */
-export function CompleteGesture(gesture: Gesture, input: { readonly world: Vec2; readonly resolvedTargetPortId?: string }): GestureResult {
-    const { world, resolvedTargetPortId } = input;
+export function CompleteGesture(gesture: Gesture, input: { readonly pointerId: number; readonly world: Vec2; readonly resolvedTargetPortId?: string }): GestureResult {
+    const { pointerId, world, resolvedTargetPortId } = input;
+    if (gesture.kind !== "none" && gesture.pointerId !== pointerId) {
+        return { gesture, actions: [] };
+    }
     switch (gesture.kind) {
+        case "pan":
+            return {
+                gesture: None,
+                actions: gesture.clearSelectionOnClick && !gesture.moved ? [{ kind: "clearSelection" }] : [],
+            };
         case "marquee": {
             const region: Bounds = {
                 minX: Math.min(gesture.startWorld.x, world.x),
@@ -233,6 +256,30 @@ export function CompleteGesture(gesture: Gesture, input: { readonly world: Vec2;
             actions.push({ kind: "setPendingWire", wire: null });
             return { gesture: None, actions };
         }
+        default:
+            return { gesture: None, actions: [] };
+    }
+}
+
+/**
+ * Cancels the active gesture for its owning pointer, clearing transient marquee/wire state and closing any
+ * bracketed node/frame interaction without applying completion-only actions.
+ * @param gesture The active gesture.
+ * @param input The pointer that was canceled.
+ * @returns The reset gesture and cleanup actions.
+ */
+export function CancelGesture(gesture: Gesture, input: { readonly pointerId: number }): GestureResult {
+    if (gesture.kind === "none" || gesture.pointerId !== input.pointerId) {
+        return { gesture, actions: [] };
+    }
+    switch (gesture.kind) {
+        case "marquee":
+            return { gesture: None, actions: [{ kind: "setMarquee", rect: null }] };
+        case "wire":
+            return { gesture: None, actions: [{ kind: "setPendingWire", wire: null }] };
+        case "moveNodes":
+        case "moveFrame":
+            return { gesture: None, actions: [{ kind: "endInteraction", moved: gesture.moved }] };
         default:
             return { gesture: None, actions: [] };
     }

--- a/packages/tools/nodeAssetsEditor/test/playwright/nae.utils.ts
+++ b/packages/tools/nodeAssetsEditor/test/playwright/nae.utils.ts
@@ -116,6 +116,27 @@ export class NodeAssetsEditorPage {
     }
 
     /**
+     * Finds a viewport point on the empty graph surface, excluding nodes, frames, wires, ports, and the minimap.
+     * @returns Client-space coordinates safely inside the canvas.
+     */
+    async findEmptyCanvasPoint(): Promise<{ readonly x: number; readonly y: number }> {
+        return await this.canvas.evaluate((canvas) => {
+            const rect = canvas.getBoundingClientRect();
+            const excludedSelector =
+                '[data-testid="graph-node"], [data-testid="graph-frame"], [data-testid="aggregate-frame"], [data-testid="graph-wire"], [data-port-id], [role="presentation"]';
+            for (let y = rect.top + 48; y < rect.bottom - 96; y += 24) {
+                for (let x = rect.left + 48; x < rect.right - 96; x += 24) {
+                    const hit = document.elementFromPoint(x, y);
+                    if (hit && canvas.contains(hit) && !hit.closest(excludedSelector)) {
+                        return { x, y };
+                    }
+                }
+            }
+            throw new Error("Could not find an empty point on the node graph canvas.");
+        });
+    }
+
+    /**
      * Locate a connection port of a node, optionally disambiguated by direction. Boundary nodes have a
      * single port (Import: one output, Export: one input), so the direction is optional; blocks with both
      * an input and an output (e.g. Compress Textures (KTX2)) need it to pick the right side.

--- a/packages/tools/nodeAssetsEditor/test/playwright/nodeAssetsEditor.test.ts
+++ b/packages/tools/nodeAssetsEditor/test/playwright/nodeAssetsEditor.test.ts
@@ -685,6 +685,9 @@ test.describe("Node Assets Editor — maintained default pipeline", () => {
         await editor.goto();
 
         const importNode = editor.nodeByTitle("Import glTF");
+        const contextNode = editor.nodeByTitle("Remove Unused Resources");
+        const minimap = editor.canvas.locator('[role="presentation"]');
+        const wireHitTarget = editor.wires.first().locator("path").first();
         await editor.selectNode("Import glTF");
         const selectedNodeName = page.getByRole("textbox").nth(0);
         await expect(selectedNodeName).toHaveValue("Import glTF");
@@ -704,15 +707,45 @@ test.describe("Node Assets Editor — maintained default pipeline", () => {
         const beforePan = await readNodeState();
         const start = await editor.findEmptyCanvasPoint();
         const delta = { x: 48, y: 32 };
+        const minimapBox = await minimap.boundingBox();
+        if (!minimapBox) {
+            throw new Error("Could not resolve the graph minimap for pointer ownership testing.");
+        }
+        const foreignPointer = {
+            pointerId: 999,
+            pointerType: "touch",
+            isPrimary: false,
+        };
+        const minimapPoint = { clientX: minimapBox.x + 16, clientY: minimapBox.y + 16 };
         await expect(editor.canvas).toHaveCSS("cursor", "grab");
         await page.mouse.move(start.x, start.y);
         await page.mouse.down();
         await expect(editor.canvas).toHaveCSS("cursor", "grabbing");
         const beforeForeignMove = await readNodeState();
+        await minimap.dispatchEvent("pointerdown", {
+            ...foreignPointer,
+            ...minimapPoint,
+            button: 0,
+            buttons: 1,
+        });
+        const afterForeignNavigation = await readNodeState();
+        expect(afterForeignNavigation.screenX).toBe(beforeForeignMove.screenX);
+        expect(afterForeignNavigation.screenY).toBe(beforeForeignMove.screenY);
+        await wireHitTarget.dispatchEvent("pointerdown", {
+            ...foreignPointer,
+            button: 0,
+            buttons: 1,
+        });
+        await expect(selectedNodeName).toHaveValue("Import glTF");
+        await contextNode.dispatchEvent("contextmenu", {
+            ...foreignPointer,
+            button: 2,
+            buttons: 0,
+        });
+        await expect(selectedNodeName).toHaveValue("Import glTF");
+        await page.keyboard.press("Escape");
         await editor.canvas.dispatchEvent("pointermove", {
-            pointerId: 999,
-            pointerType: "touch",
-            isPrimary: false,
+            ...foreignPointer,
             buttons: 1,
             clientX: start.x + 96,
             clientY: start.y + 96,
@@ -766,6 +799,34 @@ test.describe("Node Assets Editor — maintained default pipeline", () => {
         const afterZoom = await readNodeState();
         expect(afterZoom.worldLeft).toBe(afterNodeDrag.worldLeft);
         expect(afterZoom.worldTop).toBe(afterNodeDrag.worldTop);
+
+        const beforeIdleMinimapNavigation = await readNodeState();
+        await minimap.dispatchEvent("pointerdown", {
+            ...foreignPointer,
+            ...minimapPoint,
+            button: 0,
+            buttons: 1,
+        });
+        await expect
+            .poll(async () => {
+                const current = await readNodeState();
+                return Math.abs(current.screenX - beforeIdleMinimapNavigation.screenX) + Math.abs(current.screenY - beforeIdleMinimapNavigation.screenY);
+            })
+            .toBeGreaterThan(1);
+
+        await wireHitTarget.dispatchEvent("pointerdown", {
+            ...foreignPointer,
+            button: 0,
+            buttons: 1,
+        });
+        await expect(page.getByText("No selection", { exact: true })).toBeVisible();
+        await contextNode.dispatchEvent("contextmenu", {
+            ...foreignPointer,
+            button: 2,
+            buttons: 0,
+        });
+        await expect(page.getByRole("textbox").nth(0)).toHaveValue("Remove Unused Resources");
+        await page.keyboard.press("Escape");
     });
 
     test("reorganizes overlapping nodes into a left-to-right data flow", async ({ page }) => {

--- a/packages/tools/nodeAssetsEditor/test/playwright/nodeAssetsEditor.test.ts
+++ b/packages/tools/nodeAssetsEditor/test/playwright/nodeAssetsEditor.test.ts
@@ -680,7 +680,7 @@ test.describe("Node Assets Editor — maintained default pipeline", () => {
         await expect(editor.nodes).toHaveCount(2);
     });
 
-    test("pans empty canvas without mutating graph layout and preserves node drag and wheel zoom", async ({ page }) => {
+    test("blocks foreign canvas controls while another pointer owns the active pan", async ({ page }) => {
         const editor = new NodeAssetsEditorPage(page);
         await editor.goto();
 
@@ -688,6 +688,119 @@ test.describe("Node Assets Editor — maintained default pipeline", () => {
         const contextNode = editor.nodeByTitle("Remove Unused Resources");
         const minimap = editor.canvas.locator('[role="presentation"]');
         const wireHitTarget = editor.wires.first().locator("path").first();
+        await editor.selectNode("Import glTF");
+        const selectedNodeName = page.getByRole("textbox").nth(0);
+        await expect(selectedNodeName).toHaveValue("Import glTF");
+
+        const readNodePosition = async () =>
+            await importNode.evaluate((node: HTMLElement) => {
+                const rect = node.getBoundingClientRect();
+                return { screenX: rect.x, screenY: rect.y };
+            });
+
+        const start = await editor.findEmptyCanvasPoint();
+        const minimapBox = await minimap.boundingBox();
+        if (!minimapBox) {
+            throw new Error("Could not resolve the graph minimap for pointer ownership testing.");
+        }
+        await editor.canvas.evaluate((canvas) => {
+            const capturedPointerIds = new Set<number>();
+            Object.defineProperties(canvas, {
+                hasPointerCapture: { configurable: true, value: (pointerId: number) => capturedPointerIds.has(pointerId) },
+                setPointerCapture: { configurable: true, value: (pointerId: number) => capturedPointerIds.add(pointerId) },
+                releasePointerCapture: { configurable: true, value: (pointerId: number) => capturedPointerIds.delete(pointerId) },
+            });
+        });
+        const ownerPointer = {
+            pointerId: 11,
+            pointerType: "touch",
+            isPrimary: true,
+        };
+        const foreignPointer = {
+            pointerId: 22,
+            pointerType: "touch",
+            isPrimary: false,
+        };
+        const minimapPoint = { clientX: minimapBox.x + 16, clientY: minimapBox.y + 16 };
+        await expect(editor.canvas).toHaveCSS("cursor", "grab");
+        await editor.canvas.dispatchEvent("pointerdown", {
+            ...ownerPointer,
+            button: 0,
+            buttons: 1,
+            clientX: start.x,
+            clientY: start.y,
+        });
+        await expect(editor.canvas).toHaveCSS("cursor", "grabbing");
+        const beforeForeignActions = await readNodePosition();
+        await minimap.dispatchEvent("pointerdown", {
+            ...foreignPointer,
+            ...minimapPoint,
+            button: 0,
+            buttons: 1,
+        });
+        await wireHitTarget.dispatchEvent("pointerdown", {
+            ...foreignPointer,
+            button: 0,
+            buttons: 1,
+        });
+        await contextNode.dispatchEvent("contextmenu", {
+            ...foreignPointer,
+            button: 2,
+            buttons: 0,
+        });
+        const afterForeignActions = await readNodePosition();
+        expect({
+            screenX: afterForeignActions.screenX,
+            screenY: afterForeignActions.screenY,
+            selectedNodeName: await selectedNodeName.inputValue(),
+        }).toEqual({
+            screenX: beforeForeignActions.screenX,
+            screenY: beforeForeignActions.screenY,
+            selectedNodeName: "Import glTF",
+        });
+        await page.keyboard.press("Escape");
+        await editor.canvas.dispatchEvent("pointercancel", {
+            ...ownerPointer,
+            buttons: 0,
+            clientX: start.x,
+            clientY: start.y,
+        });
+        await expect(editor.canvas).toHaveCSS("cursor", "grab");
+
+        const beforeIdleMinimapNavigation = await readNodePosition();
+        await minimap.dispatchEvent("pointerdown", {
+            ...foreignPointer,
+            ...minimapPoint,
+            button: 0,
+            buttons: 1,
+        });
+        await expect
+            .poll(async () => {
+                const current = await readNodePosition();
+                return Math.abs(current.screenX - beforeIdleMinimapNavigation.screenX) + Math.abs(current.screenY - beforeIdleMinimapNavigation.screenY);
+            })
+            .toBeGreaterThan(1);
+
+        await wireHitTarget.dispatchEvent("pointerdown", {
+            ...foreignPointer,
+            button: 0,
+            buttons: 1,
+        });
+        await expect(page.getByText("No selection", { exact: true })).toBeVisible();
+        await contextNode.dispatchEvent("contextmenu", {
+            ...foreignPointer,
+            button: 2,
+            buttons: 0,
+        });
+        await expect(page.getByRole("textbox").nth(0)).toHaveValue("Remove Unused Resources");
+        await page.keyboard.press("Escape");
+    });
+
+    test("pans empty canvas without mutating graph layout and preserves node drag and wheel zoom", async ({ page }) => {
+        const editor = new NodeAssetsEditorPage(page);
+        await editor.goto();
+
+        const importNode = editor.nodeByTitle("Import glTF");
         await editor.selectNode("Import glTF");
         const selectedNodeName = page.getByRole("textbox").nth(0);
         await expect(selectedNodeName).toHaveValue("Import glTF");
@@ -707,50 +820,15 @@ test.describe("Node Assets Editor — maintained default pipeline", () => {
         const beforePan = await readNodeState();
         const start = await editor.findEmptyCanvasPoint();
         const delta = { x: 48, y: 32 };
-        const minimapBox = await minimap.boundingBox();
-        if (!minimapBox) {
-            throw new Error("Could not resolve the graph minimap for pointer ownership testing.");
-        }
-        const foreignPointer = {
-            pointerId: 22,
-            pointerType: "touch",
-            isPrimary: false,
-        };
-        const minimapPoint = { clientX: minimapBox.x + 16, clientY: minimapBox.y + 16 };
         await expect(editor.canvas).toHaveCSS("cursor", "grab");
         await page.mouse.move(start.x, start.y);
         await page.mouse.down();
         await expect(editor.canvas).toHaveCSS("cursor", "grabbing");
         const beforeForeignMove = await readNodeState();
-        await minimap.dispatchEvent("pointerdown", {
-            ...foreignPointer,
-            ...minimapPoint,
-            button: 0,
-            buttons: 1,
-        });
-        await wireHitTarget.dispatchEvent("pointerdown", {
-            ...foreignPointer,
-            button: 0,
-            buttons: 1,
-        });
-        await contextNode.dispatchEvent("contextmenu", {
-            ...foreignPointer,
-            button: 2,
-            buttons: 0,
-        });
-        const afterForeignActions = await readNodeState();
-        expect({
-            screenX: afterForeignActions.screenX,
-            screenY: afterForeignActions.screenY,
-            selectedNodeName: await selectedNodeName.inputValue(),
-        }).toEqual({
-            screenX: beforeForeignMove.screenX,
-            screenY: beforeForeignMove.screenY,
-            selectedNodeName: "Import glTF",
-        });
-        await page.keyboard.press("Escape");
         await editor.canvas.dispatchEvent("pointermove", {
-            ...foreignPointer,
+            pointerId: 999,
+            pointerType: "touch",
+            isPrimary: false,
             buttons: 1,
             clientX: start.x + 96,
             clientY: start.y + 96,
@@ -804,34 +882,6 @@ test.describe("Node Assets Editor — maintained default pipeline", () => {
         const afterZoom = await readNodeState();
         expect(afterZoom.worldLeft).toBe(afterNodeDrag.worldLeft);
         expect(afterZoom.worldTop).toBe(afterNodeDrag.worldTop);
-
-        const beforeIdleMinimapNavigation = await readNodeState();
-        await minimap.dispatchEvent("pointerdown", {
-            ...foreignPointer,
-            ...minimapPoint,
-            button: 0,
-            buttons: 1,
-        });
-        await expect
-            .poll(async () => {
-                const current = await readNodeState();
-                return Math.abs(current.screenX - beforeIdleMinimapNavigation.screenX) + Math.abs(current.screenY - beforeIdleMinimapNavigation.screenY);
-            })
-            .toBeGreaterThan(1);
-
-        await wireHitTarget.dispatchEvent("pointerdown", {
-            ...foreignPointer,
-            button: 0,
-            buttons: 1,
-        });
-        await expect(page.getByText("No selection", { exact: true })).toBeVisible();
-        await contextNode.dispatchEvent("contextmenu", {
-            ...foreignPointer,
-            button: 2,
-            buttons: 0,
-        });
-        await expect(page.getByRole("textbox").nth(0)).toHaveValue("Remove Unused Resources");
-        await page.keyboard.press("Escape");
     });
 
     test("reorganizes overlapping nodes into a left-to-right data flow", async ({ page }) => {

--- a/packages/tools/nodeAssetsEditor/test/playwright/nodeAssetsEditor.test.ts
+++ b/packages/tools/nodeAssetsEditor/test/playwright/nodeAssetsEditor.test.ts
@@ -712,7 +712,7 @@ test.describe("Node Assets Editor — maintained default pipeline", () => {
             throw new Error("Could not resolve the graph minimap for pointer ownership testing.");
         }
         const foreignPointer = {
-            pointerId: 999,
+            pointerId: 22,
             pointerType: "touch",
             isPrimary: false,
         };
@@ -728,21 +728,26 @@ test.describe("Node Assets Editor — maintained default pipeline", () => {
             button: 0,
             buttons: 1,
         });
-        const afterForeignNavigation = await readNodeState();
-        expect(afterForeignNavigation.screenX).toBe(beforeForeignMove.screenX);
-        expect(afterForeignNavigation.screenY).toBe(beforeForeignMove.screenY);
         await wireHitTarget.dispatchEvent("pointerdown", {
             ...foreignPointer,
             button: 0,
             buttons: 1,
         });
-        await expect(selectedNodeName).toHaveValue("Import glTF");
         await contextNode.dispatchEvent("contextmenu", {
             ...foreignPointer,
             button: 2,
             buttons: 0,
         });
-        await expect(selectedNodeName).toHaveValue("Import glTF");
+        const afterForeignActions = await readNodeState();
+        expect({
+            screenX: afterForeignActions.screenX,
+            screenY: afterForeignActions.screenY,
+            selectedNodeName: await selectedNodeName.inputValue(),
+        }).toEqual({
+            screenX: beforeForeignMove.screenX,
+            screenY: beforeForeignMove.screenY,
+            selectedNodeName: "Import glTF",
+        });
         await page.keyboard.press("Escape");
         await editor.canvas.dispatchEvent("pointermove", {
             ...foreignPointer,

--- a/packages/tools/nodeAssetsEditor/test/playwright/nodeAssetsEditor.test.ts
+++ b/packages/tools/nodeAssetsEditor/test/playwright/nodeAssetsEditor.test.ts
@@ -46,7 +46,7 @@ async function installSyntheticPointerCapture(editor: NodeAssetsEditorPage): Pro
     });
 }
 
-async function beginSyntheticTouchPan(editor: NodeAssetsEditorPage, pointerId: number): Promise<SyntheticTouchPan> {
+async function startSyntheticTouchPan(editor: NodeAssetsEditorPage, pointerId: number): Promise<SyntheticTouchPan> {
     const point = await editor.findEmptyCanvasPoint();
     await editor.canvas.dispatchEvent("pointerdown", {
         pointerId,
@@ -61,16 +61,41 @@ async function beginSyntheticTouchPan(editor: NodeAssetsEditorPage, pointerId: n
     return { pointerId, point };
 }
 
-async function endSyntheticTouchPan(editor: NodeAssetsEditorPage, pan: SyntheticTouchPan, eventName: "pointerup" | "pointercancel" | "lostpointercapture"): Promise<void> {
-    if (eventName === "lostpointercapture") {
-        await editor.canvas.evaluate((canvas, pointerId) => canvas.releasePointerCapture(pointerId), pan.pointerId);
-    }
+async function moveSyntheticTouchPan(editor: NodeAssetsEditorPage, pan: SyntheticTouchPan, delta: { readonly x: number; readonly y: number }): Promise<SyntheticTouchPan> {
+    const point = { x: pan.point.x + delta.x, y: pan.point.y + delta.y };
+    await editor.canvas.dispatchEvent("pointermove", {
+        pointerId: pan.pointerId,
+        pointerType: "touch",
+        isPrimary: true,
+        button: -1,
+        buttons: 1,
+        clientX: point.x,
+        clientY: point.y,
+    });
+    return { pointerId: pan.pointerId, point };
+}
+
+async function endSyntheticTouchPan(editor: NodeAssetsEditorPage, pan: SyntheticTouchPan, eventName: "pointerup" | "pointercancel"): Promise<void> {
     await editor.canvas.dispatchEvent(eventName, {
         pointerId: pan.pointerId,
         pointerType: "touch",
         isPrimary: true,
-        button: 0,
+        button: eventName === "pointerup" ? 0 : -1,
         buttons: 0,
+        clientX: pan.point.x,
+        clientY: pan.point.y,
+    });
+    await expect(editor.canvas).toHaveCSS("cursor", "grab");
+}
+
+async function loseSyntheticTouchPanCapture(editor: NodeAssetsEditorPage, pan: SyntheticTouchPan): Promise<void> {
+    await editor.canvas.evaluate((canvas, pointerId) => canvas.releasePointerCapture(pointerId), pan.pointerId);
+    await editor.canvas.dispatchEvent("lostpointercapture", {
+        pointerId: pan.pointerId,
+        pointerType: "touch",
+        isPrimary: true,
+        button: -1,
+        buttons: 1,
         clientX: pan.point.x,
         clientY: pan.point.y,
     });
@@ -747,7 +772,7 @@ test.describe("Node Assets Editor — maintained default pipeline", () => {
 
         const node = editor.nodeByTitle("Remove Unused Resources");
         const collapseNode = node.getByRole("button", { name: "Collapse node" });
-        const pan = await beginSyntheticTouchPan(editor, 11);
+        const pan = await startSyntheticTouchPan(editor, 11);
 
         await collapseNode.click();
         await expect(collapseNode).toBeVisible();
@@ -767,7 +792,7 @@ test.describe("Node Assets Editor — maintained default pipeline", () => {
 
         const aggregateNode = editor.nodeByTitle("Import glTF");
         const expandAggregate = aggregateNode.getByRole("button", { name: "Expand aggregate" });
-        const compactPan = await beginSyntheticTouchPan(editor, 21);
+        const compactPan = await startSyntheticTouchPan(editor, 21);
 
         await expandAggregate.click();
         await expect(expandAggregate).toBeVisible();
@@ -778,7 +803,7 @@ test.describe("Node Assets Editor — maintained default pipeline", () => {
         const collapseAggregate = aggregateFrame.getByRole("button", { name: "Collapse aggregate" });
         await expect(collapseAggregate).toBeVisible();
 
-        const expandedPan = await beginSyntheticTouchPan(editor, 22);
+        const expandedPan = await startSyntheticTouchPan(editor, 22);
         await collapseAggregate.click();
         await expect(aggregateFrame).toBeVisible();
 
@@ -805,7 +830,7 @@ test.describe("Node Assets Editor — maintained default pipeline", () => {
                 return { screenX: rect.x, screenY: rect.y };
             });
 
-        const pan = await beginSyntheticTouchPan(editor, 31);
+        const pan = await startSyntheticTouchPan(editor, 31);
         const beforeForeignActions = await readNodePosition();
         await minimap.click({ position: { x: 16, y: 16 } });
         await clickWirePath(page, wireHitTarget);
@@ -820,7 +845,12 @@ test.describe("Node Assets Editor — maintained default pipeline", () => {
             selectedNodeName: "Import glTF",
         });
 
-        await endSyntheticTouchPan(editor, pan, "lostpointercapture");
+        await loseSyntheticTouchPanCapture(editor, pan);
+        const afterLostCapture = await readNodePosition();
+        await expect(selectedNodeName).toHaveValue("Import glTF");
+        await endSyntheticTouchPan(editor, pan, "pointerup");
+        expect(await readNodePosition()).toEqual(afterLostCapture);
+        await expect(selectedNodeName).toHaveValue("Import glTF");
 
         await clickWirePath(page, wireHitTarget);
         await expect(page.getByText("No selection", { exact: true })).toBeVisible();
@@ -865,7 +895,7 @@ test.describe("Node Assets Editor — maintained default pipeline", () => {
                 return { x: rect.x, y: rect.y };
             }),
         };
-        const pan = await beginSyntheticTouchPan(editor, 41);
+        const pan = await startSyntheticTouchPan(editor, 41);
         await expect(selectedNodeName).toHaveValue("Import glTF");
 
         await expect.soft(visibleMenus).toHaveCount(0);
@@ -918,6 +948,7 @@ test.describe("Node Assets Editor — maintained default pipeline", () => {
     test("pans empty canvas without mutating graph layout and preserves node drag and wheel zoom", async ({ page }) => {
         const editor = new NodeAssetsEditorPage(page);
         await editor.goto();
+        await installSyntheticPointerCapture(editor);
 
         const importNode = editor.nodeByTitle("Import glTF");
         await editor.selectNode("Import glTF");
@@ -937,27 +968,21 @@ test.describe("Node Assets Editor — maintained default pipeline", () => {
             });
 
         const beforePan = await readNodeState();
-        const start = await editor.findEmptyCanvasPoint();
         const delta = { x: 48, y: 32 };
         await expect(editor.canvas).toHaveCSS("cursor", "grab");
-        await page.mouse.move(start.x, start.y);
+        const pan = await startSyntheticTouchPan(editor, 51);
+        const foreignStart = await editor.findEmptyCanvasPoint();
+        await page.mouse.move(foreignStart.x, foreignStart.y);
         await page.mouse.down();
-        await expect(editor.canvas).toHaveCSS("cursor", "grabbing");
         const beforeForeignMove = await readNodeState();
-        await editor.canvas.dispatchEvent("pointermove", {
-            pointerId: 999,
-            pointerType: "touch",
-            isPrimary: false,
-            buttons: 1,
-            clientX: start.x + 96,
-            clientY: start.y + 96,
-        });
+        await page.mouse.move(foreignStart.x + 96, foreignStart.y + 96, { steps: 4 });
+        await page.mouse.up();
         const afterForeignMove = await readNodeState();
         expect(afterForeignMove.screenX).toBe(beforeForeignMove.screenX);
         expect(afterForeignMove.screenY).toBe(beforeForeignMove.screenY);
-        await page.mouse.move(start.x + delta.x, start.y + delta.y, { steps: 4 });
-        await page.mouse.up();
-        await expect(editor.canvas).toHaveCSS("cursor", "grab");
+        await expect(editor.canvas).toHaveCSS("cursor", "grabbing");
+        const movedPan = await moveSyntheticTouchPan(editor, pan, delta);
+        await endSyntheticTouchPan(editor, movedPan, "pointerup");
 
         const afterPan = await readNodeState();
         expect(afterPan.worldLeft).toBe(beforePan.worldLeft);
@@ -966,20 +991,8 @@ test.describe("Node Assets Editor — maintained default pipeline", () => {
         expect(afterPan.screenY).toBeCloseTo(beforePan.screenY + delta.y, 4);
         await expect(selectedNodeName).toHaveValue("Import glTF");
 
-        const cancelPoint = await editor.findEmptyCanvasPoint();
-        await page.mouse.move(cancelPoint.x, cancelPoint.y);
-        await page.mouse.down();
-        await expect(editor.canvas).toHaveCSS("cursor", "grabbing");
-        await editor.canvas.dispatchEvent("pointercancel", {
-            pointerId: 1,
-            pointerType: "mouse",
-            isPrimary: true,
-            buttons: 0,
-            clientX: cancelPoint.x,
-            clientY: cancelPoint.y,
-        });
-        await expect(editor.canvas).toHaveCSS("cursor", "grab");
-        await page.mouse.up();
+        const canceledPan = await startSyntheticTouchPan(editor, 52);
+        await endSyntheticTouchPan(editor, canceledPan, "pointercancel");
         await expect(selectedNodeName).toHaveValue("Import glTF");
 
         const nodeTitle = importNode.getByText("Import glTF", { exact: true });

--- a/packages/tools/nodeAssetsEditor/test/playwright/nodeAssetsEditor.test.ts
+++ b/packages/tools/nodeAssetsEditor/test/playwright/nodeAssetsEditor.test.ts
@@ -680,6 +680,94 @@ test.describe("Node Assets Editor — maintained default pipeline", () => {
         await expect(editor.nodes).toHaveCount(2);
     });
 
+    test("pans empty canvas without mutating graph layout and preserves node drag and wheel zoom", async ({ page }) => {
+        const editor = new NodeAssetsEditorPage(page);
+        await editor.goto();
+
+        const importNode = editor.nodeByTitle("Import glTF");
+        await editor.selectNode("Import glTF");
+        const selectedNodeName = page.getByRole("textbox").nth(0);
+        await expect(selectedNodeName).toHaveValue("Import glTF");
+
+        const readNodeState = async () =>
+            await importNode.evaluate((node: HTMLElement) => {
+                const rect = node.getBoundingClientRect();
+                return {
+                    worldLeft: node.style.left,
+                    worldTop: node.style.top,
+                    screenX: rect.x,
+                    screenY: rect.y,
+                    screenWidth: rect.width,
+                };
+            });
+
+        const beforePan = await readNodeState();
+        const start = await editor.findEmptyCanvasPoint();
+        const delta = { x: 48, y: 32 };
+        await expect(editor.canvas).toHaveCSS("cursor", "grab");
+        await page.mouse.move(start.x, start.y);
+        await page.mouse.down();
+        await expect(editor.canvas).toHaveCSS("cursor", "grabbing");
+        const beforeForeignMove = await readNodeState();
+        await editor.canvas.dispatchEvent("pointermove", {
+            pointerId: 999,
+            pointerType: "touch",
+            isPrimary: false,
+            buttons: 1,
+            clientX: start.x + 96,
+            clientY: start.y + 96,
+        });
+        const afterForeignMove = await readNodeState();
+        expect(afterForeignMove.screenX).toBe(beforeForeignMove.screenX);
+        expect(afterForeignMove.screenY).toBe(beforeForeignMove.screenY);
+        await page.mouse.move(start.x + delta.x, start.y + delta.y, { steps: 4 });
+        await page.mouse.up();
+        await expect(editor.canvas).toHaveCSS("cursor", "grab");
+
+        const afterPan = await readNodeState();
+        expect(afterPan.worldLeft).toBe(beforePan.worldLeft);
+        expect(afterPan.worldTop).toBe(beforePan.worldTop);
+        expect(afterPan.screenX).toBeCloseTo(beforePan.screenX + delta.x, 4);
+        expect(afterPan.screenY).toBeCloseTo(beforePan.screenY + delta.y, 4);
+        await expect(selectedNodeName).toHaveValue("Import glTF");
+
+        const cancelPoint = await editor.findEmptyCanvasPoint();
+        await page.mouse.move(cancelPoint.x, cancelPoint.y);
+        await page.mouse.down();
+        await expect(editor.canvas).toHaveCSS("cursor", "grabbing");
+        await editor.canvas.dispatchEvent("pointercancel", {
+            pointerId: 1,
+            pointerType: "mouse",
+            isPrimary: true,
+            buttons: 0,
+            clientX: cancelPoint.x,
+            clientY: cancelPoint.y,
+        });
+        await expect(editor.canvas).toHaveCSS("cursor", "grab");
+        await page.mouse.up();
+        await expect(selectedNodeName).toHaveValue("Import glTF");
+
+        const nodeTitle = importNode.getByText("Import glTF", { exact: true });
+        const titleBox = await nodeTitle.boundingBox();
+        if (!titleBox) {
+            throw new Error("Could not resolve the selected node title for dragging.");
+        }
+        await page.mouse.move(titleBox.x + titleBox.width / 2, titleBox.y + titleBox.height / 2);
+        await page.mouse.down();
+        await page.mouse.move(titleBox.x + titleBox.width / 2 + 24, titleBox.y + titleBox.height / 2 + 16, { steps: 4 });
+        await page.mouse.up();
+        const afterNodeDrag = await readNodeState();
+        expect({ left: afterNodeDrag.worldLeft, top: afterNodeDrag.worldTop }).not.toEqual({ left: afterPan.worldLeft, top: afterPan.worldTop });
+
+        const zoomPoint = await editor.findEmptyCanvasPoint();
+        await page.mouse.move(zoomPoint.x, zoomPoint.y);
+        await page.mouse.wheel(0, -200);
+        await expect.poll(async () => (await readNodeState()).screenWidth).toBeGreaterThan(afterNodeDrag.screenWidth);
+        const afterZoom = await readNodeState();
+        expect(afterZoom.worldLeft).toBe(afterNodeDrag.worldLeft);
+        expect(afterZoom.worldTop).toBe(afterNodeDrag.worldTop);
+    });
+
     test("reorganizes overlapping nodes into a left-to-right data flow", async ({ page }) => {
         const editor = new NodeAssetsEditorPage(page);
         await editor.goto();

--- a/packages/tools/nodeAssetsEditor/test/playwright/nodeAssetsEditor.test.ts
+++ b/packages/tools/nodeAssetsEditor/test/playwright/nodeAssetsEditor.test.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page, type Download } from "@playwright/test";
+import { test, expect, type Page, type Download, type Locator } from "@playwright/test";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
@@ -29,6 +29,66 @@ type SavedEditorGraph = {
         readonly blocks: readonly SavedBlock[];
     };
 };
+
+type SyntheticTouchPan = {
+    readonly pointerId: number;
+    readonly point: { readonly x: number; readonly y: number };
+};
+
+async function installSyntheticPointerCapture(editor: NodeAssetsEditorPage): Promise<void> {
+    await editor.canvas.evaluate((canvas) => {
+        const capturedPointerIds = new Set<number>();
+        Object.defineProperties(canvas, {
+            hasPointerCapture: { configurable: true, value: (pointerId: number) => capturedPointerIds.has(pointerId) },
+            setPointerCapture: { configurable: true, value: (pointerId: number) => capturedPointerIds.add(pointerId) },
+            releasePointerCapture: { configurable: true, value: (pointerId: number) => capturedPointerIds.delete(pointerId) },
+        });
+    });
+}
+
+async function beginSyntheticTouchPan(editor: NodeAssetsEditorPage, pointerId: number): Promise<SyntheticTouchPan> {
+    const point = await editor.findEmptyCanvasPoint();
+    await editor.canvas.dispatchEvent("pointerdown", {
+        pointerId,
+        pointerType: "touch",
+        isPrimary: true,
+        button: 0,
+        buttons: 1,
+        clientX: point.x,
+        clientY: point.y,
+    });
+    await expect(editor.canvas).toHaveCSS("cursor", "grabbing");
+    return { pointerId, point };
+}
+
+async function endSyntheticTouchPan(editor: NodeAssetsEditorPage, pan: SyntheticTouchPan, eventName: "pointerup" | "pointercancel" | "lostpointercapture"): Promise<void> {
+    if (eventName === "lostpointercapture") {
+        await editor.canvas.evaluate((canvas, pointerId) => canvas.releasePointerCapture(pointerId), pan.pointerId);
+    }
+    await editor.canvas.dispatchEvent(eventName, {
+        pointerId: pan.pointerId,
+        pointerType: "touch",
+        isPrimary: true,
+        button: 0,
+        buttons: 0,
+        clientX: pan.point.x,
+        clientY: pan.point.y,
+    });
+    await expect(editor.canvas).toHaveCSS("cursor", "grab");
+}
+
+async function clickWirePath(page: Page, path: Locator, button: "left" | "right" = "left"): Promise<void> {
+    const point = await path.evaluate((element: SVGPathElement) => {
+        const matrix = element.getScreenCTM();
+        if (!matrix) {
+            throw new Error("Could not resolve the wire path screen transform.");
+        }
+        const pathPoint = element.getPointAtLength(element.getTotalLength() / 2);
+        const screenPoint = pathPoint.matrixTransform(matrix);
+        return { x: screenPoint.x, y: screenPoint.y };
+    });
+    await page.mouse.click(point.x, point.y, { button });
+}
 
 const DefaultOptimizationPipeline: readonly (readonly [string, string])[] = [
     ["Import glTF", "Weld Vertices"],
@@ -680,12 +740,59 @@ test.describe("Node Assets Editor — maintained default pipeline", () => {
         await expect(editor.nodes).toHaveCount(2);
     });
 
-    test("blocks foreign canvas controls while another pointer owns the active pan", async ({ page }) => {
+    test("keeps an ordinary node presentation inert while a touch pan owns the canvas, then restores it on pointerup", async ({ page }) => {
         const editor = new NodeAssetsEditorPage(page);
         await editor.goto();
+        await installSyntheticPointerCapture(editor);
+
+        const node = editor.nodeByTitle("Remove Unused Resources");
+        const collapseNode = node.getByRole("button", { name: "Collapse node" });
+        const pan = await beginSyntheticTouchPan(editor, 11);
+
+        await collapseNode.click();
+        await expect(collapseNode).toBeVisible();
+
+        await endSyntheticTouchPan(editor, pan, "pointerup");
+        await collapseNode.click();
+        const expandNode = node.getByRole("button", { name: "Expand node" });
+        await expect(expandNode).toBeVisible();
+        await expandNode.click();
+        await expect(collapseNode).toBeVisible();
+    });
+
+    test("keeps aggregate presentation inert while a touch pan owns the canvas, then restores it on pointerup", async ({ page }) => {
+        const editor = new NodeAssetsEditorPage(page);
+        await editor.goto();
+        await installSyntheticPointerCapture(editor);
+
+        const aggregateNode = editor.nodeByTitle("Import glTF");
+        const expandAggregate = aggregateNode.getByRole("button", { name: "Expand aggregate" });
+        const compactPan = await beginSyntheticTouchPan(editor, 21);
+
+        await expandAggregate.click();
+        await expect(expandAggregate).toBeVisible();
+
+        await endSyntheticTouchPan(editor, compactPan, "pointerup");
+        await expandAggregate.click();
+        const aggregateFrame = page.getByTestId("aggregate-frame").filter({ hasText: "Import glTF" });
+        const collapseAggregate = aggregateFrame.getByRole("button", { name: "Collapse aggregate" });
+        await expect(collapseAggregate).toBeVisible();
+
+        const expandedPan = await beginSyntheticTouchPan(editor, 22);
+        await collapseAggregate.click();
+        await expect(aggregateFrame).toBeVisible();
+
+        await endSyntheticTouchPan(editor, expandedPan, "pointerup");
+        await collapseAggregate.click();
+        await expect(expandAggregate).toBeVisible();
+    });
+
+    test("keeps minimap and wire selection inert while a touch pan owns the canvas, then restores them on lost capture", async ({ page }) => {
+        const editor = new NodeAssetsEditorPage(page);
+        await editor.goto();
+        await installSyntheticPointerCapture(editor);
 
         const importNode = editor.nodeByTitle("Import glTF");
-        const contextNode = editor.nodeByTitle("Remove Unused Resources");
         const minimap = editor.canvas.locator('[role="presentation"]');
         const wireHitTarget = editor.wires.first().locator("path").first();
         await editor.selectNode("Import glTF");
@@ -698,56 +805,10 @@ test.describe("Node Assets Editor — maintained default pipeline", () => {
                 return { screenX: rect.x, screenY: rect.y };
             });
 
-        const start = await editor.findEmptyCanvasPoint();
-        const minimapBox = await minimap.boundingBox();
-        if (!minimapBox) {
-            throw new Error("Could not resolve the graph minimap for pointer ownership testing.");
-        }
-        await editor.canvas.evaluate((canvas) => {
-            const capturedPointerIds = new Set<number>();
-            Object.defineProperties(canvas, {
-                hasPointerCapture: { configurable: true, value: (pointerId: number) => capturedPointerIds.has(pointerId) },
-                setPointerCapture: { configurable: true, value: (pointerId: number) => capturedPointerIds.add(pointerId) },
-                releasePointerCapture: { configurable: true, value: (pointerId: number) => capturedPointerIds.delete(pointerId) },
-            });
-        });
-        const ownerPointer = {
-            pointerId: 11,
-            pointerType: "touch",
-            isPrimary: true,
-        };
-        const foreignPointer = {
-            pointerId: 22,
-            pointerType: "touch",
-            isPrimary: false,
-        };
-        const minimapPoint = { clientX: minimapBox.x + 16, clientY: minimapBox.y + 16 };
-        await expect(editor.canvas).toHaveCSS("cursor", "grab");
-        await editor.canvas.dispatchEvent("pointerdown", {
-            ...ownerPointer,
-            button: 0,
-            buttons: 1,
-            clientX: start.x,
-            clientY: start.y,
-        });
-        await expect(editor.canvas).toHaveCSS("cursor", "grabbing");
+        const pan = await beginSyntheticTouchPan(editor, 31);
         const beforeForeignActions = await readNodePosition();
-        await minimap.dispatchEvent("pointerdown", {
-            ...foreignPointer,
-            ...minimapPoint,
-            button: 0,
-            buttons: 1,
-        });
-        await wireHitTarget.dispatchEvent("pointerdown", {
-            ...foreignPointer,
-            button: 0,
-            buttons: 1,
-        });
-        await contextNode.dispatchEvent("contextmenu", {
-            ...foreignPointer,
-            button: 2,
-            buttons: 0,
-        });
+        await minimap.click({ position: { x: 16, y: 16 } });
+        await clickWirePath(page, wireHitTarget);
         const afterForeignActions = await readNodePosition();
         expect({
             screenX: afterForeignActions.screenX,
@@ -758,41 +819,99 @@ test.describe("Node Assets Editor — maintained default pipeline", () => {
             screenY: beforeForeignActions.screenY,
             selectedNodeName: "Import glTF",
         });
-        await page.keyboard.press("Escape");
-        await editor.canvas.dispatchEvent("pointercancel", {
-            ...ownerPointer,
-            buttons: 0,
-            clientX: start.x,
-            clientY: start.y,
-        });
-        await expect(editor.canvas).toHaveCSS("cursor", "grab");
 
+        await endSyntheticTouchPan(editor, pan, "lostpointercapture");
+
+        await clickWirePath(page, wireHitTarget);
+        await expect(page.getByText("No selection", { exact: true })).toBeVisible();
+        await editor.selectNode("Import glTF");
         const beforeIdleMinimapNavigation = await readNodePosition();
-        await minimap.dispatchEvent("pointerdown", {
-            ...foreignPointer,
-            ...minimapPoint,
-            button: 0,
-            buttons: 1,
-        });
+        await minimap.click({ position: { x: 16, y: 16 } });
         await expect
             .poll(async () => {
                 const current = await readNodePosition();
                 return Math.abs(current.screenX - beforeIdleMinimapNavigation.screenX) + Math.abs(current.screenY - beforeIdleMinimapNavigation.screenY);
             })
             .toBeGreaterThan(1);
+    });
 
-        await wireHitTarget.dispatchEvent("pointerdown", {
-            ...foreignPointer,
-            button: 0,
-            buttons: 1,
+    test("closes and suppresses context menus while a touch pan owns the canvas, then restores them on pointercancel", async ({ page }) => {
+        const editor = new NodeAssetsEditorPage(page);
+        await editor.goto();
+        await installSyntheticPointerCapture(editor);
+
+        const importNode = editor.nodeByTitle("Import glTF");
+        const contextNode = editor.nodeByTitle("Remove Unused Resources");
+        const wireHitTarget = editor.wires.first().locator("path").first();
+        const visibleMenus = page.locator('[role="menu"]:visible');
+        const selectedNodeName = page.getByRole("textbox").nth(0);
+        await editor.selectNode("Import glTF");
+        await expect(selectedNodeName).toHaveValue("Import glTF");
+        await importNode.getByText("Import glTF", { exact: true }).click({ button: "right" });
+        await page.getByRole("menuitem", { name: "Copy" }).click();
+        await expect(selectedNodeName).toHaveValue("Import glTF");
+
+        const menuPoint = await editor.findEmptyCanvasPoint();
+        await page.mouse.click(menuPoint.x, menuPoint.y, { button: "right" });
+        const paste = page.getByRole("menuitem", { name: "Paste" });
+        await expect(paste).toBeVisible();
+        await expect(paste).toBeEnabled();
+        await expect(selectedNodeName).toHaveValue("Import glTF");
+
+        const beforeOwner = {
+            nodeCount: await editor.nodes.count(),
+            position: await importNode.evaluate((node: HTMLElement) => {
+                const rect = node.getBoundingClientRect();
+                return { x: rect.x, y: rect.y };
+            }),
+        };
+        const pan = await beginSyntheticTouchPan(editor, 41);
+        await expect(selectedNodeName).toHaveValue("Import glTF");
+
+        await expect.soft(visibleMenus).toHaveCount(0);
+        await page.keyboard.press("Enter");
+        await expect.soft(editor.nodes).toHaveCount(beforeOwner.nodeCount);
+        const positionAfterStaleAction = await importNode.evaluate((node: HTMLElement) => {
+            const rect = node.getBoundingClientRect();
+            return { x: rect.x, y: rect.y };
         });
-        await expect(page.getByText("No selection", { exact: true })).toBeVisible();
-        await contextNode.dispatchEvent("contextmenu", {
-            ...foreignPointer,
-            button: 2,
-            buttons: 0,
-        });
-        await expect(page.getByRole("textbox").nth(0)).toHaveValue("Remove Unused Resources");
+        expect.soft(positionAfterStaleAction).toEqual(beforeOwner.position);
+        await expect(selectedNodeName).toHaveValue("Import glTF");
+
+        for (const openMenu of [
+            async () => contextNode.getByText("Remove Unused Resources", { exact: true }).click({ button: "right" }),
+            async () => clickWirePath(page, wireHitTarget, "right"),
+            async () => {
+                const point = await editor.findEmptyCanvasPoint();
+                await page.mouse.click(point.x, point.y, { button: "right" });
+            },
+        ]) {
+            await openMenu();
+            await expect.soft(visibleMenus).toHaveCount(0);
+            if ((await visibleMenus.count()) > 0) {
+                await page.keyboard.press("Escape");
+            }
+            await expect(selectedNodeName).toHaveValue("Import glTF");
+        }
+
+        await endSyntheticTouchPan(editor, pan, "pointercancel");
+
+        await contextNode.getByText("Remove Unused Resources", { exact: true }).click({ button: "right" });
+        await expect(page.getByRole("menuitem", { name: "Copy" })).toBeVisible();
+        await page.keyboard.press("Escape");
+        await clickWirePath(page, wireHitTarget, "right");
+        await expect(page.getByRole("menuitem", { name: "Delete wire" })).toBeVisible();
+        await page.keyboard.press("Escape");
+        const idleCanvasPoint = await editor.findEmptyCanvasPoint();
+        await page.mouse.click(idleCanvasPoint.x, idleCanvasPoint.y, { button: "right" });
+        const beforeIdlePaste = await editor.nodes.count();
+        await expect(paste).toBeVisible();
+        await expect(paste).toBeEnabled();
+        await paste.click();
+        await expect(editor.nodes).toHaveCount(beforeIdlePaste + 1);
+        const fitMenuPoint = await editor.findEmptyCanvasPoint();
+        await page.mouse.click(fitMenuPoint.x, fitMenuPoint.y, { button: "right" });
+        await expect(page.getByRole("menuitem", { name: "Zoom to fit" })).toBeVisible();
         await page.keyboard.press("Escape");
     });
 

--- a/packages/tools/nodeAssetsEditor/test/unit/graphNodeDiagnostics.test.tsx
+++ b/packages/tools/nodeAssetsEditor/test/unit/graphNodeDiagnostics.test.tsx
@@ -41,6 +41,10 @@ describe("GraphNodeView diagnostics", () => {
             beginPortInteraction: () => undefined,
             selectWire: () => undefined,
             openContextMenu: () => undefined,
+            runWhenIdle: (action) => {
+                action();
+                return true;
+            },
         };
 
         const markup = renderToStaticMarkup(

--- a/packages/tools/nodeAssetsEditor/test/unit/nodeGraph/gestureInterpreter.test.ts
+++ b/packages/tools/nodeAssetsEditor/test/unit/nodeGraph/gestureInterpreter.test.ts
@@ -6,6 +6,7 @@ import {
     BeginFrameGesture,
     BeginNodeGesture,
     BeginPortGesture,
+    CancelGesture,
     CompleteGesture,
     type Gesture,
     type GestureAction,
@@ -17,30 +18,35 @@ function Kinds(actions: readonly GestureAction[]): string[] {
 
 describe("gestureInterpreter.BeginBackgroundGesture", () => {
     it("starts a pan on the middle button", () => {
-        const { gesture, actions } = BeginBackgroundGesture({ button: 1, spaceHeld: false, additive: false, world: { x: 5, y: 6 }, local: { x: 7, y: 8 } });
-        expect(gesture).toEqual({ kind: "pan", lastLocal: { x: 7, y: 8 } });
+        const { gesture, actions } = BeginBackgroundGesture({ pointerId: 7, button: 1, spaceHeld: false, additive: false, world: { x: 5, y: 6 }, local: { x: 7, y: 8 } });
+        expect(gesture).toEqual({ kind: "pan", pointerId: 7, lastLocal: { x: 7, y: 8 }, moved: false, clearSelectionOnClick: false });
         expect(actions).toEqual([]);
     });
 
     it("starts a pan on space + left button", () => {
-        const { gesture } = BeginBackgroundGesture({ button: 0, spaceHeld: true, additive: false, world: { x: 5, y: 6 }, local: { x: 7, y: 8 } });
+        const { gesture } = BeginBackgroundGesture({ pointerId: 7, button: 0, spaceHeld: true, additive: false, world: { x: 5, y: 6 }, local: { x: 7, y: 8 } });
         expect(gesture.kind).toBe("pan");
     });
 
-    it("starts a marquee and clears the selection on a plain left press", () => {
-        const { gesture, actions } = BeginBackgroundGesture({ button: 0, spaceHeld: false, additive: false, world: { x: 5, y: 6 }, local: { x: 7, y: 8 } });
-        expect(gesture).toEqual({ kind: "marquee", startWorld: { x: 5, y: 6 }, startLocal: { x: 7, y: 8 }, additive: false });
-        expect(actions).toEqual([{ kind: "clearSelection" }, { kind: "setMarquee", rect: { x: 7, y: 8, width: 0, height: 0 } }]);
+    it("starts a pan on a plain left press", () => {
+        const { gesture, actions } = BeginBackgroundGesture({ pointerId: 7, button: 0, spaceHeld: false, additive: false, world: { x: 5, y: 6 }, local: { x: 7, y: 8 } });
+        expect(gesture.kind).toBe("pan");
+        expect(actions).toEqual([]);
     });
 
     it("does not clear the selection on an additive (shift) left press", () => {
-        const { gesture, actions } = BeginBackgroundGesture({ button: 0, spaceHeld: false, additive: true, world: { x: 5, y: 6 }, local: { x: 7, y: 8 } });
+        const { gesture, actions } = BeginBackgroundGesture({ pointerId: 7, button: 0, spaceHeld: false, additive: true, world: { x: 5, y: 6 }, local: { x: 7, y: 8 } });
         expect(gesture.kind).toBe("marquee");
         expect(Kinds(actions)).toEqual(["setMarquee"]);
     });
 
+    it("keeps additive marquee priority when Space is also held", () => {
+        const { gesture } = BeginBackgroundGesture({ pointerId: 7, button: 0, spaceHeld: true, additive: true, world: { x: 5, y: 6 }, local: { x: 7, y: 8 } });
+        expect(gesture.kind).toBe("marquee");
+    });
+
     it("does nothing for other buttons", () => {
-        const { gesture, actions } = BeginBackgroundGesture({ button: 2, spaceHeld: false, additive: false, world: { x: 0, y: 0 }, local: { x: 0, y: 0 } });
+        const { gesture, actions } = BeginBackgroundGesture({ pointerId: 7, button: 2, spaceHeld: false, additive: false, world: { x: 0, y: 0 }, local: { x: 0, y: 0 } });
         expect(gesture).toEqual({ kind: "none" });
         expect(actions).toEqual([]);
     });
@@ -48,84 +54,138 @@ describe("gestureInterpreter.BeginBackgroundGesture", () => {
 
 describe("gestureInterpreter.BeginNodeGesture", () => {
     it("selects an unselected node and brackets the interaction", () => {
-        const { gesture, actions } = BeginNodeGesture({ nodeId: "n1", additive: false, isSelected: false, world: { x: 3, y: 4 } });
-        expect(gesture).toEqual({ kind: "moveNodes", lastWorld: { x: 3, y: 4 }, moved: false });
+        const { gesture, actions } = BeginNodeGesture({ pointerId: 7, nodeId: "n1", additive: false, isSelected: false, world: { x: 3, y: 4 } });
+        expect(gesture).toEqual({ kind: "moveNodes", pointerId: 7, lastWorld: { x: 3, y: 4 }, moved: false });
         expect(actions).toEqual([{ kind: "selectNodes", nodeIds: ["n1"] }, { kind: "beginInteraction" }]);
     });
 
     it("toggles selection on an additive press", () => {
-        const { actions } = BeginNodeGesture({ nodeId: "n1", additive: true, isSelected: true, world: { x: 0, y: 0 } });
+        const { actions } = BeginNodeGesture({ pointerId: 7, nodeId: "n1", additive: true, isSelected: true, world: { x: 0, y: 0 } });
         expect(actions).toEqual([{ kind: "toggleNodeSelection", nodeId: "n1" }, { kind: "beginInteraction" }]);
     });
 
     it("keeps an existing selection when the node is already selected", () => {
-        const { actions } = BeginNodeGesture({ nodeId: "n1", additive: false, isSelected: true, world: { x: 0, y: 0 } });
+        const { actions } = BeginNodeGesture({ pointerId: 7, nodeId: "n1", additive: false, isSelected: true, world: { x: 0, y: 0 } });
         expect(actions).toEqual([{ kind: "beginInteraction" }]);
     });
 });
 
 describe("gestureInterpreter.BeginFrameGesture", () => {
     it("brackets the interaction and tracks the frame", () => {
-        const { gesture, actions } = BeginFrameGesture({ frameId: "f1", world: { x: 9, y: 10 } });
-        expect(gesture).toEqual({ kind: "moveFrame", frameId: "f1", lastWorld: { x: 9, y: 10 }, moved: false });
+        const { gesture, actions } = BeginFrameGesture({ pointerId: 7, frameId: "f1", world: { x: 9, y: 10 } });
+        expect(gesture).toEqual({ kind: "moveFrame", pointerId: 7, frameId: "f1", lastWorld: { x: 9, y: 10 }, moved: false });
         expect(actions).toEqual([{ kind: "beginInteraction" }]);
     });
 });
 
 describe("gestureInterpreter.BeginPortGesture", () => {
     it("starts a wire and previews it from the anchor to the pointer", () => {
-        const { gesture, actions } = BeginPortGesture({ portId: "p1", anchor: { x: 100, y: 50 }, world: { x: 120, y: 60 } });
-        expect(gesture).toEqual({ kind: "wire", fromPortId: "p1", fromAnchor: { x: 100, y: 50 } });
+        const { gesture, actions } = BeginPortGesture({ pointerId: 7, portId: "p1", anchor: { x: 100, y: 50 }, world: { x: 120, y: 60 } });
+        expect(gesture).toEqual({ kind: "wire", pointerId: 7, fromPortId: "p1", fromAnchor: { x: 100, y: 50 } });
         expect(actions).toEqual([{ kind: "setPendingWire", wire: { from: { x: 100, y: 50 }, to: { x: 120, y: 60 } } }]);
     });
 });
 
 describe("gestureInterpreter.AdvanceGesture", () => {
+    it("ignores move and completion events from a pointer that does not own the gesture", () => {
+        const gesture = BeginBackgroundGesture({
+            pointerId: 7,
+            button: 0,
+            spaceHeld: false,
+            additive: false,
+            world: { x: 0, y: 0 },
+            local: { x: 10, y: 10 },
+        }).gesture;
+        const moved = AdvanceGesture(gesture, { pointerId: 8, world: { x: 50, y: 50 }, local: { x: 60, y: 60 } });
+        expect(moved.gesture).toBe(gesture);
+        expect(moved.actions).toEqual([]);
+
+        const completed = CompleteGesture(gesture, { pointerId: 8, world: { x: 50, y: 50 } });
+        expect(completed.gesture).toBe(gesture);
+        expect(completed.actions).toEqual([]);
+    });
+
     it("pans by the viewport-local delta", () => {
-        const gesture: Gesture = { kind: "pan", lastLocal: { x: 10, y: 10 } };
-        const { gesture: next, actions } = AdvanceGesture(gesture, { world: { x: 0, y: 0 }, local: { x: 25, y: 4 } });
+        const gesture: Gesture = { kind: "pan", pointerId: 7, lastLocal: { x: 10, y: 10 }, moved: false, clearSelectionOnClick: true };
+        const { gesture: next, actions } = AdvanceGesture(gesture, { pointerId: 7, world: { x: 0, y: 0 }, local: { x: 25, y: 4 } });
         expect(actions).toEqual([{ kind: "panBy", dx: 15, dy: -6 }]);
-        expect(next).toEqual({ kind: "pan", lastLocal: { x: 25, y: 4 } });
+        expect(next).toEqual({ kind: "pan", pointerId: 7, lastLocal: { x: 25, y: 4 }, moved: true, clearSelectionOnClick: true });
+    });
+
+    it("ignores a zero-delta pan move without latching movement", () => {
+        const gesture: Gesture = { kind: "pan", pointerId: 7, lastLocal: { x: 10, y: 10 }, moved: false, clearSelectionOnClick: true };
+        const { gesture: next, actions } = AdvanceGesture(gesture, { pointerId: 7, world: { x: 0, y: 0 }, local: { x: 10, y: 10 } });
+        expect(actions).toEqual([]);
+        expect(next).toBe(gesture);
     });
 
     it("normalizes the marquee rectangle regardless of drag direction", () => {
-        const gesture: Gesture = { kind: "marquee", startWorld: { x: 0, y: 0 }, startLocal: { x: 30, y: 40 }, additive: false };
-        const { actions } = AdvanceGesture(gesture, { world: { x: 0, y: 0 }, local: { x: 10, y: 100 } });
+        const gesture: Gesture = { kind: "marquee", pointerId: 7, startWorld: { x: 0, y: 0 }, startLocal: { x: 30, y: 40 }, additive: false };
+        const { actions } = AdvanceGesture(gesture, { pointerId: 7, world: { x: 0, y: 0 }, local: { x: 10, y: 100 } });
         expect(actions).toEqual([{ kind: "setMarquee", rect: { x: 10, y: 40, width: 20, height: 60 } }]);
     });
 
     it("translates selected nodes and latches moved on a non-zero delta", () => {
-        const gesture: Gesture = { kind: "moveNodes", lastWorld: { x: 0, y: 0 }, moved: false };
-        const { gesture: next, actions } = AdvanceGesture(gesture, { world: { x: 5, y: -3 }, local: { x: 0, y: 0 } });
+        const gesture: Gesture = { kind: "moveNodes", pointerId: 7, lastWorld: { x: 0, y: 0 }, moved: false };
+        const { gesture: next, actions } = AdvanceGesture(gesture, { pointerId: 7, world: { x: 5, y: -3 }, local: { x: 0, y: 0 } });
         expect(actions).toEqual([{ kind: "translateSelectedNodes", delta: { x: 5, y: -3 } }]);
-        expect(next).toEqual({ kind: "moveNodes", lastWorld: { x: 5, y: -3 }, moved: true });
+        expect(next).toEqual({ kind: "moveNodes", pointerId: 7, lastWorld: { x: 5, y: -3 }, moved: true });
     });
 
     it("ignores a zero-delta node move and keeps the moved latch", () => {
-        const moved: Gesture = { kind: "moveNodes", lastWorld: { x: 5, y: 5 }, moved: true };
-        const { gesture: next, actions } = AdvanceGesture(moved, { world: { x: 5, y: 5 }, local: { x: 0, y: 0 } });
+        const moved: Gesture = { kind: "moveNodes", pointerId: 7, lastWorld: { x: 5, y: 5 }, moved: true };
+        const { gesture: next, actions } = AdvanceGesture(moved, { pointerId: 7, world: { x: 5, y: 5 }, local: { x: 0, y: 0 } });
         expect(actions).toEqual([]);
         expect(next).toBe(moved);
     });
 
     it("translates a frame on a non-zero delta", () => {
-        const gesture: Gesture = { kind: "moveFrame", frameId: "f1", lastWorld: { x: 0, y: 0 }, moved: false };
-        const { gesture: next, actions } = AdvanceGesture(gesture, { world: { x: 2, y: 2 }, local: { x: 0, y: 0 } });
+        const gesture: Gesture = { kind: "moveFrame", pointerId: 7, frameId: "f1", lastWorld: { x: 0, y: 0 }, moved: false };
+        const { gesture: next, actions } = AdvanceGesture(gesture, { pointerId: 7, world: { x: 2, y: 2 }, local: { x: 0, y: 0 } });
         expect(actions).toEqual([{ kind: "translateFrame", frameId: "f1", delta: { x: 2, y: 2 } }]);
-        expect(next).toEqual({ kind: "moveFrame", frameId: "f1", lastWorld: { x: 2, y: 2 }, moved: true });
+        expect(next).toEqual({ kind: "moveFrame", pointerId: 7, frameId: "f1", lastWorld: { x: 2, y: 2 }, moved: true });
     });
 
     it("updates the pending wire endpoint while dragging a wire", () => {
-        const gesture: Gesture = { kind: "wire", fromPortId: "p1", fromAnchor: { x: 100, y: 50 } };
-        const { actions } = AdvanceGesture(gesture, { world: { x: 130, y: 70 }, local: { x: 0, y: 0 } });
+        const gesture: Gesture = { kind: "wire", pointerId: 7, fromPortId: "p1", fromAnchor: { x: 100, y: 50 } };
+        const { actions } = AdvanceGesture(gesture, { pointerId: 7, world: { x: 130, y: 70 }, local: { x: 0, y: 0 } });
         expect(actions).toEqual([{ kind: "setPendingWire", wire: { from: { x: 100, y: 50 }, to: { x: 130, y: 70 } } }]);
     });
 });
 
 describe("gestureInterpreter.CompleteGesture", () => {
+    it("clears the selection when a primary background pan completes without movement", () => {
+        const { gesture } = BeginBackgroundGesture({ pointerId: 7, button: 0, spaceHeld: false, additive: false, world: { x: 10, y: 20 }, local: { x: 30, y: 40 } });
+        const { gesture: next, actions } = CompleteGesture(gesture, { pointerId: 7, world: { x: 10, y: 20 } });
+        expect(next).toEqual({ kind: "none" });
+        expect(actions).toEqual([{ kind: "clearSelection" }]);
+    });
+
+    it("preserves the selection when a primary background pan moved", () => {
+        const started = BeginBackgroundGesture({ pointerId: 7, button: 0, spaceHeld: false, additive: false, world: { x: 10, y: 20 }, local: { x: 30, y: 40 } }).gesture;
+        const advanced = AdvanceGesture(started, { pointerId: 7, world: { x: 10, y: 20 }, local: { x: 31, y: 40 } }).gesture;
+        const { actions } = CompleteGesture(advanced, { pointerId: 7, world: { x: 10, y: 20 } });
+        expect(actions).toEqual([]);
+    });
+
+    it.each([
+        ["middle-button", { button: 1, spaceHeld: false }],
+        ["Space + primary", { button: 0, spaceHeld: true }],
+    ])("does not clear selection when an unmoved %s pan alias completes", (_name, input) => {
+        const gesture = BeginBackgroundGesture({
+            pointerId: 7,
+            ...input,
+            additive: false,
+            world: { x: 10, y: 20 },
+            local: { x: 30, y: 40 },
+        }).gesture;
+        const { actions } = CompleteGesture(gesture, { pointerId: 7, world: { x: 10, y: 20 } });
+        expect(actions).toEqual([]);
+    });
+
     it("selects nodes inside the marquee region and clears the overlay", () => {
-        const gesture: Gesture = { kind: "marquee", startWorld: { x: 10, y: 80 }, startLocal: { x: 0, y: 0 }, additive: true };
-        const { gesture: next, actions } = CompleteGesture(gesture, { world: { x: 40, y: 20 } });
+        const gesture: Gesture = { kind: "marquee", pointerId: 7, startWorld: { x: 10, y: 80 }, startLocal: { x: 0, y: 0 }, additive: true };
+        const { gesture: next, actions } = CompleteGesture(gesture, { pointerId: 7, world: { x: 40, y: 20 } });
         expect(actions).toEqual([
             { kind: "selectNodesInRegion", region: { minX: 10, minY: 20, maxX: 40, maxY: 80 }, additive: true },
             { kind: "setMarquee", rect: null },
@@ -134,14 +194,14 @@ describe("gestureInterpreter.CompleteGesture", () => {
     });
 
     it("ends a node move interaction with the moved flag", () => {
-        const gesture: Gesture = { kind: "moveNodes", lastWorld: { x: 0, y: 0 }, moved: true };
-        const { actions } = CompleteGesture(gesture, { world: { x: 0, y: 0 } });
+        const gesture: Gesture = { kind: "moveNodes", pointerId: 7, lastWorld: { x: 0, y: 0 }, moved: true };
+        const { actions } = CompleteGesture(gesture, { pointerId: 7, world: { x: 0, y: 0 } });
         expect(actions).toEqual([{ kind: "endInteraction", moved: true }]);
     });
 
     it("connects a wire to the resolved target port", () => {
-        const gesture: Gesture = { kind: "wire", fromPortId: "p1", fromAnchor: { x: 0, y: 0 } };
-        const { actions } = CompleteGesture(gesture, { world: { x: 0, y: 0 }, resolvedTargetPortId: "p2" });
+        const gesture: Gesture = { kind: "wire", pointerId: 7, fromPortId: "p1", fromAnchor: { x: 0, y: 0 } };
+        const { actions } = CompleteGesture(gesture, { pointerId: 7, world: { x: 0, y: 0 }, resolvedTargetPortId: "p2" });
         expect(actions).toEqual([
             { kind: "connect", fromPortId: "p1", toPortId: "p2" },
             { kind: "setPendingWire", wire: null },
@@ -149,20 +209,76 @@ describe("gestureInterpreter.CompleteGesture", () => {
     });
 
     it("does not connect a wire to its own origin port", () => {
-        const gesture: Gesture = { kind: "wire", fromPortId: "p1", fromAnchor: { x: 0, y: 0 } };
-        const { actions } = CompleteGesture(gesture, { world: { x: 0, y: 0 }, resolvedTargetPortId: "p1" });
+        const gesture: Gesture = { kind: "wire", pointerId: 7, fromPortId: "p1", fromAnchor: { x: 0, y: 0 } };
+        const { actions } = CompleteGesture(gesture, { pointerId: 7, world: { x: 0, y: 0 }, resolvedTargetPortId: "p1" });
         expect(actions).toEqual([{ kind: "setPendingWire", wire: null }]);
     });
 
     it("clears the pending wire when there is no target", () => {
-        const gesture: Gesture = { kind: "wire", fromPortId: "p1", fromAnchor: { x: 0, y: 0 } };
-        const { actions } = CompleteGesture(gesture, { world: { x: 0, y: 0 } });
+        const gesture: Gesture = { kind: "wire", pointerId: 7, fromPortId: "p1", fromAnchor: { x: 0, y: 0 } };
+        const { actions } = CompleteGesture(gesture, { pointerId: 7, world: { x: 0, y: 0 } });
         expect(actions).toEqual([{ kind: "setPendingWire", wire: null }]);
     });
 
     it("resets to no gesture when idle", () => {
-        const { gesture, actions } = CompleteGesture({ kind: "none" }, { world: { x: 0, y: 0 } });
+        const { gesture, actions } = CompleteGesture({ kind: "none" }, { pointerId: 7, world: { x: 0, y: 0 } });
         expect(gesture).toEqual({ kind: "none" });
+        expect(actions).toEqual([]);
+    });
+});
+
+describe("gestureInterpreter.CancelGesture", () => {
+    it("cancels an unmoved primary pan without clearing selection", () => {
+        const gesture = BeginBackgroundGesture({
+            pointerId: 7,
+            button: 0,
+            spaceHeld: false,
+            additive: false,
+            world: { x: 10, y: 20 },
+            local: { x: 30, y: 40 },
+        }).gesture;
+        const { gesture: next, actions } = CancelGesture(gesture, { pointerId: 7 });
+        expect(next).toEqual({ kind: "none" });
+        expect(actions).toEqual([]);
+    });
+
+    it("clears an active marquee without committing its selection", () => {
+        const gesture: Gesture = {
+            kind: "marquee",
+            pointerId: 7,
+            startWorld: { x: 10, y: 20 },
+            startLocal: { x: 30, y: 40 },
+            additive: true,
+        };
+        const { gesture: next, actions } = CancelGesture(gesture, { pointerId: 7 });
+        expect(next).toEqual({ kind: "none" });
+        expect(actions).toEqual([{ kind: "setMarquee", rect: null }]);
+    });
+
+    it("clears a pending wire without connecting it", () => {
+        const gesture: Gesture = { kind: "wire", pointerId: 7, fromPortId: "p1", fromAnchor: { x: 10, y: 20 } };
+        const { gesture: next, actions } = CancelGesture(gesture, { pointerId: 7 });
+        expect(next).toEqual({ kind: "none" });
+        expect(actions).toEqual([{ kind: "setPendingWire", wire: null }]);
+    });
+
+    it("closes a bracketed node move using its movement latch", () => {
+        const gesture: Gesture = { kind: "moveNodes", pointerId: 7, lastWorld: { x: 10, y: 20 }, moved: true };
+        const { gesture: next, actions } = CancelGesture(gesture, { pointerId: 7 });
+        expect(next).toEqual({ kind: "none" });
+        expect(actions).toEqual([{ kind: "endInteraction", moved: true }]);
+    });
+
+    it("closes a bracketed frame move without inventing movement", () => {
+        const gesture: Gesture = { kind: "moveFrame", pointerId: 7, frameId: "f1", lastWorld: { x: 10, y: 20 }, moved: false };
+        const { actions } = CancelGesture(gesture, { pointerId: 7 });
+        expect(actions).toEqual([{ kind: "endInteraction", moved: false }]);
+    });
+
+    it("ignores cancellation from a pointer that does not own the gesture", () => {
+        const gesture: Gesture = { kind: "pan", pointerId: 7, lastLocal: { x: 10, y: 20 }, moved: true, clearSelectionOnClick: true };
+        const { gesture: next, actions } = CancelGesture(gesture, { pointerId: 8 });
+        expect(next).toBe(gesture);
         expect(actions).toEqual([]);
     });
 });


### PR DESCRIPTION
## Summary

- pan the Node Assets Editor graph with an unmodified primary drag on empty canvas
- preserve no-move deselection, marquee modifiers, middle/Space aliases, node/frame/port/wire/minimap/context-menu priority, and wheel zoom
- enforce initiating-pointer ownership across controls and React-portal menus
- use complete touch/mouse lifecycles and recover cleanly after pointerup, lost capture, and pointercancel

## Validation

- Validated immutable tree: `79bbded024f69b88e7c60cf2453aeab18e94aa2e` at `fdafa9ea97be9d9b16f7f73406f3a062985c24e9`.
- Current feature head `d1701cf16768369a88ba36c9432194a51d594b41` has the identical tree after merging PR #22.
- Combined independent standards/acceptance audit: clean across 17 commits / 13 files / zero findings.
- Focused units: 38/38.
- Full unit first pass: 364 files; 5,375 passed, 1 expected failure, 30 skipped.
- Format, source/tools/test-tools builds, editor build, ESLint, all 16 tree-shaking checks, and all 4 side-effect sync checks passed.
- Targeted Playwright first pass with retries disabled: 5/5.
- Full NAE Playwright first pass with retries disabled: 44/44.
- Final process, port, artifact, and worktree cleanup was clean.

Base: `preview/nae`