### PR TITLE
feat(nae): show palette descriptions in accessible tooltips

### DIFF
--- a/.scratch/palette-description-tooltips/PRD.md
+++ b/.scratch/palette-description-tooltips/PRD.md
@@ -1,0 +1,78 @@
+# PRD — Palette description tooltips
+
+Status: ready-for-agent
+
+## Problem Statement
+
+The Node Assets Editor palette renders every available node description as a permanent subheading below the node name. The extra copy makes the categorized list taller and harder to scan, especially when authors browse many Universal decisions, while still failing to give keyboard users an intentional way to request the same help. Authors need a compact name-first palette without losing descriptions, search terms, or accessible guidance.
+
+## Solution
+
+Render each palette item with its node name as the only always-visible item text. Preserve the existing optional description in the palette model and search projection, and expose each non-empty description through the repository's shared Fluent Tooltip primitive. The entire draggable row is the trigger: the tooltip appears with Fluent's existing default timing and placement on pointer hover and keyboard focus, and contributes an accessible description while the visible node name remains the accessible name. Items without meaningful descriptions remain ordinary draggable rows and never produce an empty tooltip.
+
+## User Stories
+
+1. As a graph author, I want palette rows to show node names without permanent descriptions, so that I can scan more nodes at once.
+2. As a graph author, I want a node's explanation on hover, so that I can learn an unfamiliar node without spending palette space on every explanation.
+3. As a keyboard user, I want the same explanation when I focus a palette row, so that the help is not pointer-only.
+4. As a screen-reader user, I want the visible node name to remain the item's accessible name and the tooltip copy to be its accessible description, so that identity and help are announced distinctly.
+5. As a graph author, I want descriptions to remain searchable, so that workflow-intent terms such as “decimate” still find the intended node.
+6. As a graph author, I want family headings, category counts, and category expansion to stay unchanged, so that the palette remains familiar.
+7. As a graph author, I want Show primitives to preserve its filtering and persistence behavior, so that tooltip presentation does not change discovery rules.
+8. As a graph author, I want to drag any described node to the canvas exactly as before, so that requesting help does not interfere with authoring.
+9. As a graph author, I want pointer clicks and taps on palette rows to retain their existing behavior, so that the tooltip does not add an accidental create action.
+10. As a touch user, I want the palette to keep scrolling and dragging without a new touch-only overlay or gesture, so that the change does not regress touch interaction.
+11. As a graph author, I want palette scrolling to remain smooth and contained within the pane, so that tooltip content does not participate in row layout.
+12. As a graph author, I want long node names to keep the palette's existing wrapping behavior, so that removing descriptions does not truncate names.
+13. As a graph author, I want long descriptions to use the established tooltip wrapping behavior, so that custom sizing does not create inconsistent UI.
+14. As a graph author, I want items without descriptions to behave normally and show no blank popup, so that empty metadata is not exposed.
+15. As a graph author, I want the tooltip to use the editor's active Fluent theme, so that help text matches the rest of the tool.
+16. As a graph author, I want the tooltip to use established timing and placement defaults, so that it feels like other Babylon editor tooltips.
+17. As a maintainer, I want tests to locate palette rows by stable palette semantics rather than native title attributes, so that replacing browser titles does not weaken drag coverage.
+18. As a maintainer, I want browser coverage for hidden descriptions, hover, focus, search, and drag, so that future palette work preserves the compact accessible behavior.
+
+## Acceptance Criteria
+
+- [ ] Each palette item shows its node name as the only always-visible item copy; descriptions are absent from row layout and are not rendered as visible subheadings.
+- [ ] The existing optional description metadata remains in palette items and remains part of `PaletteItemMatchesFilter`; category, family, Show primitives, and empty-search behavior are unchanged.
+- [ ] Every non-empty description is supplied to `shared-ui-components/fluent/primitives/tooltip`; no raw HTML `title` is used as a substitute or competing native tooltip.
+- [ ] The whole draggable palette row triggers the tooltip on pointer hover and keyboard focus using the shared primitive's accessible description relationship.
+- [ ] The focusable trigger's visible node name remains its accessible name, and the tooltip text is exposed as its accessible description rather than replacing the name.
+- [ ] Missing, empty, or whitespace-only descriptions do not create an empty tooltip.
+- [ ] Tooltip delay, positioning, portal behavior, and text wrapping use the existing shared Fluent defaults; this feature adds no custom timing, placement, width, or pointer-event layer.
+- [ ] Existing label wrapping/truncation behavior, row border/padding/minimum height, family spacing, and category density are preserved except for removal of the description line.
+- [ ] Tooltip plumbing does not change native drag payloads, canvas drops, clicking, pane scrolling, filtering, category toggling, virtualization assumptions, or touch handling.
+- [ ] Automated browser coverage proves descriptions are absent before interaction, appear as accessible tooltips on both hover and focus, remain searchable, and do not break an existing node drop.
+- [ ] Focused unit tests for palette search/projection, the targeted Node Assets Editor Playwright test, package build/type-check, and changed-file lint/format checks pass.
+- [ ] The rendered editor at the existing Node Assets Editor dev surface (default port 1348) is checked for compact rows, themed tooltip rendering, keyboard focus, and successful drag/drop.
+
+## Implementation Decisions
+
+- Keep the feature inside the reusable node-graph palette view; do not change block descriptors or duplicate description state.
+- Reuse the shared Fluent Tooltip abstraction, which already suppresses absent content and applies `relationship="description"`; do not import raw Fluent Tooltip directly.
+- Keep each draggable row as the tooltip child so Fluent augments the trigger without inserting a layout wrapper. Make the existing row keyboard-focusable and retain its drag handler and data attributes.
+- Normalize tooltip content only enough to suppress whitespace-only descriptions. The source description and search metadata remain unchanged.
+- Remove the native title attribute from palette rows. Browser tests and drag helpers should locate rows through the stable palette item test seam and exact visible label.
+- Preserve Fluent theme tokens, current item padding/minimum height, and node-name typography. Do not add custom tooltip styles, timing, placement, truncation, or open-state management.
+- Update directly related model/catalog comments that still describe descriptions as visible beneath labels.
+- Do not add click-to-create or keyboard-to-create behavior as part of making rows focusable; this feature only changes help presentation.
+
+## Testing Decisions
+
+- Use the real Node Assets Editor Playwright surface as the highest test seam. Adapt the existing workflow-intent/description test so one real palette item proves description-based search, no always-visible description, pointer-hover tooltip, keyboard-focus tooltip, accessible name/description semantics, and an unchanged drag/drop action.
+- Update the shared Playwright page helper so palette-item lookup no longer depends on the removed native title. Existing drop-heavy tests remain regression coverage for drag payloads and canvas creation.
+- Keep the existing pure palette-category tests as the seam proving descriptions and keywords still participate in filtering and projection.
+- Prefer role, accessible-description, visible-label, and palette test-id assertions over Fluent implementation selectors. Allow the established tooltip delay rather than overriding production timing for tests.
+- No screenshot baseline is required: this is semantic/density behavior covered stably by DOM and accessibility assertions. Perform a rendered browser check for row density, tooltip placement/theme, focus, scrolling, and drag/drop.
+
+## Out of Scope
+
+- Editing node description copy, keywords, categories, families, or descriptor registration.
+- Changing palette search, Show primitives, accordion behavior, pane sizing, scrolling, or adding virtualization.
+- Adding click-to-create, Enter/Space-to-create, touch long-press help, pinned help, or custom tooltip preferences.
+- Reworking palette rows into a new control type or changing any other Babylon editor palette.
+- Custom tooltip timing, placement, width, animation, or styling.
+
+## Further Notes
+
+The implementation baseline is the latest `preview/nae`. Concurrent graph-panning work is expected to stay in canvas files, while concurrent import-node work may update block descriptors, palette catalog tests, and the large Node Assets Editor Playwright file. Keep edits surgical, rebase before integration, and resolve nearby test changes without overwriting new import coverage.

--- a/.scratch/palette-description-tooltips/PRD.md
+++ b/.scratch/palette-description-tooltips/PRD.md
@@ -8,12 +8,12 @@ The Node Assets Editor palette renders every available node description as a per
 
 ## Solution
 
-Render each palette item with its node name as the only always-visible item text. Preserve the existing optional description in the palette model and search projection, and expose each non-empty description through the repository's shared Fluent Tooltip primitive. The entire draggable row is the trigger: the tooltip appears with Fluent's existing default timing and placement on pointer hover and keyboard focus, and contributes an accessible description while the visible node name remains the accessible name. Items without meaningful descriptions remain ordinary draggable rows and never produce an empty tooltip.
+Render each palette item with its node name as the only always-visible item text. Preserve the existing optional description in the palette model and search projection, and expose each non-empty description through the repository's shared Fluent Tooltip primitive. The entire draggable row is the trigger: the tooltip appears with Fluent's existing default timing and placement on mouse or pen hover and keyboard focus, and contributes an accessible description while the visible node name remains the accessible name. A minimal controlled visibility path rejects touch-originated open requests so touch contact does not introduce long-press help. Items without meaningful descriptions remain ordinary draggable rows and never produce an empty tooltip.
 
 ## User Stories
 
 1. As a graph author, I want palette rows to show node names without permanent descriptions, so that I can scan more nodes at once.
-2. As a graph author, I want a node's explanation on hover, so that I can learn an unfamiliar node without spending palette space on every explanation.
+2. As a graph author, I want a node's explanation on mouse or pen hover, so that I can learn an unfamiliar node without spending palette space on every explanation.
 3. As a keyboard user, I want the same explanation when I focus a palette row, so that the help is not pointer-only.
 4. As a screen-reader user, I want the visible node name to remain the item's accessible name and the tooltip copy to be its accessible description, so that identity and help are announced distinctly.
 5. As a graph author, I want descriptions to remain searchable, so that workflow-intent terms such as “decimate” still find the intended node.
@@ -36,30 +36,31 @@ Render each palette item with its node name as the only always-visible item text
 - [ ] Each palette item shows its node name as the only always-visible item copy; descriptions are absent from row layout and are not rendered as visible subheadings.
 - [ ] The existing optional description metadata remains in palette items and remains part of `PaletteItemMatchesFilter`; category, family, Show primitives, and empty-search behavior are unchanged.
 - [ ] Every non-empty description is supplied to `shared-ui-components/fluent/primitives/tooltip`; no raw HTML `title` is used as a substitute or competing native tooltip.
-- [ ] The whole draggable palette row triggers the tooltip on pointer hover and keyboard focus using the shared primitive's accessible description relationship.
+- [ ] The whole draggable palette row triggers the tooltip on mouse or pen hover and keyboard focus using the shared primitive's accessible description relationship.
 - [ ] The focusable trigger's visible node name remains its accessible name, and the tooltip text is exposed as its accessible description rather than replacing the name.
 - [ ] Missing, empty, or whitespace-only descriptions do not create an empty tooltip.
-- [ ] Tooltip delay, positioning, portal behavior, and text wrapping use the existing shared Fluent defaults; this feature adds no custom timing, placement, width, or pointer-event layer.
+- [ ] Tooltip delay, positioning, portal behavior, and text wrapping use the existing shared Fluent defaults; controlled visibility only suppresses touch-originated open requests.
 - [ ] Existing label wrapping/truncation behavior, row border/padding/minimum height, family spacing, and category density are preserved except for removal of the description line.
-- [ ] Tooltip plumbing does not change native drag payloads, canvas drops, clicking, pane scrolling, filtering, category toggling, virtualization assumptions, or touch handling.
-- [ ] Automated browser coverage proves descriptions are absent before interaction, appear as accessible tooltips on both hover and focus, remain searchable, and do not break an existing node drop.
+- [ ] Tooltip plumbing does not change native drag payloads, canvas drops, clicking, pane scrolling, filtering, category toggling, or virtualization assumptions.
+- [ ] Holding touch contact beyond Fluent's show delay does not open a tooltip or add a touch long-press help gesture.
+- [ ] Automated browser coverage proves descriptions are absent before interaction, remain hidden during touch contact, appear as accessible tooltips on mouse hover and keyboard focus, remain searchable, and do not break an existing node drop.
 - [ ] Focused unit tests for palette search/projection, the targeted Node Assets Editor Playwright test, package build/type-check, and changed-file lint/format checks pass.
 - [ ] The rendered editor at the existing Node Assets Editor dev surface (default port 1348) is checked for compact rows, themed tooltip rendering, keyboard focus, and successful drag/drop.
 
 ## Implementation Decisions
 
 - Keep the feature inside the reusable node-graph palette view; do not change block descriptors or duplicate description state.
-- Reuse the shared Fluent Tooltip abstraction, which already suppresses absent content and applies `relationship="description"`; do not import raw Fluent Tooltip directly.
+- Reuse the shared Fluent Tooltip abstraction, which suppresses absent content, applies `relationship="description"`, and passes through Fluent's controlled visibility props; do not import raw Fluent Tooltip directly.
 - Keep each draggable row as the tooltip child so Fluent augments the trigger without inserting a layout wrapper. Make the existing row keyboard-focusable and retain its drag handler and data attributes.
 - Normalize tooltip content only enough to suppress whitespace-only descriptions. The source description and search metadata remain unchanged.
 - Remove the native title attribute from palette rows. Browser tests and drag helpers should locate rows through the stable palette item test seam and exact visible label.
-- Preserve Fluent theme tokens, current item padding/minimum height, and node-name typography. Do not add custom tooltip styles, timing, placement, truncation, or open-state management.
+- Preserve Fluent theme tokens, current item padding/minimum height, and node-name typography. Do not add custom tooltip styles, timing, placement, or truncation; control visibility only to reject touch-originated opens.
 - Update directly related model/catalog comments that still describe descriptions as visible beneath labels.
 - Do not add click-to-create or keyboard-to-create behavior as part of making rows focusable; this feature only changes help presentation.
 
 ## Testing Decisions
 
-- Use the real Node Assets Editor Playwright surface as the highest test seam. Adapt the existing workflow-intent/description test so one real palette item proves description-based search, no always-visible description, pointer-hover tooltip, keyboard-focus tooltip, accessible name/description semantics, and an unchanged drag/drop action.
+- Use the real Node Assets Editor Playwright surface as the highest test seam. Adapt the existing workflow-intent/description test so one real palette item proves description-based search, no always-visible description, no tooltip after touch contact exceeds the show delay, mouse-hover and keyboard-focus tooltips, accessible name/description semantics, and an unchanged drag/drop action.
 - Update the shared Playwright page helper so palette-item lookup no longer depends on the removed native title. Existing drop-heavy tests remain regression coverage for drag payloads and canvas creation.
 - Keep the existing pure palette-category tests as the seam proving descriptions and keywords still participate in filtering and projection.
 - Prefer role, accessible-description, visible-label, and palette test-id assertions over Fluent implementation selectors. Allow the established tooltip delay rather than overriding production timing for tests.

--- a/.scratch/palette-description-tooltips/issues/01-implement-accessible-palette-description-tooltips.md
+++ b/.scratch/palette-description-tooltips/issues/01-implement-accessible-palette-description-tooltips.md
@@ -1,6 +1,6 @@
 # Implement accessible palette description tooltips
 
-Status: resolved
+Status: ready-for-agent
 
 ## Parent
 
@@ -8,19 +8,20 @@ Status: resolved
 
 ## What to build
 
-Make the Node Assets Editor palette name-first and compact by removing always-visible node descriptions from palette rows while preserving description metadata and description-based search. Attach every meaningful description to the entire draggable row through the existing shared Fluent Tooltip abstraction. The row must expose the node name as its accessible name and the tooltip copy as its accessible description on pointer hover and keyboard focus, without changing drag/drop, click/touch, scrolling, filtering, category, family, or Show primitives behavior. Update the existing browser test seam and drag helper so the behavior is verified without relying on native title attributes.
+Make the Node Assets Editor palette name-first and compact by removing always-visible node descriptions from palette rows while preserving description metadata and description-based search. Attach every meaningful description to the entire draggable row through the existing shared Fluent Tooltip abstraction. The row must expose the node name as its accessible name and the tooltip copy as its accessible description on mouse or pen hover and keyboard focus, while rejecting touch-originated tooltip opens without changing drag/drop, click/touch, scrolling, filtering, category, family, or Show primitives behavior. Update the existing browser test seam and drag helper so the behavior is verified without relying on native title attributes.
 
 ## Acceptance criteria
 
 - [x] Descriptions no longer render as visible palette subheadings; node names remain visible with existing typography and wrapping.
-- [x] Non-empty descriptions use `shared-ui-components/fluent/primitives/tooltip`, open on pointer hover and keyboard focus, and are exposed through the tooltip's accessible description relationship.
+- [x] Non-empty descriptions use `shared-ui-components/fluent/primitives/tooltip`, open on mouse or pen hover and keyboard focus, and are exposed through the tooltip's accessible description relationship.
 - [x] The focusable trigger keeps the node name as its accessible name; no native `title` tooltip competes with Fluent.
 - [x] Missing, empty, or whitespace-only descriptions create no tooltip.
-- [x] Tooltip defaults control timing, placement, wrapping, portal, and pointer behavior; no manual tooltip state or layout wrapper is added.
+- [x] Tooltip defaults control timing, placement, wrapping, portal, and pointer behavior; controlled visibility only rejects touch-originated open requests and adds no layout wrapper.
 - [x] Description metadata and description/keyword/category filtering remain unchanged.
-- [x] Drag payloads and canvas drops remain unchanged, and no click-to-create, keyboard-to-create, or touch gesture is introduced.
+- [x] Drag payloads and canvas drops remain unchanged, and no click-to-create or keyboard-to-create behavior is introduced.
+- [x] Holding touch contact beyond Fluent's show delay does not open a tooltip or introduce touch long-press help.
 - [x] Pane scrolling, category/family rendering, Show primitives, and item row density remain intact apart from removal of the description line.
-- [x] Tests are developed first and prove hidden descriptions, hover, focus, accessible semantics, search, and an unchanged palette-item drop through stable locators.
+- [x] Tests are developed first and prove hidden descriptions, touch suppression, mouse hover, focus, accessible semantics, search, and an unchanged palette-item drop through stable locators.
 - [x] Focused unit, Playwright, build/type-check, lint, and format validation passes, followed by a rendered check of the Node Assets Editor dev surface.
 - [x] `/code-review` reports no unresolved findings.
 
@@ -31,6 +32,7 @@ None - can start immediately.
 ## Comments
 
 - 2026-07-21: Implemented compact label-only rows with trimmed shared Fluent description tooltips, visible-label accessible names, keyboard focus, and unchanged drag payloads/search metadata.
-- Validation: palette unit tests 13/13; focused package Playwright 1/1; full NAE Playwright project 39/39; NAE build, changed-file ESLint, Prettier, and diff checks passed.
-- Rendered validation: rows remained 34 px high; hover and focus showed the themed 240 px-default tooltip; the palette scrolled 500 px inside its pane; click kept 4 nodes and the existing drop path created a fifth node.
-- Two-axis `/code-review`: standards and spec both reported no unresolved findings.
+- 2026-07-21: Root review reopened the issue because Fluent also reacts to touch pointer entry, allowing a held contact to open the tooltip after the show delay.
+- Earlier validation, rendered-check, and child-review claims do not cover the reopened final head and are not accepted as landing evidence.
+- The complete touch lifecycle regression and controlled Fluent visibility path passed the palette unit seam (13/13), targeted tooltip Playwright test (1/1), full NAE Playwright project (44/44), NAE production build, changed-file Prettier/ESLint, and diff checks under the exclusive local lease.
+- Automatic agnostic and instructions review lenses at Sol/Max reported no significant issues; landing remains pending, so the issue stays unresolved.

--- a/.scratch/palette-description-tooltips/issues/01-implement-accessible-palette-description-tooltips.md
+++ b/.scratch/palette-description-tooltips/issues/01-implement-accessible-palette-description-tooltips.md
@@ -1,6 +1,6 @@
 # Implement accessible palette description tooltips
 
-Status: ready-for-agent
+Status: resolved
 
 ## Parent
 
@@ -12,17 +12,17 @@ Make the Node Assets Editor palette name-first and compact by removing always-vi
 
 ## Acceptance criteria
 
-- [ ] Descriptions no longer render as visible palette subheadings; node names remain visible with existing typography and wrapping.
-- [ ] Non-empty descriptions use `shared-ui-components/fluent/primitives/tooltip`, open on pointer hover and keyboard focus, and are exposed through the tooltip's accessible description relationship.
-- [ ] The focusable trigger keeps the node name as its accessible name; no native `title` tooltip competes with Fluent.
-- [ ] Missing, empty, or whitespace-only descriptions create no tooltip.
-- [ ] Tooltip defaults control timing, placement, wrapping, portal, and pointer behavior; no manual tooltip state or layout wrapper is added.
-- [ ] Description metadata and description/keyword/category filtering remain unchanged.
-- [ ] Drag payloads and canvas drops remain unchanged, and no click-to-create, keyboard-to-create, or touch gesture is introduced.
-- [ ] Pane scrolling, category/family rendering, Show primitives, and item row density remain intact apart from removal of the description line.
-- [ ] Tests are developed first and prove hidden descriptions, hover, focus, accessible semantics, search, and an unchanged palette-item drop through stable locators.
-- [ ] Focused unit, Playwright, build/type-check, lint, and format validation passes, followed by a rendered check of the Node Assets Editor dev surface.
-- [ ] `/code-review` reports no unresolved findings.
+- [x] Descriptions no longer render as visible palette subheadings; node names remain visible with existing typography and wrapping.
+- [x] Non-empty descriptions use `shared-ui-components/fluent/primitives/tooltip`, open on pointer hover and keyboard focus, and are exposed through the tooltip's accessible description relationship.
+- [x] The focusable trigger keeps the node name as its accessible name; no native `title` tooltip competes with Fluent.
+- [x] Missing, empty, or whitespace-only descriptions create no tooltip.
+- [x] Tooltip defaults control timing, placement, wrapping, portal, and pointer behavior; no manual tooltip state or layout wrapper is added.
+- [x] Description metadata and description/keyword/category filtering remain unchanged.
+- [x] Drag payloads and canvas drops remain unchanged, and no click-to-create, keyboard-to-create, or touch gesture is introduced.
+- [x] Pane scrolling, category/family rendering, Show primitives, and item row density remain intact apart from removal of the description line.
+- [x] Tests are developed first and prove hidden descriptions, hover, focus, accessible semantics, search, and an unchanged palette-item drop through stable locators.
+- [x] Focused unit, Playwright, build/type-check, lint, and format validation passes, followed by a rendered check of the Node Assets Editor dev surface.
+- [x] `/code-review` reports no unresolved findings.
 
 ## Blocked by
 
@@ -30,4 +30,7 @@ None - can start immediately.
 
 ## Comments
 
-No comments yet.
+- 2026-07-21: Implemented compact label-only rows with trimmed shared Fluent description tooltips, visible-label accessible names, keyboard focus, and unchanged drag payloads/search metadata.
+- Validation: palette unit tests 13/13; focused package Playwright 1/1; full NAE Playwright project 39/39; NAE build, changed-file ESLint, Prettier, and diff checks passed.
+- Rendered validation: rows remained 34 px high; hover and focus showed the themed 240 px-default tooltip; the palette scrolled 500 px inside its pane; click kept 4 nodes and the existing drop path created a fifth node.
+- Two-axis `/code-review`: standards and spec both reported no unresolved findings.

--- a/.scratch/palette-description-tooltips/issues/01-implement-accessible-palette-description-tooltips.md
+++ b/.scratch/palette-description-tooltips/issues/01-implement-accessible-palette-description-tooltips.md
@@ -1,0 +1,33 @@
+# Implement accessible palette description tooltips
+
+Status: ready-for-agent
+
+## Parent
+
+[Palette description tooltips PRD](../PRD.md)
+
+## What to build
+
+Make the Node Assets Editor palette name-first and compact by removing always-visible node descriptions from palette rows while preserving description metadata and description-based search. Attach every meaningful description to the entire draggable row through the existing shared Fluent Tooltip abstraction. The row must expose the node name as its accessible name and the tooltip copy as its accessible description on pointer hover and keyboard focus, without changing drag/drop, click/touch, scrolling, filtering, category, family, or Show primitives behavior. Update the existing browser test seam and drag helper so the behavior is verified without relying on native title attributes.
+
+## Acceptance criteria
+
+- [ ] Descriptions no longer render as visible palette subheadings; node names remain visible with existing typography and wrapping.
+- [ ] Non-empty descriptions use `shared-ui-components/fluent/primitives/tooltip`, open on pointer hover and keyboard focus, and are exposed through the tooltip's accessible description relationship.
+- [ ] The focusable trigger keeps the node name as its accessible name; no native `title` tooltip competes with Fluent.
+- [ ] Missing, empty, or whitespace-only descriptions create no tooltip.
+- [ ] Tooltip defaults control timing, placement, wrapping, portal, and pointer behavior; no manual tooltip state or layout wrapper is added.
+- [ ] Description metadata and description/keyword/category filtering remain unchanged.
+- [ ] Drag payloads and canvas drops remain unchanged, and no click-to-create, keyboard-to-create, or touch gesture is introduced.
+- [ ] Pane scrolling, category/family rendering, Show primitives, and item row density remain intact apart from removal of the description line.
+- [ ] Tests are developed first and prove hidden descriptions, hover, focus, accessible semantics, search, and an unchanged palette-item drop through stable locators.
+- [ ] Focused unit, Playwright, build/type-check, lint, and format validation passes, followed by a rendered check of the Node Assets Editor dev surface.
+- [ ] `/code-review` reports no unresolved findings.
+
+## Blocked by
+
+None - can start immediately.
+
+## Comments
+
+No comments yet.

--- a/packages/dev/sharedUiComponents/src/fluent/primitives/tooltip.tsx
+++ b/packages/dev/sharedUiComponents/src/fluent/primitives/tooltip.tsx
@@ -10,8 +10,12 @@ import { Tooltip as FluentTooltip, type TooltipProps as FluentTooltipProps } fro
 export type TooltipProps = {
     /** The tooltip content. If null/empty, the tooltip is not rendered. */
     content?: Nullable<string | ReactElement>;
+    /** Notification when the tooltip requests a visibility change. */
+    onVisibleChange?: FluentTooltipProps["onVisibleChange"];
     /** Optional positioning passed through to the underlying FluentTooltip. */
     positioning?: FluentTooltipProps["positioning"];
+    /** Optional controlled visibility passed through to the underlying FluentTooltip. */
+    visible?: FluentTooltipProps["visible"];
     /** The element that the tooltip is attached to. */
     children: ReactElement;
 };
@@ -19,14 +23,14 @@ export type TooltipProps = {
 // forwardRef wrapper to avoid "function components cannot be given refs" warning
 // FluentTooltip handles ref forwarding to children internally via applyTriggerPropsToChildren
 export const Tooltip = forwardRef<HTMLElement, TooltipProps>((props, _ref) => {
-    const { content, positioning, children } = props;
+    const { content, onVisibleChange, positioning, visible, children } = props;
 
     if (!content) {
         return children;
     }
 
     return (
-        <FluentTooltip relationship="description" content={content} positioning={positioning}>
+        <FluentTooltip relationship="description" content={content} onVisibleChange={onVisibleChange} positioning={positioning} visible={visible}>
             {children}
         </FluentTooltip>
     );

--- a/packages/tools/nodeAssetsEditor/src/nodeAssets/blockCatalog.ts
+++ b/packages/tools/nodeAssetsEditor/src/nodeAssets/blockCatalog.ts
@@ -123,7 +123,7 @@ export interface IBlockDescriptor {
     readonly paletteItemId: string;
     /** Human readable label, used both in the palette and as the new node's title. */
     readonly label: string;
-    /** Concise explanation shown in the palette. */
+    /** Optional concise explanation exposed as palette help and used by search. */
     readonly description?: string;
     /** Workflow terms and aliases used by palette search. */
     readonly keywords?: readonly string[];

--- a/packages/tools/nodeAssetsEditor/src/nodeGraph/components/PaletteView.tsx
+++ b/packages/tools/nodeAssetsEditor/src/nodeGraph/components/PaletteView.tsx
@@ -2,6 +2,7 @@ import { Fragment, type DragEvent, type FunctionComponent, useEffect, useMemo, u
 
 import { Accordion, AccordionHeader, AccordionItem, AccordionPanel, Body1, Caption1, Checkbox, makeStyles, tokens } from "@fluentui/react-components";
 import { SearchBar } from "shared-ui-components/fluent/primitives/searchBar";
+import { Tooltip } from "shared-ui-components/fluent/primitives/tooltip";
 
 import { type EditorContextValue } from "../editorContext";
 import { type IPaletteCategory, type IPaletteItem, type IPalettePreferences, PaletteDragFormat } from "../paletteModel";
@@ -61,9 +62,6 @@ const useStyles = makeStyles({
             backgroundColor: tokens.colorNeutralBackground1Pressed,
             cursor: "grabbing",
         },
-    },
-    description: {
-        color: tokens.colorNeutralForeground2,
     },
     empty: {
         color: tokens.colorNeutralForeground3,
@@ -147,25 +145,33 @@ export const PaletteView: FunctionComponent<{ context: EditorContextValue; prefe
                                 </AccordionHeader>
                                 <AccordionPanel>
                                     <div className={classes.panel}>
-                                        {category.items.map((item, itemIndex) => (
-                                            <Fragment key={item.id}>
-                                                {item.family !== undefined && item.family !== category.items[itemIndex - 1]?.family && (
-                                                    <Caption1 className={classes.family} data-testid="palette-family">
-                                                        {item.family}
-                                                    </Caption1>
-                                                )}
-                                                <div
-                                                    className={classes.row}
-                                                    data-testid="palette-item"
-                                                    draggable={true}
-                                                    title={item.label}
-                                                    onDragStart={(event) => onDragStart(event, item)}
-                                                >
-                                                    <Body1 data-testid="palette-item-label">{item.label}</Body1>
-                                                    {item.description && <Caption1 className={classes.description}>{item.description}</Caption1>}
-                                                </div>
-                                            </Fragment>
-                                        ))}
+                                        {category.items.map((item, itemIndex) => {
+                                            const tooltipContent = item.description?.trim() || undefined;
+                                            const labelId = `palette-item-label-${item.id}`;
+                                            return (
+                                                <Fragment key={item.id}>
+                                                    {item.family !== undefined && item.family !== category.items[itemIndex - 1]?.family && (
+                                                        <Caption1 className={classes.family} data-testid="palette-family">
+                                                            {item.family}
+                                                        </Caption1>
+                                                    )}
+                                                    <Tooltip content={tooltipContent}>
+                                                        <div
+                                                            aria-labelledby={labelId}
+                                                            className={classes.row}
+                                                            data-testid="palette-item"
+                                                            draggable={true}
+                                                            tabIndex={0}
+                                                            onDragStart={(event) => onDragStart(event, item)}
+                                                        >
+                                                            <Body1 id={labelId} data-testid="palette-item-label">
+                                                                {item.label}
+                                                            </Body1>
+                                                        </div>
+                                                    </Tooltip>
+                                                </Fragment>
+                                            );
+                                        })}
                                     </div>
                                 </AccordionPanel>
                             </AccordionItem>

--- a/packages/tools/nodeAssetsEditor/src/nodeGraph/components/PaletteView.tsx
+++ b/packages/tools/nodeAssetsEditor/src/nodeGraph/components/PaletteView.tsx
@@ -1,4 +1,4 @@
-import { Fragment, type DragEvent, type FunctionComponent, useEffect, useMemo, useState } from "react";
+import { Fragment, type DragEvent, type FunctionComponent, type ReactElement, useEffect, useMemo, useState } from "react";
 
 import { Accordion, AccordionHeader, AccordionItem, AccordionPanel, Body1, Caption1, Checkbox, makeStyles, tokens } from "@fluentui/react-components";
 import { SearchBar } from "shared-ui-components/fluent/primitives/searchBar";
@@ -69,6 +69,29 @@ const useStyles = makeStyles({
 });
 
 const GetCategoryValue = (category: IPaletteCategory, index: number) => `${index}:${category.label}`;
+
+type PaletteItemTooltipProps = {
+    children: ReactElement;
+    content?: string;
+};
+
+const PaletteItemTooltip: FunctionComponent<PaletteItemTooltipProps> = (props) => {
+    const { children, content } = props;
+    const [visible, setVisible] = useState(false);
+
+    return (
+        <Tooltip
+            content={content}
+            visible={visible}
+            onVisibleChange={(event, data) => {
+                const isTouchPointer = event !== undefined && "pointerType" in event && event.pointerType === "touch";
+                setVisible(data.visible && !isTouchPointer);
+            }}
+        >
+            {children}
+        </Tooltip>
+    );
+};
 
 /**
  * Renders the categorized node palette and prepares dragged palette items for canvas drops.
@@ -155,7 +178,7 @@ export const PaletteView: FunctionComponent<{ context: EditorContextValue; prefe
                                                             {item.family}
                                                         </Caption1>
                                                     )}
-                                                    <Tooltip content={tooltipContent}>
+                                                    <PaletteItemTooltip content={tooltipContent}>
                                                         <div
                                                             aria-labelledby={labelId}
                                                             className={classes.row}
@@ -168,7 +191,7 @@ export const PaletteView: FunctionComponent<{ context: EditorContextValue; prefe
                                                                 {item.label}
                                                             </Body1>
                                                         </div>
-                                                    </Tooltip>
+                                                    </PaletteItemTooltip>
                                                 </Fragment>
                                             );
                                         })}

--- a/packages/tools/nodeAssetsEditor/src/nodeGraph/paletteModel.ts
+++ b/packages/tools/nodeAssetsEditor/src/nodeGraph/paletteModel.ts
@@ -14,7 +14,7 @@ export interface IPaletteItem {
     readonly label: string;
     /** Optional family heading shown within the containing category. */
     readonly family?: string;
-    /** Concise explanation shown below the label. */
+    /** Optional concise explanation exposed as palette help and used by search. */
     readonly description?: string;
     /** Workflow terms and aliases used by palette search. */
     readonly keywords?: readonly string[];

--- a/packages/tools/nodeAssetsEditor/test/playwright/nae.utils.ts
+++ b/packages/tools/nodeAssetsEditor/test/playwright/nae.utils.ts
@@ -107,6 +107,15 @@ export class NodeAssetsEditorPage {
     }
 
     /**
+     * Locate a palette item through the palette's stable test seam and exact visible label.
+     * @param label - The palette item's visible label.
+     * @returns The palette item row locator.
+     */
+    paletteItem(label: string): Locator {
+        return this.page.getByTestId("palette-item").filter({ has: this.page.getByText(label, { exact: true }) });
+    }
+
+    /**
      * Select a node by clicking its header title, which reveals its properties in the right pane.
      * @param title - The node's visible title.
      * @param occurrence - Optional disambiguator when several nodes share the title (see {@link nodeByTitle}).
@@ -154,7 +163,7 @@ export class NodeAssetsEditorPage {
      * @param at - Drop point as canvas-rect fractions (0..1); defaults to the center.
      */
     async dropPaletteItem(label: string, at: CanvasPoint = { x: 0.5, y: 0.5 }): Promise<void> {
-        const source = await this.page.getByTitle(label, { exact: true }).first().elementHandle();
+        const source = await this.paletteItem(label).first().elementHandle();
         const target = await this.canvas.elementHandle();
         if (!source || !target) {
             throw new Error(`Could not resolve palette item "${label}" or the canvas for the drop gesture.`);

--- a/packages/tools/nodeAssetsEditor/test/playwright/nodeAssetsEditor.test.ts
+++ b/packages/tools/nodeAssetsEditor/test/playwright/nodeAssetsEditor.test.ts
@@ -656,6 +656,14 @@ test.describe("Node Assets Editor — maintained default pipeline", () => {
         await expect(paletteItem).toHaveAttribute("tabindex", "0");
         await expect(paletteItem).not.toHaveAttribute("title");
 
+        const touchPointer = { pointerId: 41_001, pointerType: "touch", isPrimary: true };
+        await paletteItem.dispatchEvent("pointerover", { ...touchPointer, button: -1, buttons: 0 });
+        await paletteItem.dispatchEvent("pointerdown", { ...touchPointer, button: 0, buttons: 1 });
+        await page.waitForTimeout(1_000);
+        await expect(tooltip).toBeHidden();
+        await paletteItem.dispatchEvent("pointerup", { ...touchPointer, button: 0, buttons: 0 });
+        await paletteItem.dispatchEvent("pointerout", { ...touchPointer, button: -1, buttons: 0 });
+
         await paletteItem.hover();
         await expect(tooltip).toBeVisible({ timeout: 10_000 });
         await expect(tooltip).toHaveText(description);

--- a/packages/tools/nodeAssetsEditor/test/playwright/nodeAssetsEditor.test.ts
+++ b/packages/tools/nodeAssetsEditor/test/playwright/nodeAssetsEditor.test.ts
@@ -552,20 +552,40 @@ test.describe("Node Assets Editor — maintained default pipeline", () => {
         await expect(editor.previewCanvas).toBeVisible();
     });
 
-    test("finds nodes by workflow intent and shows their descriptions", async ({ page }) => {
+    test("keeps palette descriptions searchable and exposes them on hover and focus", async ({ page }) => {
         const editor = new NodeAssetsEditorPage(page);
         await editor.goto();
 
         const search = page.getByPlaceholder("Search palette");
-        for (const [query, label, description] of [
-            ["decimate", "Simplify Meshes", "Reduce Universal mesh geometry to a target ratio and error limit."],
-            ["unused", "Remove Unused Resources", "Remove resources that are no longer referenced by the scene."],
-            ["compress", "Compress Textures (KTX2)", "Compress scene textures to KTX2 / Basis Universal."],
-        ]) {
-            await search.fill(query);
-            await expect(page.getByTitle(label, { exact: true })).toBeVisible();
-            await expect(page.getByText(description, { exact: true })).toBeVisible();
-        }
+        const label = "Simplify Meshes";
+        const description = "Reduce Universal mesh geometry to a target ratio and error limit.";
+        await search.fill("target ratio");
+
+        const paletteItem = editor.paletteItem(label);
+        const tooltip = page.getByRole("tooltip");
+        await expect(paletteItem).toBeVisible();
+        await search.clear();
+        await paletteItem.scrollIntoViewIfNeeded();
+        await expect(page.getByText(description, { exact: true })).toBeHidden();
+        await expect(paletteItem).toHaveAccessibleName(label);
+        await expect(paletteItem).toHaveAttribute("tabindex", "0");
+        await expect(paletteItem).not.toHaveAttribute("title");
+
+        await paletteItem.hover();
+        await expect(tooltip).toBeVisible({ timeout: 10_000 });
+        await expect(tooltip).toHaveText(description);
+        await expect(paletteItem).toHaveAccessibleDescription(description);
+
+        await page.mouse.move(0, 0);
+        await expect(tooltip).toBeHidden();
+        await paletteItem.focus();
+        await expect(paletteItem).toBeFocused();
+        await expect(tooltip).toBeVisible({ timeout: 10_000 });
+        await expect(tooltip).toHaveText(description);
+        await expect(paletteItem).toHaveAccessibleDescription(description);
+
+        await editor.dropPaletteItem(label, { x: 0.65, y: 0.75 });
+        await expect(editor.nodeByTitle(label)).toBeVisible();
     });
 
     test("persists Show primitives without changing canvas or expanded aggregate nodes", async ({ page }) => {
@@ -650,7 +670,7 @@ test.describe("Node Assets Editor — maintained default pipeline", () => {
         await search.clear();
         await showPrimitives.uncheck();
         await expect(nodeGeometryCategory).toHaveCount(0);
-        await expect(page.getByTitle("Read Babylon", { exact: true })).toHaveCount(0);
+        await expect(editor.paletteItem("Read Babylon")).toHaveCount(0);
         await expect(categories).toHaveText(["Inputs (4)", "Universal (17)", "glTF (3)"]);
         await expect(items).toHaveText(defaultItems);
         await expect(editor.nodeByTitle("Read Babylon")).toBeVisible();
@@ -1175,7 +1195,7 @@ test.describe("Node Assets Editor — Universal glTF aggregates", () => {
             buffer: createNodeGeometryEditorFile(),
         });
         await expect(editor.nodes).toHaveCount(2);
-        await expect(page.getByTitle("Evaluate Node Geometry", { exact: true })).toHaveCount(0);
+        await expect(editor.paletteItem("Evaluate Node Geometry")).toHaveCount(0);
 
         await editor.selectNode("Import Node Geometry");
         await propertyTextbox("Snippet ID").fill("#TEST#1");


### PR DESCRIPTION
## Summary

- make Node Assets Editor palette rows compact and name-first by moving meaningful descriptions into the shared Fluent Tooltip
- preserve description search metadata, category/family behavior, Show primitives, drag payloads, and canvas drops
- expose descriptions on mouse/pen hover and keyboard focus while suppressing touch-originated tooltip opens
- keep the node name as the accessible name and tooltip copy as the accessible description

## Final validation

Validated on the latest integrated `preview/nae` tree through fix PR #33:

- first targeted unit attempt preserved as environmental failure because `vitest`/`vite` were absent; one authorized `npm ci` restored prerequisites
- palette units: 13/13
- targeted tooltip Chromium: 1/1 with one worker and zero retries
- full Node Assets Editor Playwright: 44/44 exactly once with one worker and zero retries
- Node Assets Editor production build passed
- changed-file Prettier, ESLint, and CRLF-aware diff checks passed
- automatic agnostic and instructions review lenses at GPT-5.6 Sol / max found no significant issues
- server/process/artifact cleanup complete; ports 1348/1359 free

## Touch regression

The regression uses one complete synthetic touch lifecycle—pointerover, primary pointerdown, hold beyond Fluent's show delay, hidden assertion, pointerup, pointerout—then proves the existing real mouse hover, keyboard focus, accessible-description, and drag/drop behavior.

## Local specification

- `.scratch/palette-description-tooltips/PRD.md`
- `.scratch/palette-description-tooltips/issues/01-implement-accessible-palette-description-tooltips.md`