### PR TITLE
Add FBX upload import funnel to Node Assets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22161,6 +22161,7 @@
             "name": "@dev/node-assets",
             "version": "1.0.0",
             "dependencies": {
+                "@dev/loaders": "^1.0.0",
                 "@gltf-transform/core": "^4.4.1",
                 "@gltf-transform/extensions": "^4.4.1",
                 "@gltf-transform/functions": "^4.4.1",

--- a/packages/dev/node-assets/package.json
+++ b/packages/dev/node-assets/package.json
@@ -22,6 +22,7 @@
     },
     "sideEffects": true,
     "dependencies": {
+        "@dev/loaders": "^1.0.0",
         "@gltf-transform/core": "^4.4.1",
         "@gltf-transform/extensions": "^4.4.1",
         "@gltf-transform/functions": "^4.4.1",

--- a/packages/dev/node-assets/src/Blocks/fbxToUniversalBlock.ts
+++ b/packages/dev/node-assets/src/Blocks/fbxToUniversalBlock.ts
@@ -1,0 +1,97 @@
+import { NullEngine } from "core/Engines/nullEngine";
+import { Scene } from "core/scene";
+import { GLTF2Export } from "serializers/glTF/2.0/glTFSerializer";
+
+import { RegisterBlock } from "../blockFoundation/blockRegistry";
+import { NodeAssetBlock } from "../blockFoundation/nodeAssetBlock";
+import { type NodeAssetConnectionPoint } from "../connection/nodeAssetConnectionPoint";
+import { NodeAssetConnectionPointType } from "../connection/nodeAssetConnectionPointType";
+import { type NodeAsset } from "../nodeAsset";
+import { IsFBXSource } from "../representations/fbxSource";
+import { GltfAsset } from "../representations/gltfAsset";
+
+/** Parses an FBX source payload and explicitly crosses into Universal. */
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export class FBXToUniversalBlock extends NodeAssetBlock {
+    /** The class name, used for identification and safe under minification. */
+    public static override ClassName = "FBXToUniversalBlock";
+
+    /** The raw FBX source payload. */
+    public readonly input: NodeAssetConnectionPoint;
+
+    /** The Universal working payload. */
+    public readonly output: NodeAssetConnectionPoint;
+
+    /**
+     * Creates an FBX-to-Universal transcoder.
+     * @param name The display name.
+     * @param nodeAsset The owning graph.
+     */
+    public constructor(name: string, nodeAsset: NodeAsset) {
+        super(name, nodeAsset);
+        this.input = this._registerInput("input", NodeAssetConnectionPointType.FBX_SOURCE);
+        this.output = this._registerOutput("output", NodeAssetConnectionPointType.UNIVERSAL);
+    }
+
+    /** Loads the FBX scene, exports it to GLB, and wraps the resulting Universal document. */
+    public override async _buildBlockAsync(): Promise<void> {
+        if (!IsFBXSource(this.input.value)) {
+            throw new Error(`The "${this.name}" block did not receive an FBX source payload.`);
+        }
+        const source = this.input.value;
+        const engine = new NullEngine();
+        let scene: Scene | undefined;
+        let conversionFailure: Error | undefined;
+        try {
+            scene = new Scene(engine);
+            const { FBXFileLoader } = await import("loaders/FBX/fbxFileLoader.pure");
+            const container = await new FBXFileLoader().loadAssetContainerAsync(scene, source.data, source.rootUrl, undefined, source.source);
+            container.addAllToScene();
+
+            const glbData = await GLTF2Export.GLBAsync(scene, "fbx-universal", { exportWithoutWaitingForScene: true });
+            const glb = glbData.files["fbx-universal.glb"];
+            const bytes = glb instanceof Blob ? new Uint8Array(await glb.arrayBuffer()) : new TextEncoder().encode(glb);
+            const { WebIO } = await import("@gltf-transform/core");
+            const { ALL_EXTENSIONS } = await import("@gltf-transform/extensions");
+            const document = await new WebIO().registerExtensions(ALL_EXTENSIONS).readBinary(bytes);
+            this.output.value = new GltfAsset(document, {
+                identity: source.source,
+                revision: 0,
+                manifest: { format: "universal", importedFrom: "fbx", source: source.source },
+            });
+        } catch (error) {
+            conversionFailure = new Error(
+                `The "${this.name}" block failed to convert "${source.source}" from FBX to Universal: ${error instanceof Error ? error.message : String(error)}`,
+                {
+                    cause: error,
+                }
+            );
+        }
+
+        const cleanupFailures: unknown[] = [];
+        if (scene) {
+            try {
+                scene.dispose();
+            } catch (error) {
+                cleanupFailures.push(error);
+            }
+        }
+        try {
+            engine.dispose();
+        } catch (error) {
+            cleanupFailures.push(error);
+        }
+
+        if (conversionFailure) {
+            if (cleanupFailures.length > 0) {
+                throw new AggregateError([conversionFailure, ...cleanupFailures], conversionFailure.message, { cause: conversionFailure.cause });
+            }
+            throw conversionFailure;
+        }
+        if (cleanupFailures.length > 0) {
+            throw new AggregateError(cleanupFailures, `The "${this.name}" block failed to dispose temporary resources for "${source.source}".`);
+        }
+    }
+}
+
+RegisterBlock(FBXToUniversalBlock.ClassName, (name, nodeAsset) => new FBXToUniversalBlock(name, nodeAsset));

--- a/packages/dev/node-assets/src/Blocks/importFBXAggregateBlock.ts
+++ b/packages/dev/node-assets/src/Blocks/importFBXAggregateBlock.ts
@@ -1,0 +1,64 @@
+import { AggregateBlock } from "../blockFoundation/aggregateBlock";
+import { RegisterBlock } from "../blockFoundation/blockRegistry";
+import { type NodeAssetConnectionPoint } from "../connection/nodeAssetConnectionPoint";
+import { type NodeAsset } from "../nodeAsset";
+import { FBXToUniversalBlock } from "./fbxToUniversalBlock";
+import { type FBXSourceKind, ReadFBXBlock } from "./readFBXBlock";
+
+/** Built-in `Read FBX -> FBX -> Universal` aggregate. */
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export class ImportFBXAggregateBlock extends AggregateBlock {
+    /** The class name, used for identification and safe under minification. */
+    public static override ClassName = "ImportFBXAggregateBlock";
+
+    /** The aggregate's Universal output. */
+    public readonly output: NodeAssetConnectionPoint;
+
+    /**
+     * Creates the built-in FBX import aggregate.
+     * @param name The display name.
+     * @param nodeAsset The owning graph.
+     */
+    public constructor(name: string, nodeAsset: NodeAsset) {
+        super(name, nodeAsset);
+        const read = new ReadFBXBlock("Read FBX", this.subgraph);
+        const transcoder = new FBXToUniversalBlock("FBX → Universal", this.subgraph);
+        read.output.connectTo(transcoder.input);
+        this.output = this._exposeOutput(transcoder.output, "output");
+    }
+
+    /** The owned Read FBX primitive. */
+    public get readBlock(): ReadFBXBlock {
+        const block = this.subgraph.attachedBlocks.find((candidate): candidate is ReadFBXBlock => candidate instanceof ReadFBXBlock);
+        if (!block) {
+            throw new Error(`The "${this.name}" aggregate has no ReadFBXBlock.`);
+        }
+        return block;
+    }
+
+    /** Source bytes forwarded to the Read FBX primitive. */
+    public get data(): Uint8Array | null {
+        return this.readBlock.data;
+    }
+
+    /** Active source label forwarded to the Read FBX primitive. */
+    public get source(): string | null {
+        return this.readBlock.source;
+    }
+
+    /** Active source kind forwarded to the Read FBX primitive. */
+    public get sourceKind(): FBXSourceKind | null {
+        return this.readBlock.sourceKind;
+    }
+
+    /**
+     * Makes uploaded bytes the active child source.
+     * @param data The uploaded bytes.
+     * @param fileName The uploaded file name.
+     */
+    public setUploadedSource(data: Uint8Array, fileName: string): void {
+        this.readBlock.setUploadedSource(data, fileName);
+    }
+}
+
+RegisterBlock(ImportFBXAggregateBlock.ClassName, (name, nodeAsset) => new ImportFBXAggregateBlock(name, nodeAsset));

--- a/packages/dev/node-assets/src/Blocks/readFBXBlock.ts
+++ b/packages/dev/node-assets/src/Blocks/readFBXBlock.ts
@@ -1,0 +1,125 @@
+import { DecodeBase64ToBinary, EncodeArrayBufferToBase64 } from "core/Misc/stringTools";
+import { type Nullable } from "core/types";
+
+import { RegisterBlock } from "../blockFoundation/blockRegistry";
+import { NodeAssetBlock } from "../blockFoundation/nodeAssetBlock";
+import { type NodeAssetConnectionPoint } from "../connection/nodeAssetConnectionPoint";
+import { NodeAssetConnectionPointType } from "../connection/nodeAssetConnectionPointType";
+import { type BuildScope } from "../evaluation/buildScope";
+import { type NodeAsset } from "../nodeAsset";
+import { FBXSource } from "../representations/fbxSource";
+import { GetSerializedNullableString, GetSerializedStringUnion, type NodeAssetBlockSerialization } from "../serialization/nodeAssetSerialization";
+
+/** The active source kind for a Read FBX block. */
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export type FBXSourceKind = "upload";
+
+/** Resolves uploaded `.fbx` bytes into a raw FBX source payload. */
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export class ReadFBXBlock extends NodeAssetBlock {
+    /** The class name, used for identification and safe under minification. */
+    public static override ClassName = "ReadFBXBlock";
+
+    /** The raw FBX source payload. */
+    public readonly output: NodeAssetConnectionPoint;
+
+    private _data: Nullable<Uint8Array> = null;
+    private _source: Nullable<string> = null;
+    private _sourceKind: Nullable<FBXSourceKind> = null;
+
+    /**
+     * Creates an FBX read block.
+     * @param name The display name.
+     * @param nodeAsset The owning graph.
+     */
+    public constructor(name: string, nodeAsset: NodeAsset) {
+        super(name, nodeAsset);
+        this.output = this._registerOutput("output", NodeAssetConnectionPointType.FBX_SOURCE);
+    }
+
+    /** A defensive copy of the active FBX bytes, or null when cleared. */
+    public get data(): Nullable<Uint8Array> {
+        return this._data?.slice() ?? null;
+    }
+
+    /** The active uploaded file name, or null when cleared. */
+    public get source(): Nullable<string> {
+        return this._source;
+    }
+
+    /** Whether the active source was loaded from an upload. */
+    public get sourceKind(): Nullable<FBXSourceKind> {
+        return this._sourceKind;
+    }
+
+    /**
+     * Makes uploaded bytes the active source.
+     * @param data The uploaded `.fbx` bytes.
+     * @param fileName The uploaded file name.
+     */
+    public setUploadedSource(data: Uint8Array, fileName: string): void {
+        if (!fileName.trim()) {
+            throw new Error("An FBX upload must have a nonempty source label.");
+        }
+        this._data = data.slice();
+        this._source = fileName;
+        this._sourceKind = "upload";
+    }
+
+    /** Clears the active source. */
+    public clearSource(): void {
+        this._data = null;
+        this._source = null;
+        this._sourceKind = null;
+    }
+
+    /**
+     * Emits the active uploaded bytes without parsing the FBX scene.
+     * @param scope The build scope used to account source bytes.
+     */
+    public override async _buildBlockAsync(scope?: BuildScope): Promise<void> {
+        const data = this._data;
+        const source = this._source;
+        if (!data || !source || this._sourceKind !== "upload") {
+            throw new Error(`The "${this.name}" read block has no FBX source.`);
+        }
+        scope?.accountSourceBytes(data.byteLength);
+        this.output.value = new FBXSource(data, source);
+    }
+
+    /**
+     * Serializes the source bytes and active source choice.
+     * @returns The serialized block.
+     */
+    public override serialize(): NodeAssetBlockSerialization {
+        return {
+            ...super.serialize(),
+            data: this._data ? EncodeArrayBufferToBase64(this._data) : null,
+            source: this._source,
+            sourceKind: this._sourceKind ?? "",
+        };
+    }
+
+    /**
+     * Restores the source bytes and active source choice.
+     * @param serializationObject The serialized block.
+     */
+    public override _deserialize(serializationObject: NodeAssetBlockSerialization): void {
+        super._deserialize(serializationObject);
+        const encodedData = GetSerializedNullableString(serializationObject, "data");
+        const source = GetSerializedNullableString(serializationObject, "source");
+        const sourceKind = GetSerializedStringUnion(serializationObject, "sourceKind", ["upload", ""] as const, "") || null;
+        if (encodedData === null && source === null && sourceKind === null) {
+            this.clearSource();
+            return;
+        }
+        if (encodedData === null || source === null || source.trim().length === 0 || sourceKind !== "upload") {
+            throw new Error(`The serialized "${this.name}" block has an invalid FBX source state.`);
+        }
+        this._data = new Uint8Array(DecodeBase64ToBinary(encodedData));
+        this._source = source;
+        this._sourceKind = sourceKind;
+    }
+}
+
+RegisterBlock(ReadFBXBlock.ClassName, (name, nodeAsset) => new ReadFBXBlock(name, nodeAsset));

--- a/packages/dev/node-assets/src/connection/nodeAssetConnectionPointType.ts
+++ b/packages/dev/node-assets/src/connection/nodeAssetConnectionPointType.ts
@@ -54,4 +54,7 @@ export enum NodeAssetConnectionPointType {
 
     /** Lightweight resolved USD source bytes consumed only by USD-to-Universal transcoding. */
     USD_SOURCE = 10,
+
+    /** Raw FBX source bytes consumed only by FBX-to-Universal transcoding. */
+    FBX_SOURCE = 12,
 }

--- a/packages/dev/node-assets/src/connection/nodeAssetValueMap.ts
+++ b/packages/dev/node-assets/src/connection/nodeAssetValueMap.ts
@@ -1,6 +1,7 @@
 import { type ImagePayload } from "../Blocks/imagePayload";
 import { type BabylonAsset } from "../representations/babylonAsset";
 import { type BabylonSource } from "../representations/babylonSource";
+import { type FBXSource } from "../representations/fbxSource";
 import { type GltfAsset } from "../representations/gltfAsset";
 import { type NodeGeometryAsset } from "../representations/nodeGeometryAsset";
 import { type NodeGeometrySource } from "../representations/nodeGeometrySource";
@@ -74,4 +75,5 @@ export type NodeAssetValueMap = {
     [NodeAssetConnectionPointType.UNIVERSAL]: GltfAsset;
     [NodeAssetConnectionPointType.BABYLON_SOURCE]: BabylonSource;
     [NodeAssetConnectionPointType.USD_SOURCE]: UsdSourceAsset;
+    [NodeAssetConnectionPointType.FBX_SOURCE]: FBXSource;
 };

--- a/packages/dev/node-assets/src/index.ts
+++ b/packages/dev/node-assets/src/index.ts
@@ -43,6 +43,7 @@ export { type IUsdAssetMetadata, IsUsdAsset, UsdAsset } from "./representations/
 export { IsUsdSourceAsset, UsdSourceAsset, type USDSourceKind } from "./representations/usdSourceAsset";
 export { BabylonAsset, type IBabylonAssetMetadata, IsBabylonAsset } from "./representations/babylonAsset";
 export { BabylonSource, IsBabylonSource } from "./representations/babylonSource";
+export { FBXSource, IsFBXSource } from "./representations/fbxSource";
 export { type INodeGeometryAssetMetadata, IsNodeGeometryAsset, NodeGeometryAsset } from "./representations/nodeGeometryAsset";
 export { type INodeGeometrySourceMetadata, IsNodeGeometrySource, NodeGeometrySource, type NodeGeometrySourceKind } from "./representations/nodeGeometrySource";
 export {
@@ -62,6 +63,9 @@ export { ExportGLTFAggregateBlock } from "./Blocks/exportGLTFAggregateBlock";
 export { type BabylonSourceFetcher, type BabylonSourceKind, type IBabylonSourceResponse, ReadBabylonBlock } from "./Blocks/readBabylonBlock";
 export { BabylonToUniversalBlock } from "./Blocks/babylonToUniversalBlock";
 export { ImportBabylonAggregateBlock } from "./Blocks/importBabylonAggregateBlock";
+export { type FBXSourceKind, ReadFBXBlock } from "./Blocks/readFBXBlock";
+export { FBXToUniversalBlock } from "./Blocks/fbxToUniversalBlock";
+export { ImportFBXAggregateBlock } from "./Blocks/importFBXAggregateBlock";
 export { type IUSDSourceResponse, ReadUSDBlock, type USDSourceFetcher } from "./Blocks/readUSDBlock";
 export { USDToUniversalBlock } from "./Blocks/usdToUniversalBlock";
 export { ImportUSDAggregateBlock } from "./Blocks/importUSDAggregateBlock";

--- a/packages/dev/node-assets/src/representations/fbxSource.ts
+++ b/packages/dev/node-assets/src/representations/fbxSource.ts
@@ -1,0 +1,36 @@
+/** Raw FBX source bytes carried only from Read FBX to FBX-to-Universal transcoding. */
+export class FBXSource {
+    private readonly _data: Uint8Array;
+
+    /** The uploaded file name. */
+    public readonly source: string;
+
+    /** The URL base used to resolve external FBX resources. */
+    public readonly rootUrl: string;
+
+    /**
+     * Creates an immutable FBX source payload.
+     * @param data The raw FBX bytes.
+     * @param source The uploaded file name.
+     * @param rootUrl The URL base used to resolve external resources.
+     */
+    public constructor(data: Uint8Array, source: string, rootUrl = "") {
+        this._data = data.slice();
+        this.source = source;
+        this.rootUrl = rootUrl;
+    }
+
+    /** A defensive copy of the raw FBX bytes. */
+    public get data(): Uint8Array {
+        return this._data.slice();
+    }
+}
+
+/**
+ * Tests whether a runtime value is a raw FBX source payload.
+ * @param value The value to test.
+ * @returns Whether the value is an {@link FBXSource}.
+ */
+export function IsFBXSource(value: unknown): value is FBXSource {
+    return value instanceof FBXSource;
+}

--- a/packages/dev/node-assets/test/unit/blockRegistry.test.ts
+++ b/packages/dev/node-assets/test/unit/blockRegistry.test.ts
@@ -25,6 +25,7 @@ import {
     ExportGLTFBlock,
     ExportImageBlock,
     ExtractTexture,
+    FBXToUniversalBlock,
     FixFaceWindingBlock,
     FlattenBlock,
     FlattenHierarchyBlock,
@@ -37,6 +38,7 @@ import {
     GLTFToUniversalBlock,
     ImportBabylonBlock,
     ImportBabylonAggregateBlock,
+    ImportFBXAggregateBlock,
     ImportGLTFBlock,
     ImportGLTFAggregateBlock,
     ImportNodeGeometryAggregateBlock,
@@ -81,6 +83,7 @@ import {
     ReadGLTFBlock,
     ReadNodeGeometryBlock,
     ReadBabylonBlock,
+    ReadFBXBlock,
     ReuseIdenticalMeshesBlock,
     ReadUSDBlock,
     USDToUniversalBlock,
@@ -269,12 +272,15 @@ describe("block self-registration", () => {
                     ReadBabylonBlock.ClassName,
                     BabylonToUniversalBlock.ClassName,
                     ImportBabylonAggregateBlock.ClassName,
+                    ReadFBXBlock.ClassName,
+                    FBXToUniversalBlock.ClassName,
+                    ImportFBXAggregateBlock.ClassName,
                     ReadUSDBlock.ClassName,
                     USDToUniversalBlock.ClassName,
                     ImportUSDAggregateBlock.ClassName,
                 ])
             );
-            expect(registeredClassNames).toHaveLength(80);
+            expect(registeredClassNames).toHaveLength(83);
         });
 
         it.each(registeredClassNames)("round-trips %s through serialize/Parse", (className) => {

--- a/packages/dev/node-assets/test/unit/fbxUniversalFunnel.test.ts
+++ b/packages/dev/node-assets/test/unit/fbxUniversalFunnel.test.ts
@@ -1,0 +1,285 @@
+import { WebIO } from "@gltf-transform/core";
+import { ALL_EXTENSIONS } from "@gltf-transform/extensions";
+import { NullEngine } from "core/Engines/nullEngine";
+import { Scene } from "core/scene";
+import { describe, expect, it, vi } from "vitest";
+
+import { CenterSceneBlock } from "../../src/Blocks/centerSceneBlock";
+import { ExportGLTFAggregateBlock } from "../../src/Blocks/exportGLTFAggregateBlock";
+import { FBXToUniversalBlock } from "../../src/Blocks/fbxToUniversalBlock";
+import { ImportFBXAggregateBlock } from "../../src/Blocks/importFBXAggregateBlock";
+import { ReadFBXBlock } from "../../src/Blocks/readFBXBlock";
+import { NodeAssetConnectionPointType } from "../../src/connection/nodeAssetConnectionPointType";
+import { NodeAsset } from "../../src/nodeAsset";
+import { FBXSource } from "../../src/representations/fbxSource";
+import { GetGltfAsset } from "../../src/representations/gltfAsset";
+
+vi.mock("draco3dgltf", async () => await vi.importActual("draco3dgltf"));
+
+// Original hand-authored ASCII FBX 7.4 fixture. It contains one indexed triangle and no
+// third-party-authored content.
+function CreateTriangleFBX74(): Uint8Array {
+    return new TextEncoder().encode(`; FBX 7.4.0 project file
+Objects: {
+    Geometry: 1, "Geometry::Triangle", "Mesh" {
+        Vertices: *9 {
+            a: 0,0,0,1,0,0,0,1,0
+        }
+        PolygonVertexIndex: *3 {
+            a: 0,1,-3
+        }
+        LayerElementNormal: 0 {
+            MappingInformationType: "ByControlPoint"
+            ReferenceInformationType: "Direct"
+            Normals: *9 {
+                a: 0,0,1,0,0,1,0,0,1
+            }
+        }
+    }
+    Model: 2, "Model::Triangle", "Mesh" {
+    }
+}
+Connections: {
+    C: "OO", 1, 2
+    C: "OO", 2, 0
+}`);
+}
+
+async function ReadAssetFactsAsync(glb: Uint8Array): Promise<{
+    readonly meshCount: number;
+    readonly nodeNames: readonly string[];
+    readonly positionCount: number;
+    readonly primitiveCount: number;
+}> {
+    const document = await new WebIO().registerExtensions(ALL_EXTENSIONS).readBinary(glb);
+    const root = document.getRoot();
+    const mesh = root.listMeshes()[0];
+    const primitive = mesh.listPrimitives()[0];
+    return {
+        meshCount: root.listMeshes().length,
+        nodeNames: root.listNodes().map((node) => node.getName()),
+        positionCount: primitive.getAttribute("POSITION")?.getCount() ?? 0,
+        primitiveCount: mesh.listPrimitives().length,
+    };
+}
+
+describe("FBX Universal funnel", () => {
+    it("emits an uploaded FBX source with stable bytes and metadata", async () => {
+        const uploaded = CreateTriangleFBX74();
+        const expected = uploaded.slice();
+        const asset = new NodeAsset("fbx-source");
+        const read = new ReadFBXBlock("Read FBX", asset);
+
+        read.setUploadedSource(uploaded, "triangle.fbx");
+        uploaded.fill(0);
+        await read._buildBlockAsync();
+
+        expect(NodeAssetConnectionPointType.FBX_SOURCE).toBe(12);
+        expect(read.output.type).toBe(NodeAssetConnectionPointType.FBX_SOURCE);
+        expect(read.sourceKind).toBe("upload");
+        expect(read.output.value).toBeInstanceOf(FBXSource);
+        const source = read.output.value as FBXSource;
+        expect(source.data).toEqual(expected);
+        expect(source.source).toBe("triangle.fbx");
+        expect(source.rootUrl).toBe("");
+        const exposedBytes = source.data;
+        exposedBytes.fill(0);
+        expect(source.data).toEqual(expected);
+    });
+
+    it("round-trips and clears the uploaded FBX source state", async () => {
+        const bytes = CreateTriangleFBX74();
+        const asset = new NodeAsset("serialized-fbx-source");
+        const read = new ReadFBXBlock("Read FBX", asset);
+        read.setUploadedSource(bytes, "triangle.fbx");
+
+        const serialized = JSON.parse(JSON.stringify(asset.serialize()));
+        expect(serialized.blocks[0]).toMatchObject({
+            customType: ReadFBXBlock.ClassName,
+            source: "triangle.fbx",
+            sourceKind: "upload",
+        });
+        expect(serialized.blocks[0].data).toEqual(expect.any(String));
+
+        const parsed = NodeAsset.Parse(serialized);
+        const parsedRead = parsed.attachedBlocks[0] as ReadFBXBlock;
+        expect(parsedRead.data).toEqual(bytes);
+        expect(parsedRead.source).toBe("triangle.fbx");
+        expect(parsedRead.sourceKind).toBe("upload");
+
+        parsedRead.clearSource();
+        expect(parsedRead.data).toBeNull();
+        expect(parsedRead.source).toBeNull();
+        expect(parsedRead.sourceKind).toBeNull();
+        await expect(parsedRead._buildBlockAsync()).rejects.toThrow('The "Read FBX" read block has no FBX source.');
+    });
+
+    it("preserves a zero-byte upload through graph serialization", () => {
+        const asset = new NodeAsset("empty-fbx-source");
+        const read = new ReadFBXBlock("Read FBX", asset);
+        read.setUploadedSource(new Uint8Array(), "empty.fbx");
+
+        const parsed = NodeAsset.Parse(JSON.parse(JSON.stringify(asset.serialize())));
+        const parsedRead = parsed.attachedBlocks[0] as ReadFBXBlock;
+
+        expect(parsedRead.data).toEqual(new Uint8Array());
+        expect(parsedRead.source).toBe("empty.fbx");
+        expect(parsedRead.sourceKind).toBe("upload");
+    });
+
+    it.each([
+        { data: null, source: "triangle.fbx", sourceKind: "upload" },
+        { data: "", source: null, sourceKind: "upload" },
+        { data: "", source: " ", sourceKind: "upload" },
+        { data: "", source: "triangle.fbx", sourceKind: "" },
+    ])("rejects a partial serialized FBX source state: %o", (partialState) => {
+        const asset = new NodeAsset("partial-fbx-source");
+        const read = new ReadFBXBlock("Read FBX", asset);
+        const serialized = JSON.parse(JSON.stringify(asset.serialize()));
+        Object.assign(serialized.blocks[0], partialState);
+
+        expect(() => NodeAsset.Parse(serialized)).toThrow(/invalid FBX source state/);
+    });
+
+    it("rejects an upload without a source label", () => {
+        const asset = new NodeAsset("unlabeled-fbx-source");
+        const read = new ReadFBXBlock("Read FBX", asset);
+
+        expect(() => read.setUploadedSource(CreateTriangleFBX74(), " ")).toThrow(/source label/);
+    });
+
+    it("builds and reloads Import FBX through an existing Universal operator", async () => {
+        const asset = new NodeAsset("serialized-fbx-funnel");
+        const importer = new ImportFBXAggregateBlock("Import FBX", asset);
+        importer.setUploadedSource(CreateTriangleFBX74(), "triangle.fbx");
+        const center = new CenterSceneBlock("Center Scene", asset);
+        const exporter = new ExportGLTFAggregateBlock("Export glTF", asset);
+        importer.output.connectTo(center.input);
+        center.output.connectTo(exporter.input);
+
+        const serialized = JSON.parse(JSON.stringify(asset.serialize()));
+        expect(serialized.blocks[0]).toMatchObject({
+            customType: ImportFBXAggregateBlock.ClassName,
+            aggregateVersion: 1,
+            subgraph: {
+                blocks: [
+                    {
+                        customType: ReadFBXBlock.ClassName,
+                        source: "triangle.fbx",
+                        sourceKind: "upload",
+                    },
+                    { customType: FBXToUniversalBlock.ClassName, name: "FBX → Universal" },
+                ],
+            },
+        });
+
+        const parsed = NodeAsset.Parse(serialized);
+        const parsedImporter = parsed.attachedBlocks[0] as ImportFBXAggregateBlock;
+        expect(parsedImporter.source).toBe("triangle.fbx");
+        expect(parsedImporter.sourceKind).toBe("upload");
+        expect(parsedImporter.data).toEqual(CreateTriangleFBX74());
+
+        const result = await parsed.buildAsync();
+        expect(result.subarray(0, 4)).toEqual(new TextEncoder().encode("glTF"));
+        expect(await ReadAssetFactsAsync(result)).toEqual({
+            meshCount: 1,
+            nodeNames: ["Triangle", "Bounds-derived centering"],
+            positionCount: 3,
+            primitiveCount: 1,
+        });
+    });
+
+    it("publishes FBX source metadata and disposes its temporary scene on success", async () => {
+        const sceneDispose = vi.spyOn(Scene.prototype, "dispose");
+        const engineDispose = vi.spyOn(NullEngine.prototype, "dispose");
+        try {
+            const asset = new NodeAsset("fbx-metadata");
+            const read = new ReadFBXBlock("Read FBX", asset);
+            const toUniversal = new FBXToUniversalBlock("FBX → Universal", asset);
+            read.setUploadedSource(CreateTriangleFBX74(), "triangle.fbx");
+            await read._buildBlockAsync();
+            toUniversal.input.value = read.output.value;
+
+            await toUniversal._buildBlockAsync();
+
+            const universal = GetGltfAsset(toUniversal.output.value, "output");
+            expect(universal.manifest).toEqual({
+                format: "universal",
+                importedFrom: "fbx",
+                source: "triangle.fbx",
+            });
+            expect(universal.document.getRoot().listMeshes()).toHaveLength(1);
+            expect(sceneDispose).toHaveBeenCalledTimes(1);
+            expect(engineDispose).toHaveBeenCalledTimes(1);
+        } finally {
+            sceneDispose.mockRestore();
+            engineDispose.mockRestore();
+        }
+    });
+
+    it("preserves malformed FBX errors with block and source context while disposing temporary resources", async () => {
+        const sceneDispose = vi.spyOn(Scene.prototype, "dispose");
+        const engineDispose = vi.spyOn(NullEngine.prototype, "dispose");
+        try {
+            const asset = new NodeAsset("malformed-fbx");
+            const read = new ReadFBXBlock("Read FBX", asset);
+            const toUniversal = new FBXToUniversalBlock("FBX → Universal", asset);
+            read.setUploadedSource(new TextEncoder().encode("; FBX malformed"), "broken.fbx");
+            await read._buildBlockAsync();
+            toUniversal.input.value = read.output.value;
+
+            let failure: unknown;
+            try {
+                await toUniversal._buildBlockAsync();
+            } catch (error) {
+                failure = error;
+            }
+
+            expect(failure).toBeInstanceOf(Error);
+            expect((failure as Error).message).toContain('The "FBX → Universal" block failed to convert "broken.fbx" from FBX to Universal');
+            expect((failure as Error).cause).toBeInstanceOf(Error);
+            expect((failure as Error).cause).not.toBe(failure);
+            expect(sceneDispose).toHaveBeenCalledTimes(1);
+            expect(engineDispose).toHaveBeenCalledTimes(1);
+        } finally {
+            sceneDispose.mockRestore();
+            engineDispose.mockRestore();
+        }
+    });
+
+    it("attempts both cleanups without replacing a malformed FBX cause", async () => {
+        const sceneCleanupFailure = new Error("scene cleanup failed");
+        const engineCleanupFailure = new Error("engine cleanup failed");
+        const sceneDispose = vi.spyOn(Scene.prototype, "dispose").mockImplementationOnce(() => {
+            throw sceneCleanupFailure;
+        });
+        const engineDispose = vi.spyOn(NullEngine.prototype, "dispose").mockImplementationOnce(() => {
+            throw engineCleanupFailure;
+        });
+        try {
+            const asset = new NodeAsset("malformed-fbx-cleanup");
+            const read = new ReadFBXBlock("Read FBX", asset);
+            const toUniversal = new FBXToUniversalBlock("FBX → Universal", asset);
+            read.setUploadedSource(new TextEncoder().encode("; FBX malformed"), "broken.fbx");
+            await read._buildBlockAsync();
+            toUniversal.input.value = read.output.value;
+
+            let failure: unknown;
+            try {
+                await toUniversal._buildBlockAsync();
+            } catch (error) {
+                failure = error;
+            }
+
+            expect(failure).toBeInstanceOf(AggregateError);
+            expect((failure as AggregateError).message).toContain('The "FBX → Universal" block failed to convert "broken.fbx"');
+            expect((failure as Error).cause).toBeInstanceOf(Error);
+            expect((failure as AggregateError).errors).toEqual(expect.arrayContaining([sceneCleanupFailure, engineCleanupFailure]));
+            expect(sceneDispose).toHaveBeenCalledTimes(1);
+            expect(engineDispose).toHaveBeenCalledTimes(1);
+        } finally {
+            sceneDispose.mockRestore();
+            engineDispose.mockRestore();
+        }
+    });
+});

--- a/packages/dev/node-assets/test/unit/typedRepresentations.test.ts
+++ b/packages/dev/node-assets/test/unit/typedRepresentations.test.ts
@@ -9,6 +9,7 @@ import { describe, expect, expectTypeOf, it } from "vitest";
 import { NodeAssetConnectionPointType } from "../../src/connection/nodeAssetConnectionPointType";
 import { type NodeAssetJsonValue, type NodeAssetValueMap } from "../../src/connection/nodeAssetValueMap";
 import { BabylonAsset, IsBabylonAsset } from "../../src/representations/babylonAsset";
+import { type FBXSource } from "../../src/representations/fbxSource";
 import { GltfAsset, IsGltfAsset } from "../../src/representations/gltfAsset";
 import { IsNodeGeometryAsset, NodeGeometryAsset } from "../../src/representations/nodeGeometryAsset";
 import { IsUsdAsset, UsdAsset } from "../../src/representations/usdAsset";
@@ -104,6 +105,10 @@ describe("typed representations", () => {
         expect(NodeAssetConnectionPointType.NODE_GEOMETRY).toBe(7);
         expect(NodeAssetConnectionPointType.UNIVERSAL).toBe(8);
         expect(NodeAssetConnectionPointType.USD_SOURCE).toBe(10);
+        expect(NodeAssetConnectionPointType[11]).toBeUndefined();
+        expect(NodeAssetConnectionPointType.FBX_SOURCE).toBe(12);
+        expect("OBJ_SOURCE" in NodeAssetConnectionPointType).toBe(false);
+        expect("RBXM_SOURCE" in NodeAssetConnectionPointType).toBe(false);
         expect("REPRESENTATION" in NodeAssetConnectionPointType).toBe(false);
         expect(NodeAssetConnectionPointType[NodeAssetConnectionPointType.GLTF_DOCUMENT]).toBe("GLTF_DOCUMENT");
     });
@@ -112,6 +117,7 @@ describe("typed representations", () => {
         expectTypeOf<NodeAssetValueMap[NodeAssetConnectionPointType.GLTF_DOCUMENT]>().toEqualTypeOf<GltfAsset>();
         expectTypeOf<NodeAssetValueMap[NodeAssetConnectionPointType.USD_STAGE]>().toEqualTypeOf<UsdAsset>();
         expectTypeOf<NodeAssetValueMap[NodeAssetConnectionPointType.USD_SOURCE]>().toEqualTypeOf<UsdSourceAsset>();
+        expectTypeOf<NodeAssetValueMap[NodeAssetConnectionPointType.FBX_SOURCE]>().toEqualTypeOf<FBXSource>();
         expectTypeOf<NodeAssetValueMap[NodeAssetConnectionPointType.BABYLON_SCENE]>().toEqualTypeOf<BabylonAsset>();
         expectTypeOf<NodeAssetValueMap[NodeAssetConnectionPointType.NODE_GEOMETRY]>().toEqualTypeOf<NodeGeometryAsset>();
         expectTypeOf<NodeAssetValueMap[NodeAssetConnectionPointType.NUMBER]>().toEqualTypeOf<number>();

--- a/packages/dev/node-assets/tsconfig.build.json
+++ b/packages/dev/node-assets/tsconfig.build.json
@@ -8,6 +8,12 @@
         "rootDir": "./src"
     },
 
+    "references": [
+        {
+            "path": "../loaders/tsconfig.build.json"
+        }
+    ],
+
     "include": ["./src/**/*.ts", "./src/**/*.tsx"],
     "exclude": ["**/node_modules", "**/dist"]
 }

--- a/packages/tools/nodeAssetsEditor/src/nodeAssets/blockCatalog.ts
+++ b/packages/tools/nodeAssetsEditor/src/nodeAssets/blockCatalog.ts
@@ -108,6 +108,10 @@ export const TranscodersHeaderColor = "#6B4C8A";
 export const BabylonCategory = "Babylon";
 export const BabylonHeaderColor = "#4A90D9";
 
+/** Shared node header color for the FBX block family. */
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export const FBXHeaderColor = "#B35900";
+
 /** Palette category and shared node header color for the USD operator block family. */
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export const USDCategory = "USD";

--- a/packages/tools/nodeAssetsEditor/src/nodeAssets/blockDescriptors/fbxToUniversalBlockDescriptor.ts
+++ b/packages/tools/nodeAssetsEditor/src/nodeAssets/blockDescriptors/fbxToUniversalBlockDescriptor.ts
@@ -1,0 +1,15 @@
+import { FBXToUniversalBlock } from "node-assets/Blocks/fbxToUniversalBlock";
+
+import { FBXHeaderColor, RegisterBlockDescriptor } from "../blockCatalog";
+
+RegisterBlockDescriptor({
+    paletteItemId: "fbx-to-universal",
+    label: "FBX → Universal",
+    description: "Parse an FBX source and cross into Universal.",
+    keywords: ["convert", "transcode", "fbx", "Universal"],
+    category: "FBX",
+    headerColor: FBXHeaderColor,
+    className: FBXToUniversalBlock.ClassName,
+    abstractedBy: "import-fbx",
+    create: (nodeAsset) => new FBXToUniversalBlock("FBX → Universal", nodeAsset),
+});

--- a/packages/tools/nodeAssetsEditor/src/nodeAssets/blockDescriptors/importFBXAggregateBlockDescriptor.ts
+++ b/packages/tools/nodeAssetsEditor/src/nodeAssets/blockDescriptors/importFBXAggregateBlockDescriptor.ts
@@ -1,0 +1,15 @@
+import { ImportFBXAggregateBlock } from "node-assets/Blocks/importFBXAggregateBlock";
+
+import { AggregateImportsFamily, ConfigureBlockForEditor, FBXHeaderColor, RegisterBlockDescriptor } from "../blockCatalog";
+
+RegisterBlockDescriptor({
+    paletteItemId: "import-fbx",
+    label: "Import FBX",
+    description: "Read an .fbx source and cross into Universal.",
+    keywords: ["open", "load", "source", "fbx", "Universal"],
+    category: "Inputs",
+    family: AggregateImportsFamily,
+    headerColor: FBXHeaderColor,
+    className: ImportFBXAggregateBlock.ClassName,
+    create: (nodeAsset) => ConfigureBlockForEditor(new ImportFBXAggregateBlock("Import FBX", nodeAsset)),
+});

--- a/packages/tools/nodeAssetsEditor/src/nodeAssets/blockDescriptors/index.ts
+++ b/packages/tools/nodeAssetsEditor/src/nodeAssets/blockDescriptors/index.ts
@@ -7,6 +7,7 @@
 import "./importGLTFBlockDescriptor";
 import "./importUSDBlockDescriptor";
 import "./importBabylonAggregateBlockDescriptor";
+import "./importFBXAggregateBlockDescriptor";
 import "./importNodeGeometryBlockDescriptor";
 
 import "./universalToGLTFBlockDescriptor";
@@ -35,11 +36,13 @@ import "./exportGLTFBlockDescriptor";
 import "./readGLTFBlockDescriptor";
 import "./readUSDBlockDescriptor";
 import "./readBabylonBlockDescriptor";
+import "./readFBXBlockDescriptor";
 import "./readNodeGeometryBlockDescriptor";
 import "./gltfToUniversalBlockDescriptor";
 import "./writeGLTFBlockDescriptor";
 import "./usdToUniversalBlockDescriptor";
 import "./babylonToUniversalBlockDescriptor";
+import "./fbxToUniversalBlockDescriptor";
 import "./nodeGeometryToUniversalBlockDescriptor";
 
 import "./legacyImportGLTFBlockDescriptor";

--- a/packages/tools/nodeAssetsEditor/src/nodeAssets/blockDescriptors/readFBXBlockDescriptor.ts
+++ b/packages/tools/nodeAssetsEditor/src/nodeAssets/blockDescriptors/readFBXBlockDescriptor.ts
@@ -1,0 +1,95 @@
+import { ReadFBXBlock } from "node-assets/Blocks/readFBXBlock";
+
+import { type IPropertySection } from "../../nodeGraph/propertyModel";
+import { PromptForFileAsync } from "../browserFiles";
+import { ConfigureBlockForEditor, FBXHeaderColor, type IPropertySectionContext, RegisterBlockDescriptor } from "../blockCatalog";
+
+const SourceErrors = new WeakMap<ReadFBXBlock, string>();
+const PendingSourceRequests = new WeakMap<ReadFBXBlock, Promise<ArrayBuffer>>();
+
+// eslint-disable-next-line @typescript-eslint/naming-convention
+async function PromptForFBXAsync(block: ReadFBXBlock, context: IPropertySectionContext): Promise<void> {
+    const file = await PromptForFileAsync(".fbx");
+    if (!file) {
+        return;
+    }
+    const authoredBlock = context.prepareEdit(block);
+    if (!authoredBlock) {
+        return;
+    }
+    const request = file.arrayBuffer();
+    PendingSourceRequests.set(authoredBlock, request);
+    try {
+        const data = new Uint8Array(await request);
+        if (context.prepareEdit(authoredBlock) !== authoredBlock || PendingSourceRequests.get(authoredBlock) !== request) {
+            return;
+        }
+        authoredBlock.setUploadedSource(data, file.name);
+        SourceErrors.delete(authoredBlock);
+    } catch (error) {
+        if (context.prepareEdit(authoredBlock) === authoredBlock && PendingSourceRequests.get(authoredBlock) === request) {
+            SourceErrors.set(authoredBlock, error instanceof Error ? error.message : String(error));
+        }
+    } finally {
+        if (PendingSourceRequests.get(authoredBlock) === request) {
+            PendingSourceRequests.delete(authoredBlock);
+        }
+    }
+    if (context.prepareEdit(authoredBlock) === authoredBlock) {
+        context.refresh();
+    }
+}
+
+/**
+ * Builds the upload controls shared by Read FBX and Import FBX.
+ * @param block The owned Read FBX primitive.
+ * @param context Editor property actions.
+ * @param title Child-attributed section title.
+ * @returns The shared property section.
+ */
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export function CreateReadFBXPropertySection(block: ReadFBXBlock, context: IPropertySectionContext, title = "SOURCE"): IPropertySection {
+    const sourceError = SourceErrors.get(block);
+    return {
+        title,
+        properties: [
+            {
+                kind: "text",
+                label: "Active source",
+                value: block.source ?? "No source loaded",
+                disabled: true,
+                onChange: () => undefined,
+            },
+            {
+                kind: "button",
+                label: "Upload FBX\u2026",
+                onClick: () => {
+                    void PromptForFBXAsync(block, context);
+                },
+            },
+            ...(sourceError
+                ? ([
+                      {
+                          kind: "text",
+                          label: "Source error",
+                          value: sourceError,
+                          disabled: true,
+                          onChange: () => undefined,
+                      },
+                  ] as const)
+                : []),
+        ],
+    };
+}
+
+RegisterBlockDescriptor({
+    paletteItemId: "read-fbx",
+    label: "Read FBX",
+    description: "Read an uploaded .fbx source.",
+    category: "Inputs",
+    headerColor: FBXHeaderColor,
+    className: ReadFBXBlock.ClassName,
+    abstractedBy: "import-fbx",
+    create: (nodeAsset) => ConfigureBlockForEditor(new ReadFBXBlock("Read FBX", nodeAsset)),
+    getPropertySection: (block, context) => CreateReadFBXPropertySection(block as ReadFBXBlock, context),
+});

--- a/packages/tools/nodeAssetsEditor/src/nodeAssets/blockNodeMapping.ts
+++ b/packages/tools/nodeAssetsEditor/src/nodeAssets/blockNodeMapping.ts
@@ -14,6 +14,7 @@ import { type NodeAssetConnectionPoint } from "node-assets/connection/nodeAssetC
 import { type IGraphNode, type IGraphPort, type Vec2 } from "../nodeGraph/graphModel";
 import {
     BabylonScenePortColor,
+    FBXHeaderColor,
     ImagePortColor,
     JsonPortColor,
     NodeGeometryPortColor,
@@ -67,6 +68,7 @@ const PortStyleByType: Partial<Record<NodeAssetConnectionPointType, { readonly n
     [NodeAssetConnectionPointType.NODE_GEOMETRY]: { name: "Node Geometry", color: NodeGeometryPortColor },
     [NodeAssetConnectionPointType.UNIVERSAL]: { name: "Universal", color: UniversalPortColor },
     [NodeAssetConnectionPointType.BABYLON_SOURCE]: { name: "Babylon", color: BabylonScenePortColor },
+    [NodeAssetConnectionPointType.FBX_SOURCE]: { name: "FBX", color: FBXHeaderColor },
 };
 
 /**

--- a/packages/tools/nodeAssetsEditor/test/unit/blockNodeMapping.test.ts
+++ b/packages/tools/nodeAssetsEditor/test/unit/blockNodeMapping.test.ts
@@ -4,7 +4,15 @@ import { NodeAsset } from "node-assets/nodeAsset";
 import { NodeAssetBlock } from "node-assets/blockFoundation/nodeAssetBlock";
 import { NodeAssetConnectionPointType } from "node-assets/connection/nodeAssetConnectionPointType";
 
-import { NumberPortColor, ScenePortColor, UsdStagePortColor, BabylonScenePortColor, NodeGeometryPortColor, type IBlockDescriptor } from "../../src/nodeAssets/blockCatalog";
+import {
+    NumberPortColor,
+    ScenePortColor,
+    UsdStagePortColor,
+    BabylonScenePortColor,
+    FBXHeaderColor,
+    NodeGeometryPortColor,
+    type IBlockDescriptor,
+} from "../../src/nodeAssets/blockCatalog";
 import { BlockToNode, NodeIdForBlock, PointToPort, PortIdForPoint } from "../../src/nodeAssets/blockNodeMapping";
 
 class MappingTestBlock extends NodeAssetBlock {
@@ -24,6 +32,7 @@ class RepresentationMappingTestBlock extends NodeAssetBlock {
     public readonly babylon = this._registerOutput("babylon", NodeAssetConnectionPointType.BABYLON_SCENE);
     public readonly nodeGeometry = this._registerOutput("nodeGeometry", NodeAssetConnectionPointType.NODE_GEOMETRY);
     public readonly usdSource = this._registerOutput("usdSource", NodeAssetConnectionPointType.USD_SOURCE);
+    public readonly fbxSource = this._registerOutput("fbxSource", NodeAssetConnectionPointType.FBX_SOURCE);
 
     public override async _buildBlockAsync(): Promise<void> {}
 }
@@ -74,6 +83,7 @@ describe("blockNodeMapping", () => {
         expect(PointToPort(block, block.babylon).color).toBe(BabylonScenePortColor);
         expect(PointToPort(block, block.nodeGeometry).color).toBe(NodeGeometryPortColor);
         expect(PointToPort(block, block.usdSource)).toMatchObject({ name: "USD", color: UsdStagePortColor });
+        expect(PointToPort(block, block.fbxSource)).toMatchObject({ name: "FBX", color: FBXHeaderColor });
     });
 
     it("builds a node with input ports before output ports", () => {

--- a/packages/tools/nodeAssetsEditor/test/unit/importExportFields.test.ts
+++ b/packages/tools/nodeAssetsEditor/test/unit/importExportFields.test.ts
@@ -21,6 +21,7 @@ vi.mock("../../src/nodeAssets/browserFiles", () => ({
 
 const ImportFileButtonLabel = "Upload glTF\u2026";
 const BabylonImportFileButtonLabel = "Upload Babylon\u2026";
+const FBXImportFileButtonLabel = "Upload FBX\u2026";
 const UploadUSDButtonLabel = "Upload USD\u2026";
 
 function FindNode(controller: NodeAssetGraphController, title: string): IGraphNode {
@@ -952,6 +953,41 @@ describe("Import block source label", () => {
                 reloaded.load(controller.serialize());
                 const reloadedImport = FindNode(reloaded, "Import Babylon");
                 expect(FindPropertyInSection(reloaded, reloadedImport, "READ BABYLON", "Active source", "text").value).toBe("myScene.babylon");
+            } finally {
+                reloaded.dispose();
+            }
+        } finally {
+            controller.dispose();
+        }
+    });
+
+    it("shares the uploaded FBX source across compact, expanded, and reloaded editor surfaces", async () => {
+        const controller = new NodeAssetGraphController();
+        try {
+            const importNode = AddPaletteNode(controller, "import-fbx");
+            expect(FindPropertyInSection(controller, importNode, "READ FBX", "Active source", "text").value).toBe("No source loaded");
+
+            vi.mocked(PromptForFileAsync).mockResolvedValue({
+                name: "triangle.fbx",
+                arrayBuffer: async () => new Uint8Array([1, 2, 3, 4]).buffer,
+            } as unknown as File);
+
+            FindPropertyInSection(controller, importNode, "READ FBX", FBXImportFileButtonLabel, "button").onClick();
+            await vi.waitFor(() => {
+                expect(FindPropertyInSection(controller, importNode, "READ FBX", "Active source", "text").value).toBe("triangle.fbx");
+            });
+            expect(PromptForFileAsync).toHaveBeenCalledWith(".fbx");
+
+            controller.setAggregateExpanded(importNode.id, true);
+            const readNode = FindNode(controller, "Read FBX");
+            expect(FindPropertyInSection(controller, readNode, "SOURCE", "Active source", "text").value).toBe("triangle.fbx");
+            expect(FindPropertyInSection(controller, readNode, "SOURCE", FBXImportFileButtonLabel, "button")).toBeDefined();
+
+            const reloaded = new NodeAssetGraphController();
+            try {
+                reloaded.load(controller.serialize());
+                const reloadedImport = FindNode(reloaded, "Import FBX");
+                expect(FindPropertyInSection(reloaded, reloadedImport, "READ FBX", "Active source", "text").value).toBe("triangle.fbx");
             } finally {
                 reloaded.dispose();
             }

--- a/packages/tools/nodeAssetsEditor/test/unit/nodeAssetBuildWorkerRegistration.test.ts
+++ b/packages/tools/nodeAssetsEditor/test/unit/nodeAssetBuildWorkerRegistration.test.ts
@@ -95,6 +95,9 @@ const ExpectedBlockClassNames = [
     "ReadBabylonBlock",
     "BabylonToUniversalBlock",
     "ImportBabylonAggregateBlock",
+    "ReadFBXBlock",
+    "FBXToUniversalBlock",
+    "ImportFBXAggregateBlock",
 ] as const;
 
 const DefaultPipelineClassNames = ["ImportGLTFAggregateBlock", "WeldVerticesBlock", "RemoveUnusedResourcesBlock", "ExportGLTFAggregateBlock"] as const;

--- a/packages/tools/nodeAssetsEditor/test/unit/paletteCategories.test.ts
+++ b/packages/tools/nodeAssetsEditor/test/unit/paletteCategories.test.ts
@@ -18,6 +18,19 @@ function Descriptor(
 }
 
 describe("BuildPaletteCategories", () => {
+    it("places Import FBX after Import Babylon and before Import Node Geometry", () => {
+        const inputs = BuildPaletteCategories(GetAllBlockDescriptors()).find((category) => category.label === "Inputs");
+        const labels = inputs?.items.map((item) => item.label) ?? [];
+        const babylonIndex = labels.indexOf("Import Babylon");
+        const fbxIndex = labels.indexOf("Import FBX");
+        const nodeGeometryIndex = labels.indexOf("Import Node Geometry");
+
+        expect(labels).toContain("Import FBX");
+        expect(babylonIndex).toBeGreaterThanOrEqual(0);
+        expect(fbxIndex).toBeGreaterThan(babylonIndex);
+        expect(nodeGeometryIndex).toBeGreaterThan(fbxIndex);
+    });
+
     it("publishes the exact default product palette in canonical category, family, and item order", () => {
         const projection = BuildPaletteCategories(GetAllBlockDescriptors()).map((category) => ({
             category: category.label,
@@ -34,6 +47,7 @@ describe("BuildPaletteCategories", () => {
                     { family: "Aggregate imports", label: "Import glTF" },
                     { family: "Aggregate imports", label: "Import USD" },
                     { family: "Aggregate imports", label: "Import Babylon" },
+                    { family: "Aggregate imports", label: "Import FBX" },
                     { family: "Aggregate imports", label: "Import Node Geometry" },
                 ],
             },
@@ -81,12 +95,12 @@ describe("BuildPaletteCategories", () => {
             };
         });
 
-        expect(primitiveCategories.map((category) => category.label)).toEqual(["Inputs", "Universal", "glTF", "USD", "Babylon", "Node Geometry"]);
+        expect(primitiveCategories.map((category) => category.label)).toEqual(["Inputs", "Universal", "glTF", "USD", "Babylon", "FBX", "Node Geometry"]);
         for (const defaultCategory of defaultCategories) {
             expect(primitiveCategories.find((category) => category.label === defaultCategory.label)?.items.slice(0, defaultCategory.items.length)).toEqual(defaultCategory.items);
         }
         expect(additions).toEqual([
-            { category: "Inputs", items: ["Read glTF", "Read USD", "Read Babylon", "Read Node Geometry"] },
+            { category: "Inputs", items: ["Read glTF", "Read USD", "Read Babylon", "Read FBX", "Read Node Geometry"] },
             {
                 category: "Universal",
                 items: ["Universal → glTF", "Deduplicate Materials", "Deduplicate Textures", "Reuse Identical Meshes", "Deduplicate Data"],
@@ -94,6 +108,7 @@ describe("BuildPaletteCategories", () => {
             { category: "glTF", items: ["glTF → Universal", "Write glTF"] },
             { category: "USD", items: ["USD → Universal"] },
             { category: "Babylon", items: ["Babylon → Universal"] },
+            { category: "FBX", items: ["FBX → Universal"] },
             { category: "Node Geometry", items: ["Node Geometry → Universal"] },
         ]);
     });


### PR DESCRIPTION
## Summary

- add typed uploaded FBX source, Read FBX, FBX → Universal, and Import FBX aggregate runtime blocks
- convert through the side-effect-free in-tree FBX loader into Universal with contextual errors and deterministic cleanup
- register the editor palette, upload controls, FBX styling, port display metadata, serialization, and worker coverage

## Testing

- `npm run compile:source -w @dev/node-assets`
- `npm run build -w @tools/node-assets-editor`
- `npm run format:check`
- `npm run lint:check`
- `npx vitest run --project=unit packages/dev/node-assets/test/unit/fbxUniversalFunnel.test.ts`
- `npx vitest run --project=unit packages/dev/node-assets/test/unit packages/tools/nodeAssetsEditor/test/unit` (all FBX/relevant tests passed; one unrelated KTX2 registry test timed out under parallel load and passed in isolation)
- `npm run test:unit` (5,380 tests passed; one unrelated UMD Rollup test timed out under parallel load and passed in isolation)

Stacked on `preview/nae`.
