### PR TITLE
feat(nae): hydrate default CDN source

### DIFF
--- a/.scratch/replace-placeholder-assets/issues/01-hydrate-default-cdn-source.md
+++ b/.scratch/replace-placeholder-assets/issues/01-hydrate-default-cdn-source.md
@@ -1,6 +1,6 @@
 # Hydrate the default catalog source from Babylon CDN
 
-Status: ready-for-agent
+Status: resolved
 
 ## What to build
 

--- a/packages/tools/nodeAssetsEditor/src/buildScheduler.ts
+++ b/packages/tools/nodeAssetsEditor/src/buildScheduler.ts
@@ -16,6 +16,8 @@ export interface IBuildSchedulerOptions<Result> {
     readonly debounceMs: number;
     /** Async build work that produces the result to apply. */
     readonly buildAsync: () => Promise<Result>;
+    /** Whether construction starts a build immediately. Defaults to true. */
+    readonly buildImmediately?: boolean;
     /** Applies the latest build result. Stale results skip this callback entirely. */
     readonly applyResultAsync?: (result: Result) => Promise<void>;
     /** Called whenever a new build starts. */
@@ -27,8 +29,8 @@ export interface IBuildSchedulerOptions<Result> {
 }
 
 /**
- * Debounces graph-change triggers, runs once immediately for editor open, and discards stale in-flight
- * results after a newer build starts.
+ * Debounces graph-change triggers, runs once immediately for editor open, and invalidates stale
+ * in-flight results as soon as a newer graph change is observed.
  */
 export class BuildScheduler<Result> {
     private readonly _options: IBuildSchedulerOptions<Result>;
@@ -44,7 +46,9 @@ export class BuildScheduler<Result> {
     public constructor(options: IBuildSchedulerOptions<Result>) {
         this._options = options;
         this._triggerSubscription = options.triggerSource.add(() => this.trigger());
-        void this._startBuildAsync();
+        if (options.buildImmediately !== false) {
+            void this._startBuildAsync();
+        }
     }
 
     /**
@@ -54,6 +58,7 @@ export class BuildScheduler<Result> {
         if (this._isDisposed) {
             return;
         }
+        this._generation++;
         if (this._debounceHandle) {
             clearTimeout(this._debounceHandle);
         }

--- a/packages/tools/nodeAssetsEditor/src/nodeAssets/buildOrchestrator.ts
+++ b/packages/tools/nodeAssetsEditor/src/nodeAssets/buildOrchestrator.ts
@@ -120,6 +120,7 @@ export class BuildOrchestrator {
                     const message = GetErrorMessage(error);
                     Logger.Error(`[NodeAssetsEditor] Default asset load failed: ${message}`);
                     this._preview.setStatus(false, message);
+                    this._startScheduler(false);
                 }
             }
         })();
@@ -156,11 +157,12 @@ export class BuildOrchestrator {
         this._scheduler?.dispose();
     }
 
-    private _startScheduler(): void {
+    private _startScheduler(buildImmediately = true): void {
         this._scheduler = new BuildScheduler({
             triggerSource: this._controller.onBuildRelevantChanged,
             debounceMs: AutoBuildDebounceMs,
             buildAsync: async () => await this._controller.buildAsync(),
+            buildImmediately,
             applyResultAsync: async (bytes) => await this._preview.loadAssetAsync(bytes),
             onBuildStarted: () => {
                 this._buildStatusGeneration++;

--- a/packages/tools/nodeAssetsEditor/src/nodeAssets/builtInLibraryEntries.ts
+++ b/packages/tools/nodeAssetsEditor/src/nodeAssets/builtInLibraryEntries.ts
@@ -70,9 +70,9 @@ class BuiltInPipelineBuilder {
         readName: string,
         transcoderCustomType: string,
         transcoderName: string,
-        data: Uint8Array,
+        data: Uint8Array | null,
         source: string,
-        sourceKind: "upload"
+        sourceKind: "url" | "upload"
     ): BlockReference {
         const readId = this._allocateId();
         const transcoderId = this._allocateId();
@@ -82,7 +82,7 @@ class BuiltInPipelineBuilder {
             x,
             y,
             [
-                { customType: readCustomType, id: readId, name: readName, data: EncodeArrayBufferToBase64(data), source, sourceKind },
+                { customType: readCustomType, id: readId, name: readName, data: data ? EncodeArrayBufferToBase64(data) : null, source, sourceKind },
                 { customType: transcoderCustomType, id: transcoderId, name: transcoderName },
             ],
             [{ fromBlock: readId, fromPoint: "output", toBlock: transcoderId, toPoint: "input" }],
@@ -246,7 +246,19 @@ function CreateNodeGeometryImport(builder: BuiltInPipelineBuilder, x = 40, y = 1
 
 function CreateGltfOptimizationEntry(): INodeAssetLibraryEntry {
     const builder = new BuiltInPipelineBuilder("glTF Optimization");
-    const source = CreateGltfImport(builder);
+    const source = builder.addImport(
+        "ImportGLTFAggregateBlock",
+        "Import glTF",
+        40,
+        120,
+        "ReadGLTFBlock",
+        "Read glTF",
+        "GLTFToUniversalBlock",
+        "glTF to Universal",
+        null,
+        "https://assets.babylonjs.com/meshes/roundedCube.glb",
+        "url"
+    );
     const weld = builder.addBlock("WeldVerticesBlock", "Weld Vertices", 340, 120, { overwrite: true });
     const prune = builder.addBlock("RemoveUnusedResourcesBlock", "Remove Unused Resources", 640, 120, {
         keptPropertyTypes: [],

--- a/packages/tools/nodeAssetsEditor/src/nodeAssets/builtInLibraryFixtures.ts
+++ b/packages/tools/nodeAssetsEditor/src/nodeAssets/builtInLibraryFixtures.ts
@@ -58,7 +58,7 @@ function CreateTriangleGlb(indexed: boolean): Uint8Array {
     return glb;
 }
 
-/** Deterministic local source payloads embedded into every built-in pipeline serialization. */
+/** Deterministic local source payloads used by inline catalog entries and tests. */
 export const BuiltInLibraryFixtures = {
     gltf: CreateTriangleGlb(true),
     unweldedGltf: CreateTriangleGlb(false),

--- a/packages/tools/nodeAssetsEditor/src/nodeAssets/nodeAssetGraphController.ts
+++ b/packages/tools/nodeAssetsEditor/src/nodeAssets/nodeAssetGraphController.ts
@@ -14,6 +14,7 @@
 import { Observable } from "core/Misc/observable";
 
 import { ExportGLTFBlock } from "node-assets/Blocks/exportGLTFBlock";
+import { ReadGLTFBlock, type GLTFSourceFetcher, type IGLTFSourceResponse } from "node-assets/Blocks/readGLTFBlock";
 import { NodeAsset } from "node-assets/nodeAsset";
 import { NodeAssetBuildError } from "node-assets/nodeAssetBuildError";
 import { AggregateBlock } from "node-assets/blockFoundation/aggregateBlock";
@@ -81,6 +82,21 @@ interface INodeAssetEditorFile {
         readonly blocks: readonly IEditorBlockMetadata[];
         readonly frames: readonly IEditorFrameMetadata[];
     };
+}
+
+type GltfSourceResult = { readonly ok: true; readonly data: Uint8Array } | { readonly ok: false; readonly status: number; readonly statusText: string };
+
+function CreateGraphInvalidationSignal(): { readonly promise: Promise<void>; readonly resolve: () => void } {
+    let resolveSignal = () => {};
+    const promise = new Promise<void>((resolve) => {
+        resolveSignal = resolve;
+    });
+    return { promise, resolve: resolveSignal };
+}
+
+async function AwaitOutcomeAsync<Outcome extends string>(promise: Promise<void>, outcome: Outcome): Promise<Outcome> {
+    await promise;
+    return outcome;
 }
 
 function IsRecord(value: unknown): value is Record<string, unknown> {
@@ -292,11 +308,17 @@ export class NodeAssetGraphController {
     private _nodeAsset: NodeAsset;
     private readonly _reconciler: NodeAssetReconciler;
     private readonly _buildClient: INodeAssetBuildClient;
+    private readonly _gltfSourceFetcher: GLTFSourceFetcher;
+    private readonly _gltfSourceDataByUrl = new Map<string, Uint8Array>();
+    private readonly _gltfSourceRequestByUrl = new Map<string, Promise<GltfSourceResult>>();
+    private _gltfSourceRequestGeneration = 0;
     private _buildRelevantSignature: string;
     private readonly _onChangedObserver;
     private readonly _aggregateRootByChildNodeId = new Map<string, string>();
     private _projectingAggregate = false;
     private _graphRevision = 0;
+    private _graphInvalidated: Promise<void>;
+    private _resolveGraphInvalidated: () => void;
     private _isDisposed = false;
     /**
      * Authored (not merely visual) intent that an aggregate block is expanded, keyed by block id.
@@ -311,10 +333,15 @@ export class NodeAssetGraphController {
     /**
      * Creates a controller seeded from the maintained default entry in the production pipeline catalog.
      * @param buildClient - Worker-backed build client.
+     * @param gltfSourceFetcher - Fetch-compatible glTF source loader.
      */
-    public constructor(buildClient: INodeAssetBuildClient = new NodeAssetBuildWorkerClient()) {
+    public constructor(buildClient: INodeAssetBuildClient = new NodeAssetBuildWorkerClient(), gltfSourceFetcher: GLTFSourceFetcher = async (url) => await fetch(url)) {
+        const graphInvalidationSignal = CreateGraphInvalidationSignal();
+        this._graphInvalidated = graphInvalidationSignal.promise;
+        this._resolveGraphInvalidated = graphInvalidationSignal.resolve;
         this._nodeAsset = new NodeAsset("nodeAsset");
         this._buildClient = buildClient;
+        this._gltfSourceFetcher = gltfSourceFetcher;
         this._reconciler = new NodeAssetReconciler(this._nodeAsset);
         this.state = new GraphEditorState(
             { nodes: [], wires: [], frames: [] },
@@ -342,11 +369,20 @@ export class NodeAssetGraphController {
     }
 
     /**
-     * Preserves the build-orchestrator startup contract. Catalog source fixtures are already embedded in
-     * the serialized default graph, so startup performs no network loading.
-     * @returns An already-resolved promise.
+     * Hydrates the active startup graph, following a replacement graph when the original load becomes stale.
      */
-    public async loadDefaultImportAsync(): Promise<void> {}
+    public async loadDefaultImportAsync(): Promise<void> {
+        const nodeAsset = this._nodeAsset;
+        const graphRevision = this._graphRevision;
+        const graphInvalidated = this._graphInvalidated;
+        const hydration = this._hydrateGltfSourcesAsync(nodeAsset, graphRevision);
+        await Promise.race([AwaitOutcomeAsync(hydration, "hydrated"), AwaitOutcomeAsync(graphInvalidated, "invalidated")]);
+        if (this._isActiveGraph(nodeAsset, graphRevision)) {
+            this._buildRelevantSignature = this._createBuildRelevantSignature();
+        } else if (!this._isDisposed) {
+            await this.loadDefaultImportAsync();
+        }
+    }
 
     /**
      * Projects the registered block catalog into the current palette discovery view.
@@ -601,7 +637,13 @@ export class NodeAssetGraphController {
      */
     public async buildAsync(): Promise<Uint8Array> {
         this._reconcileAndNotifyBuildRelevantChange();
-        return await this._buildClient.buildAsync(this._nodeAsset.serialize());
+        const nodeAsset = this._nodeAsset;
+        const graphRevision = this._graphRevision;
+        await this._hydrateGltfSourcesAsync(nodeAsset, graphRevision);
+        if (!this._isActiveGraph(nodeAsset, graphRevision)) {
+            throw new Error("The NodeAsset graph changed before its build could be serialized.");
+        }
+        return await this._buildClient.buildAsync(nodeAsset.serialize());
     }
 
     /** Clears the node diagnostic produced by the previous build. */
@@ -828,7 +870,7 @@ export class NodeAssetGraphController {
 
         // Commit only after the complete candidate file has parsed and mapped successfully.
         this._nodeAsset = asset;
-        this._graphRevision++;
+        this._invalidateGraph();
         this._reconciler.reset(asset);
         this._aggregateRootByChildNodeId.clear();
         this._authoredAggregateExpansion.clear();
@@ -852,11 +894,113 @@ export class NodeAssetGraphController {
             return;
         }
         this._isDisposed = true;
-        this._graphRevision++;
+        this._invalidateGraph();
         this._onChangedObserver.remove();
         this.onExportRequested.clear();
         this.onBuildRelevantChanged.clear();
         this._buildClient.dispose();
+    }
+
+    private async _hydrateGltfSourcesAsync(nodeAsset: NodeAsset, graphRevision: number): Promise<void> {
+        const readBlocks: ReadGLTFBlock[] = [];
+        this._collectUrlOnlyGltfReadBlocks(nodeAsset, readBlocks);
+        await Promise.all(
+            readBlocks.map(async (readBlock) => {
+                const url = readBlock.source;
+                if (!url) {
+                    return;
+                }
+                await readBlock.setUrlAsync(
+                    url,
+                    async (sourceUrl) => await this._getCachedGltfSourceResponseAsync(sourceUrl),
+                    () => this._isActiveGraph(nodeAsset, graphRevision) && this._ownsBlock(nodeAsset, readBlock)
+                );
+            })
+        );
+    }
+
+    private _collectUrlOnlyGltfReadBlocks(nodeAsset: NodeAsset, readBlocks: ReadGLTFBlock[]): void {
+        for (const block of nodeAsset.attachedBlocks) {
+            if (block instanceof ReadGLTFBlock && block.sourceKind === "url" && block.source && !block.data) {
+                readBlocks.push(block);
+            }
+            if (block instanceof AggregateBlock) {
+                this._collectUrlOnlyGltfReadBlocks(block.subgraph, readBlocks);
+            }
+        }
+    }
+
+    private async _getCachedGltfSourceResponseAsync(url: string): Promise<IGLTFSourceResponse> {
+        const cached = this._gltfSourceDataByUrl.get(url);
+        const result = cached ? { ok: true as const, data: cached } : await this._getGltfSourceRequestAsync(url);
+        if (!result.ok) {
+            return {
+                ok: false,
+                status: result.status,
+                statusText: result.statusText,
+                // eslint-disable-next-line @typescript-eslint/naming-convention -- fetch-compatible response contract
+                arrayBuffer: async () => new ArrayBuffer(0),
+            };
+        }
+        return {
+            ok: true,
+            status: 200,
+            statusText: "OK",
+            // eslint-disable-next-line @typescript-eslint/naming-convention -- fetch-compatible response contract
+            arrayBuffer: async () => result.data.slice().buffer,
+        };
+    }
+
+    private async _getGltfSourceRequestAsync(url: string): Promise<GltfSourceResult> {
+        const existing = this._gltfSourceRequestByUrl.get(url);
+        if (existing) {
+            return await existing;
+        }
+        const requestGeneration = this._gltfSourceRequestGeneration;
+        const request = this._loadGltfSourceAsync(url, requestGeneration);
+        this._gltfSourceRequestByUrl.set(url, request);
+        try {
+            return await request;
+        } finally {
+            if (this._gltfSourceRequestByUrl.get(url) === request) {
+                this._gltfSourceRequestByUrl.delete(url);
+            }
+        }
+    }
+
+    private async _loadGltfSourceAsync(url: string, requestGeneration: number): Promise<GltfSourceResult> {
+        const response = await this._gltfSourceFetcher(url);
+        if (!response.ok) {
+            return { ok: false, status: response.status, statusText: response.statusText };
+        }
+        const data = new Uint8Array(await response.arrayBuffer());
+        if (this._gltfSourceRequestGeneration === requestGeneration) {
+            this._gltfSourceDataByUrl.set(url, data);
+        }
+        return { ok: true, data };
+    }
+
+    private _isActiveGraph(nodeAsset: NodeAsset, graphRevision: number): boolean {
+        return !this._isDisposed && this._nodeAsset === nodeAsset && this._graphRevision === graphRevision;
+    }
+
+    private _ownsBlock(nodeAsset: NodeAsset, target: NodeAssetBlock): boolean {
+        for (const block of nodeAsset.attachedBlocks) {
+            if (block === target || (block instanceof AggregateBlock && this._ownsBlock(block.subgraph, target))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private _invalidateGraph(): void {
+        this._graphRevision++;
+        this._gltfSourceRequestGeneration++;
+        this._gltfSourceRequestByUrl.clear();
+        this._resolveGraphInvalidated();
+        const graphInvalidationSignal = CreateGraphInvalidationSignal();
+        this._graphInvalidated = graphInvalidationSignal.promise;
+        this._resolveGraphInvalidated = graphInvalidationSignal.resolve;
     }
 
     private _instantiateBlock(descriptor: IBlockDescriptor, position: Vec2): IGraphNode {

--- a/packages/tools/nodeAssetsEditor/test/playwright/library/nodeAssetsEditor.test.ts
+++ b/packages/tools/nodeAssetsEditor/test/playwright/library/nodeAssetsEditor.test.ts
@@ -2,7 +2,7 @@ import { expect, test, type Download } from "@playwright/test";
 import { readFileSync } from "node:fs";
 
 import { CreateBuiltInNodeAssetLibraryEntries } from "../../../src/nodeAssets/builtInLibraryEntries";
-import { NodeAssetsEditorPage, useLocalGltfValidator } from "../nae.utils";
+import { NodeAssetsEditorPage, useLocalGltfValidator, useLocalRoundedCubeSource } from "../nae.utils";
 
 async function AssertValidDownloadedGlb(download: Download): Promise<void> {
     const path = await download.path();
@@ -15,7 +15,10 @@ async function AssertValidDownloadedGlb(download: Download): Promise<void> {
 
 test.describe("Node Assets Editor built-in pipeline catalog", () => {
     test.describe.configure({ timeout: 420_000 });
-    test.beforeEach(async ({ page }) => await useLocalGltfValidator(page));
+    test.beforeEach(async ({ page }) => {
+        await useLocalGltfValidator(page);
+        await useLocalRoundedCubeSource(page);
+    });
 
     test("lists, previews, and exports every production catalog graph", async ({ page }) => {
         const entries = CreateBuiltInNodeAssetLibraryEntries();

--- a/packages/tools/nodeAssetsEditor/test/playwright/nae.utils.ts
+++ b/packages/tools/nodeAssetsEditor/test/playwright/nae.utils.ts
@@ -2,6 +2,10 @@ import { type Page, type Locator, expect } from "@playwright/test";
 import { getGlobalConfig } from "@tools/test-tools";
 import { resolve } from "node:path";
 
+import { BuiltInLibraryFixtures } from "../../src/nodeAssets/builtInLibraryFixtures";
+
+export const RoundedCubeSourceUrl = "https://assets.babylonjs.com/meshes/roundedCube.glb";
+
 /** Narrows a title lookup to a single node when several share the title: an index, or "last" for the most recently added. */
 type NodeOccurrence = number | "last";
 
@@ -30,6 +34,25 @@ export async function useLocalGltfValidator(page: Page): Promise<void> {
         await route.fulfill({
             path: resolve(__dirname, "../../../babylonServer/public/gltf_validator.js"),
             contentType: "application/javascript",
+            headers: { "access-control-allow-origin": "*" },
+        });
+    });
+}
+
+export async function useLocalRoundedCubeSource(page: Page, options: { readonly status?: number; readonly waitFor?: Promise<void> } = {}): Promise<void> {
+    await page.route("https://assets.babylonjs.com/**", async (route) => {
+        if (route.request().url() !== RoundedCubeSourceUrl) {
+            await route.abort("blockedbyclient");
+            return;
+        }
+        await options.waitFor;
+        if (options.status && options.status >= 400) {
+            await route.fulfill({ status: options.status, body: "Source unavailable" });
+            return;
+        }
+        await route.fulfill({
+            body: Buffer.from(BuiltInLibraryFixtures.gltf),
+            contentType: "model/gltf-binary",
             headers: { "access-control-allow-origin": "*" },
         });
     });

--- a/packages/tools/nodeAssetsEditor/test/playwright/nodeAssetsEditor.test.ts
+++ b/packages/tools/nodeAssetsEditor/test/playwright/nodeAssetsEditor.test.ts
@@ -4,14 +4,19 @@ import { resolve } from "node:path";
 
 import { CreateBuiltInNodeAssetLibraryEntries } from "../../src/nodeAssets/builtInLibraryEntries";
 import { BuiltInLibraryFixtures } from "../../src/nodeAssets/builtInLibraryFixtures";
-import { NodeAssetsEditorPage, useLocalGltfValidator } from "./nae.utils";
+import { NodeAssetsEditorPage, RoundedCubeSourceUrl, useLocalGltfValidator, useLocalRoundedCubeSource } from "./nae.utils";
 
 type GltfJson = {
     readonly accessors?: readonly { readonly count?: number; readonly type?: string }[];
     readonly extensionsUsed?: readonly string[];
     readonly extensionsRequired?: readonly string[];
     readonly nodes?: readonly { readonly name?: string }[];
-    readonly meshes?: readonly { readonly primitives?: readonly { readonly attributes?: { readonly POSITION?: number }; readonly indices?: number }[] }[];
+    readonly meshes?: readonly {
+        readonly primitives?: readonly {
+            readonly attributes?: { readonly POSITION?: number; readonly NORMAL?: number; readonly TANGENT?: number; readonly TEXCOORD_0?: number };
+            readonly indices?: number;
+        }[];
+    }[];
 };
 
 type SavedBlock = {
@@ -318,11 +323,15 @@ async function saveEditorGraph(page: Page): Promise<SavedEditorGraph> {
     return JSON.parse(readFileSync(downloadPath, "utf8")) as SavedEditorGraph;
 }
 
+test.beforeEach(async ({ page }) => {
+    await useLocalGltfValidator(page);
+    await useLocalRoundedCubeSource(page);
+});
+
 test.describe("Node Assets Editor — maintained default pipeline", () => {
     test.describe.configure({ timeout: 180_000 });
-    test.beforeEach(async ({ page }) => await useLocalGltfValidator(page));
 
-    test("opens to the maintained catalog graph and auto-previews without network requests or console errors", async ({ page }) => {
+    test("hydrates only the maintained default source and auto-previews without console errors", async ({ page }) => {
         const pageErrors = collectPageErrors(page);
         const editor = new NodeAssetsEditorPage(page);
         const sourceRequests: string[] = [];
@@ -346,10 +355,30 @@ test.describe("Node Assets Editor — maintained default pipeline", () => {
         await expect(editor.previewCanvas).toBeVisible();
 
         await editor.selectNode("Import glTF");
-        await expect(page.getByRole("textbox").nth(3)).toHaveValue("catalog-triangle.glb");
+        await expect(page.getByRole("textbox").nth(3)).toHaveValue(RoundedCubeSourceUrl);
 
-        expect(sourceRequests).toEqual([]);
+        expect(sourceRequests).toEqual([RoundedCubeSourceUrl]);
+        await editor.openLibraryButton.click();
+        await expect(page.getByRole("dialog", { name: "NodeAsset Library" })).toBeVisible();
+        expect(sourceRequests).toEqual([RoundedCubeSourceUrl]);
         expect(pageErrors).toEqual([]);
+    });
+
+    test("keeps loading visible and surfaces a deterministic default-source failure without building", async ({ page }) => {
+        let releaseResponse: () => void = () => undefined;
+        const responseReleased = new Promise<void>((resolve) => {
+            releaseResponse = resolve;
+        });
+        await page.unroute("https://assets.babylonjs.com/**");
+        await useLocalRoundedCubeSource(page, { status: 503, waitFor: responseReleased });
+        const editor = new NodeAssetsEditorPage(page);
+
+        await editor.goto();
+        await expect(editor.previewBuildingOverlay).toBeVisible();
+        releaseResponse();
+
+        await expect(editor.previewBuildingOverlay).toBeHidden();
+        await expect(editor.previewErrorOverlay).toContainText("503");
     });
 
     test("restores the rendered preview across repeated Validation tab visits", async ({ page }) => {
@@ -416,7 +445,7 @@ test.describe("Node Assets Editor — maintained default pipeline", () => {
         await editor.expectPreviewToHaveRenderedContent();
     });
 
-    test("exports the optimized catalog triangle the preview rendered", async ({ page }) => {
+    test("exports the structurally valid indexed glTF the preview rendered", async ({ page }) => {
         const editor = new NodeAssetsEditorPage(page);
         await editor.goto();
         await editor.waitForNextSuccessfulPreviewBuild();
@@ -429,7 +458,16 @@ test.describe("Node Assets Editor — maintained default pipeline", () => {
         await exportButton.click();
         const exported = await readDownloadedGlb(await downloadPromise);
         const gltf = parseGlbJson(exported);
-        expect((gltf.nodes ?? []).map((node) => node.name)).toContain("Catalog Triangle");
+        expect(gltf.meshes?.[0].primitives?.[0]).toEqual(
+            expect.objectContaining({
+                attributes: expect.objectContaining({
+                    POSITION: expect.any(Number),
+                    NORMAL: expect.any(Number),
+                    TEXCOORD_0: expect.any(Number),
+                }),
+                indices: expect.any(Number),
+            })
+        );
         expect(gltf.extensionsUsed ?? []).not.toContain("KHR_texture_basisu");
         expect(gltf.extensionsUsed ?? []).not.toContain("KHR_draco_mesh_compression");
     });
@@ -483,7 +521,7 @@ test.describe("Node Assets Editor — maintained default pipeline", () => {
         const downloadPromise = page.waitForEvent("download");
         await page.getByRole("button", { name: "Export .glb" }).click();
         const exported = parseGlbJson(await readDownloadedGlb(await downloadPromise));
-        expect((exported.nodes ?? []).map((node) => node.name)).toContain("Catalog Triangle");
+        expect(typeof exported.meshes?.[0].primitives?.[0]?.indices).toBe("number");
     });
 
     test("replaces an occupied input connection when a new wire is dropped on it", async ({ page }) => {
@@ -1088,7 +1126,7 @@ test.describe("Node Assets Editor — Universal glTF aggregates", () => {
         await page.getByRole("textbox").nth(2).blur();
 
         await expect(page.getByText("Source error", { exact: true })).toBeVisible();
-        await expect(page.getByRole("textbox").nth(3)).toHaveValue("catalog-triangle.glb");
+        await expect(page.getByRole("textbox").nth(3)).toHaveValue(RoundedCubeSourceUrl);
         await expect(page.getByRole("textbox").nth(4)).toHaveValue(/404/);
     });
 

--- a/packages/tools/nodeAssetsEditor/test/unit/blockPropertySections.test.ts
+++ b/packages/tools/nodeAssetsEditor/test/unit/blockPropertySections.test.ts
@@ -70,7 +70,7 @@ describe("block property sections (unified descriptor path)", () => {
             const section = FindSection(controller, importNode, "READ GLTF");
 
             expect(section.properties.map((property) => property.label)).toEqual(["URL", "Active source", "Upload glTF\u2026"]);
-            expect(FindProperty(controller, importNode, "Active source", "text").value).toBe("catalog-triangle.glb");
+            expect(FindProperty(controller, importNode, "Active source", "text").value).toBe("https://assets.babylonjs.com/meshes/roundedCube.glb");
             expect(FindProperty(controller, importNode, "Upload glTF\u2026", "button")).toBeDefined();
         } finally {
             controller.dispose();

--- a/packages/tools/nodeAssetsEditor/test/unit/buildOrchestrator.test.ts
+++ b/packages/tools/nodeAssetsEditor/test/unit/buildOrchestrator.test.ts
@@ -159,6 +159,30 @@ describe("BuildOrchestrator", () => {
         orchestrator.dispose();
     });
 
+    it("retries with a debounced build when the graph changes after the default import fails", async () => {
+        vi.spyOn(Logger, "Error").mockImplementation(() => undefined);
+        const { controller, preview, orchestrator } = Setup();
+        controller.loadDefaultImportAsync.mockRejectedValue(new Error("startup failed"));
+        controller.buildAsync.mockResolvedValue(new Uint8Array([1]));
+
+        orchestrator.start();
+        await Flush();
+        expect(controller.buildAsync).not.toHaveBeenCalled();
+        expect(preview.lastStatus).toEqual({ isBuilding: false, errorMessage: "startup failed" });
+
+        controller.onBuildRelevantChanged.trigger();
+        await vi.advanceTimersByTimeAsync(399);
+        expect(controller.buildAsync).not.toHaveBeenCalled();
+
+        await vi.advanceTimersByTimeAsync(1);
+        expect(controller.buildAsync).toHaveBeenCalledTimes(1);
+        expect(preview.lastStatus).toEqual({ isBuilding: true, errorMessage: null });
+
+        await vi.runAllTimersAsync();
+        expect(preview.lastStatus).toEqual({ isBuilding: false, errorMessage: null });
+        orchestrator.dispose();
+    });
+
     it("applies a successful build result to the preview", async () => {
         const { controller, preview, orchestrator } = Setup();
         const bytes = new Uint8Array([1, 2, 3]);

--- a/packages/tools/nodeAssetsEditor/test/unit/buildScheduler.test.ts
+++ b/packages/tools/nodeAssetsEditor/test/unit/buildScheduler.test.ts
@@ -53,6 +53,26 @@ describe("BuildScheduler", () => {
         expect(buildAsync).toHaveBeenCalledTimes(1);
     });
 
+    it("can subscribe without an immediate build and still responds to the next debounced trigger", async () => {
+        const triggerSource = new TestTriggerSource();
+        const buildAsync = vi.fn(async () => "recovered");
+        const scheduler = new BuildScheduler({
+            triggerSource,
+            debounceMs: 400,
+            buildAsync,
+            buildImmediately: false,
+        });
+
+        expect(buildAsync).not.toHaveBeenCalled();
+        triggerSource.trigger();
+        await vi.advanceTimersByTimeAsync(399);
+        expect(buildAsync).not.toHaveBeenCalled();
+
+        await vi.advanceTimersByTimeAsync(1);
+        expect(buildAsync).toHaveBeenCalledTimes(1);
+        scheduler.dispose();
+    });
+
     it("collapses rapid graph changes into one debounced build", async () => {
         const triggerSource = new TestTriggerSource();
         const buildAsync = vi.fn(async () => "built");
@@ -119,6 +139,34 @@ describe("BuildScheduler", () => {
 
         expect(appliedResults).toEqual(["latest"]);
         expect(builtResults).toEqual(["latest"]);
+        scheduler.dispose();
+    });
+
+    it("invalidates an in-flight build immediately when a newer graph change is debouncing", async () => {
+        const triggerSource = new TestTriggerSource();
+        const firstBuild = CreateDeferred<string>();
+        const buildAsync = vi.fn<() => Promise<string>>().mockReturnValueOnce(firstBuild.promise).mockResolvedValueOnce("latest");
+        const appliedResults: string[] = [];
+        const scheduler = new BuildScheduler({
+            triggerSource,
+            debounceMs: 400,
+            buildAsync,
+            applyResultAsync: async (result) => {
+                appliedResults.push(result);
+            },
+        });
+
+        triggerSource.trigger();
+        firstBuild.resolve("superseded");
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(appliedResults).toEqual([]);
+        expect(buildAsync).toHaveBeenCalledTimes(1);
+
+        await vi.advanceTimersByTimeAsync(400);
+        expect(buildAsync).toHaveBeenCalledTimes(2);
+        expect(appliedResults).toEqual(["latest"]);
         scheduler.dispose();
     });
 });

--- a/packages/tools/nodeAssetsEditor/test/unit/builtInLibraryEntries.test.ts
+++ b/packages/tools/nodeAssetsEditor/test/unit/builtInLibraryEntries.test.ts
@@ -7,6 +7,7 @@ import { NodeAsset } from "node-assets/nodeAsset";
 
 import { CreateBuiltInNodeAssetLibraryEntries, GetDefaultBuiltInNodeAssetLibraryEntry } from "../../src/nodeAssets/builtInLibraryEntries";
 import { NodeAssetGraphController } from "../../src/nodeAssets/nodeAssetGraphController";
+import { BuiltInLibraryFixtures } from "../../src/nodeAssets/builtInLibraryFixtures";
 import { type INodeAssetBuildClient } from "../../src/nodeAssets/nodeAssetBuildWorkerClient";
 
 const ExpectedPipelineNames = [
@@ -46,6 +47,9 @@ const ObsoletePipelineNames = ["USD with Custom Textures", "Material Decompositi
 
 type SerializedBlockShape = {
     customType: string;
+    data?: string | null;
+    source?: string | null;
+    sourceKind?: string;
     subgraph?: {
         blocks?: SerializedBlockShape[];
     };
@@ -55,7 +59,7 @@ type GltfJson = {
     asset?: { version?: string };
     extensionsUsed?: string[];
     scenes?: unknown[];
-    meshes?: Array<{ primitives?: Array<{ attributes?: Record<string, number> }> }>;
+    meshes?: Array<{ primitives?: Array<{ attributes?: Record<string, number>; indices?: number }> }>;
 };
 
 function AssertValidGlb(glb: Uint8Array): GltfJson {
@@ -70,6 +74,10 @@ function AssertValidGlb(glb: Uint8Array): GltfJson {
     expect(json.asset?.version).toBe("2.0");
     expect(json.scenes?.length).toBeGreaterThan(0);
     return json;
+}
+
+function CollectBlocks(blocks: SerializedBlockShape[]): SerializedBlockShape[] {
+    return blocks.flatMap((block) => [block, ...(block.subgraph?.blocks ? CollectBlocks(block.subgraph.blocks) : [])]);
 }
 
 function CreateUnusedBuildClient(): INodeAssetBuildClient {
@@ -113,6 +121,27 @@ describe("built-in NodeAsset pipeline catalog", () => {
         }
     });
 
+    it("serializes only the default glTF source as the exact rounded cube URL without embedded bytes", () => {
+        const entries = CreateBuiltInNodeAssetLibraryEntries();
+        const readGltfBlocks = (entryIndex: number) => {
+            const editorFile = JSON.parse(entries[entryIndex].serializedGraph) as { graph: { blocks: SerializedBlockShape[] } };
+            return CollectBlocks(editorFile.graph.blocks).filter((block) => block.customType === "ReadGLTFBlock");
+        };
+
+        expect(readGltfBlocks(0)).toEqual([
+            expect.objectContaining({
+                data: null,
+                source: "https://assets.babylonjs.com/meshes/roundedCube.glb",
+                sourceKind: "url",
+            }),
+        ]);
+        expect(entries.slice(1).flatMap((_, index) => readGltfBlocks(index + 1))).not.toContainEqual(
+            expect.objectContaining({
+                source: "https://assets.babylonjs.com/meshes/roundedCube.glb",
+            })
+        );
+    });
+
     it("round-trips and loads every preview-ready graph without retired block types", () => {
         const controller = new NodeAssetGraphController(CreateUnusedBuildClient());
         try {
@@ -140,8 +169,19 @@ describe("built-in NodeAsset pipeline catalog", () => {
     it("builds every production pipeline to a valid non-empty GLB without network sources", async () => {
         for (const entry of CreateBuiltInNodeAssetLibraryEntries()) {
             const editorFile = JSON.parse(entry.serializedGraph) as { graph: unknown };
-            const result = await NodeAsset.Parse(editorFile.graph).buildAsync();
+            const result = entry.name === "glTF Optimization" ? await BuildDefaultPipelineAsync(entry.serializedGraph) : await NodeAsset.Parse(editorFile.graph).buildAsync();
             const gltf = AssertValidGlb(result);
+            if (entry.name === "glTF Optimization") {
+                const primitive = gltf.meshes?.[0].primitives?.[0];
+                expect(primitive?.indices).toBeTypeOf("number");
+                expect(primitive?.attributes).toEqual(
+                    expect.objectContaining({
+                        POSITION: expect.any(Number),
+                        NORMAL: expect.any(Number),
+                        TEXCOORD_0: expect.any(Number),
+                    })
+                );
+            }
             if (entry.name === "Full Universal Optimization") {
                 expect(gltf.meshes?.[0].primitives?.[0].attributes?.TANGENT).toBeTypeOf("number");
             }
@@ -151,3 +191,25 @@ describe("built-in NodeAsset pipeline catalog", () => {
         }
     }, 180_000);
 });
+
+async function BuildDefaultPipelineAsync(serializedGraph: string): Promise<Uint8Array> {
+    const buildClient: INodeAssetBuildClient = {
+        buildAsync: async (graph) => await NodeAsset.Parse(graph).buildAsync(),
+        dispose: () => undefined,
+    };
+    const controller = new NodeAssetGraphController(buildClient, async (url) => {
+        expect(url).toBe("https://assets.babylonjs.com/meshes/roundedCube.glb");
+        return {
+            ok: true,
+            status: 200,
+            statusText: "OK",
+            arrayBuffer: async () => BuiltInLibraryFixtures.gltf.slice().buffer,
+        };
+    });
+    try {
+        controller.load(serializedGraph);
+        return await controller.buildAsync();
+    } finally {
+        controller.dispose();
+    }
+}

--- a/packages/tools/nodeAssetsEditor/test/unit/importExportFields.test.ts
+++ b/packages/tools/nodeAssetsEditor/test/unit/importExportFields.test.ts
@@ -138,7 +138,7 @@ describe("Import block source label", () => {
         const controller = new NodeAssetGraphController();
         try {
             const importNode = FindNode(controller, "Import glTF");
-            expect(FindPropertyInSection(controller, importNode, "READ GLTF", "Active source", "text").value).toBe("catalog-triangle.glb");
+            expect(FindPropertyInSection(controller, importNode, "READ GLTF", "Active source", "text").value).toBe("https://assets.babylonjs.com/meshes/roundedCube.glb");
 
             vi.mocked(PromptForFileAsync).mockResolvedValue({
                 name: "myModel.glb",
@@ -289,7 +289,9 @@ describe("Import block source label", () => {
             };
             const authoredImport = canceledUpload.graph.blocks.find((block) => block.name === "Import glTF");
             expect(authoredImport?.customType).toBe("ImportGLTFAggregateBlock");
-            expect(authoredImport?.subgraph?.blocks).toContainEqual(expect.objectContaining({ customType: "ReadGLTFBlock", source: "catalog-triangle.glb" }));
+            expect(authoredImport?.subgraph?.blocks).toContainEqual(
+                expect.objectContaining({ customType: "ReadGLTFBlock", source: "https://assets.babylonjs.com/meshes/roundedCube.glb" })
+            );
         } finally {
             controller.dispose();
         }
@@ -310,7 +312,7 @@ describe("Import block source label", () => {
             await vi.waitFor(() => {
                 expect(FindPropertyInSection(controller, importNode, "READ GLTF", "Source error", "text").value).toBe("Could not read unreadable.glb");
             });
-            expect(FindPropertyInSection(controller, importNode, "READ GLTF", "Active source", "text").value).toBe("catalog-triangle.glb");
+            expect(FindPropertyInSection(controller, importNode, "READ GLTF", "Active source", "text").value).toBe("https://assets.babylonjs.com/meshes/roundedCube.glb");
         } finally {
             controller.dispose();
         }

--- a/packages/tools/nodeAssetsEditor/test/unit/nodeAssetGraphController.test.ts
+++ b/packages/tools/nodeAssetsEditor/test/unit/nodeAssetGraphController.test.ts
@@ -6,6 +6,7 @@ import { DracoCompressionBlock } from "node-assets/Blocks/dracoCompressionBlock"
 import { ExportGLTFAggregateBlock } from "node-assets/Blocks/exportGLTFAggregateBlock";
 import { ImportGLTFAggregateBlock } from "node-assets/Blocks/importGLTFAggregateBlock";
 import { KTX2CompressionBlock } from "node-assets/Blocks/ktx2CompressionBlock";
+import { ReadGLTFBlock, type GLTFSourceFetcher } from "node-assets/Blocks/readGLTFBlock";
 import { StringLiteral } from "node-assets/Blocks/stringLiteral";
 
 import { NodeAssetBuildError } from "node-assets/nodeAssetBuildError";
@@ -16,6 +17,7 @@ import { type PropertyDescriptor } from "../../src/nodeGraph/propertyModel";
 import { GetBlockDescriptorByPaletteItemId } from "../../src/nodeAssets/blockCatalog";
 import { NodeIdForBlockId } from "../../src/nodeAssets/blockNodeMapping";
 import { CreateBuiltInNodeAssetLibraryEntries } from "../../src/nodeAssets/builtInLibraryEntries";
+import { BuiltInLibraryFixtures } from "../../src/nodeAssets/builtInLibraryFixtures";
 import { NodeAssetGraphController } from "../../src/nodeAssets/nodeAssetGraphController";
 import { type INodeAssetBuildClient, Ktx2EncoderResourceConflictError } from "../../src/nodeAssets/nodeAssetBuildWorkerClient";
 import { NodeAssetReconciler } from "../../src/nodeAssets/nodeAssetReconciler";
@@ -59,6 +61,24 @@ function CountBuildRelevantChanges(controller: NodeAssetGraphController): { read
     return {
         count: () => count,
         dispose: () => observer.remove(),
+    };
+}
+
+function CreateGltfResponse(data: Uint8Array) {
+    return {
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        arrayBuffer: async () => data.slice().buffer,
+    };
+}
+
+function CreateUnusedBuildClient(): INodeAssetBuildClient {
+    return {
+        buildAsync: async () => {
+            throw new Error("This test must not invoke the build client.");
+        },
+        dispose: vi.fn(),
     };
 }
 
@@ -355,7 +375,7 @@ describe("NodeAssetGraphController", () => {
             dispose: vi.fn(),
         };
         const reconcileSpy = vi.spyOn(NodeAssetReconciler.prototype, "reconcile");
-        const controller = new NodeAssetGraphController(buildClient);
+        const controller = new NodeAssetGraphController(buildClient, async () => CreateGltfResponse(BuiltInLibraryFixtures.gltf));
         reconcileSpy.mockClear();
         try {
             controller.serialize();
@@ -368,6 +388,383 @@ describe("NodeAssetGraphController", () => {
         } finally {
             controller.dispose();
             reconcileSpy.mockRestore();
+        }
+    });
+
+    it("hydrates the active URL-only Read glTF block before worker serialization", async () => {
+        let resolveResponse: (() => void) | undefined;
+        const responseReady = new Promise<void>((resolve) => {
+            resolveResponse = resolve;
+        });
+        const sourceFetcher = vi.fn<GLTFSourceFetcher>(async () => {
+            await responseReady;
+            return CreateGltfResponse(BuiltInLibraryFixtures.gltf);
+        });
+        const buildClient: INodeAssetBuildClient = {
+            buildAsync: vi.fn(async () => new Uint8Array([1, 2, 3])),
+            dispose: vi.fn(),
+        };
+        const controller = new NodeAssetGraphController(buildClient, sourceFetcher);
+        try {
+            const build = controller.buildAsync();
+            await vi.waitFor(() => expect(sourceFetcher).toHaveBeenCalledWith("https://assets.babylonjs.com/meshes/roundedCube.glb"));
+            expect(buildClient.buildAsync).not.toHaveBeenCalled();
+
+            resolveResponse?.();
+            await expect(build).resolves.toEqual(new Uint8Array([1, 2, 3]));
+
+            const serializedGraph = vi.mocked(buildClient.buildAsync).mock.calls[0][0] as {
+                blocks: Array<{ customType: string; data?: string | null; source?: string | null; sourceKind?: string; subgraph?: { blocks: unknown[] } }>;
+            };
+            expect(JSON.stringify(serializedGraph)).toContain(Buffer.from(BuiltInLibraryFixtures.gltf).toString("base64"));
+        } finally {
+            controller.dispose();
+        }
+    });
+
+    it("does not publish a spurious graph change when the first worker build follows startup hydration", async () => {
+        const buildClient: INodeAssetBuildClient = {
+            buildAsync: vi.fn(async () => new Uint8Array([1])),
+            dispose: vi.fn(),
+        };
+        const controller = new NodeAssetGraphController(buildClient, async () => CreateGltfResponse(BuiltInLibraryFixtures.gltf));
+        const changes = CountBuildRelevantChanges(controller);
+        try {
+            await controller.loadDefaultImportAsync();
+            await controller.buildAsync();
+
+            expect(changes.count()).toBe(0);
+            expect(buildClient.buildAsync).toHaveBeenCalledTimes(1);
+        } finally {
+            changes.dispose();
+            controller.dispose();
+        }
+    });
+
+    it("reuses successful URL bytes after reloading the same URL-only graph", async () => {
+        const sourceFetcher = vi.fn<GLTFSourceFetcher>(async () => CreateGltfResponse(BuiltInLibraryFixtures.gltf));
+        const buildClient: INodeAssetBuildClient = {
+            buildAsync: vi.fn(async () => new Uint8Array([1])),
+            dispose: vi.fn(),
+        };
+        const controller = new NodeAssetGraphController(buildClient, sourceFetcher);
+        const defaultGraph = CreateBuiltInNodeAssetLibraryEntries()[0].serializedGraph;
+        try {
+            await controller.buildAsync();
+            controller.load(defaultGraph);
+            await controller.buildAsync();
+
+            expect(sourceFetcher).toHaveBeenCalledTimes(1);
+            expect(buildClient.buildAsync).toHaveBeenCalledTimes(2);
+        } finally {
+            controller.dispose();
+        }
+    });
+
+    it("shares one in-flight request across active Read glTF blocks using the exact same URL", async () => {
+        const defaultGraph = JSON.parse(CreateBuiltInNodeAssetLibraryEntries()[0].serializedGraph) as {
+            graph: { blocks: Array<{ id: number; subgraph: { blocks: Array<{ id: number }> } }> };
+        };
+        const duplicateImport = structuredClone(defaultGraph.graph.blocks[0]);
+        duplicateImport.id = 100;
+        defaultGraph.graph.blocks.push(duplicateImport);
+
+        let resolveData: (() => void) | undefined;
+        const dataReady = new Promise<void>((resolve) => {
+            resolveData = resolve;
+        });
+        const arrayBuffer = vi.fn(async () => {
+            await dataReady;
+            return BuiltInLibraryFixtures.gltf.slice().buffer;
+        });
+        const sourceFetcher = vi.fn<GLTFSourceFetcher>(async () => ({
+            ok: true,
+            status: 200,
+            statusText: "OK",
+            arrayBuffer,
+        }));
+        const controller = new NodeAssetGraphController(CreateUnusedBuildClient(), sourceFetcher);
+        try {
+            controller.load(JSON.stringify(defaultGraph));
+            const hydration = controller.loadDefaultImportAsync();
+            await vi.waitFor(() => expect(arrayBuffer).toHaveBeenCalledTimes(1));
+            expect(sourceFetcher).toHaveBeenCalledTimes(1);
+
+            resolveData?.();
+            await hydration;
+            const serialized = controller.serialize();
+            expect(serialized.match(/"sourceKind": "url"/g)).toHaveLength(2);
+        } finally {
+            controller.dispose();
+        }
+    });
+
+    it("retries a failed URL hydration and dispatches no worker build for the failed attempt", async () => {
+        const sourceFetcher = vi
+            .fn<GLTFSourceFetcher>()
+            .mockResolvedValueOnce({
+                ok: false,
+                status: 503,
+                statusText: "Unavailable",
+                arrayBuffer: async () => new ArrayBuffer(0),
+            })
+            .mockResolvedValueOnce(CreateGltfResponse(BuiltInLibraryFixtures.gltf));
+        const buildClient: INodeAssetBuildClient = {
+            buildAsync: vi.fn(async () => new Uint8Array([1])),
+            dispose: vi.fn(),
+        };
+        const controller = new NodeAssetGraphController(buildClient, sourceFetcher);
+        try {
+            await expect(controller.buildAsync()).rejects.toThrow("503 Unavailable");
+            expect(buildClient.buildAsync).not.toHaveBeenCalled();
+
+            await expect(controller.buildAsync()).resolves.toEqual(new Uint8Array([1]));
+            expect(sourceFetcher).toHaveBeenCalledTimes(2);
+            expect(buildClient.buildAsync).toHaveBeenCalledTimes(1);
+        } finally {
+            controller.dispose();
+        }
+    });
+
+    it("follows a replacement startup graph without applying a stale URL success", async () => {
+        let resolveResponse: ((response: ReturnType<typeof CreateGltfResponse>) => void) | undefined;
+        const response = new Promise<ReturnType<typeof CreateGltfResponse>>((resolve) => {
+            resolveResponse = resolve;
+        });
+        const sourceFetcher = vi.fn<GLTFSourceFetcher>(async () => await response);
+        const controller = new NodeAssetGraphController(CreateUnusedBuildClient(), sourceFetcher);
+        const replacement = CreateBuiltInNodeAssetLibraryEntries()[3].serializedGraph;
+        try {
+            const startup = controller.loadDefaultImportAsync();
+            await vi.waitFor(() => expect(sourceFetcher).toHaveBeenCalledTimes(1));
+            controller.load(replacement);
+
+            resolveResponse?.(CreateGltfResponse(BuiltInLibraryFixtures.gltf));
+            await expect(startup).resolves.toBeUndefined();
+            expect(JSON.parse(controller.serialize())).toEqual(JSON.parse(replacement));
+        } finally {
+            controller.dispose();
+        }
+    });
+
+    it("does not wait for a stale unresolved fetch before hydrating a replacement graph", async () => {
+        let resolveResponse: ((response: ReturnType<typeof CreateGltfResponse>) => void) | undefined;
+        const response = new Promise<ReturnType<typeof CreateGltfResponse>>((resolve) => {
+            resolveResponse = resolve;
+        });
+        const sourceFetcher = vi.fn<GLTFSourceFetcher>(async () => await response);
+        const originalSetUrlAsync = ReadGLTFBlock.prototype.setUrlAsync;
+        let obsoleteBlock: ReadGLTFBlock | undefined;
+        let markStaleHydrationSettled: () => void = () => undefined;
+        const staleHydrationSettled = new Promise<void>((resolve) => {
+            markStaleHydrationSettled = resolve;
+        });
+        const setUrlSpy = vi.spyOn(ReadGLTFBlock.prototype, "setUrlAsync").mockImplementation(async function (this: ReadGLTFBlock, ...args) {
+            obsoleteBlock = this;
+            await originalSetUrlAsync.apply(this, args);
+            markStaleHydrationSettled();
+        });
+        const controller = new NodeAssetGraphController(CreateUnusedBuildClient(), sourceFetcher);
+        const replacement = CreateBuiltInNodeAssetLibraryEntries()[5].serializedGraph;
+        try {
+            let startupResolved = false;
+            const startup = controller.loadDefaultImportAsync().then(() => {
+                startupResolved = true;
+            });
+            await vi.waitFor(() => expect(sourceFetcher).toHaveBeenCalledTimes(1));
+
+            controller.load(replacement);
+            await vi.waitFor(() => expect(startupResolved).toBe(true), { timeout: 100 });
+            expect(sourceFetcher).toHaveBeenCalledTimes(1);
+            expect(JSON.parse(controller.serialize())).toEqual(JSON.parse(replacement));
+
+            resolveResponse?.(CreateGltfResponse(BuiltInLibraryFixtures.gltf));
+            await staleHydrationSettled;
+            expect(obsoleteBlock?.data).toBeNull();
+            await startup;
+        } finally {
+            setUrlSpy.mockRestore();
+            controller.dispose();
+        }
+    });
+
+    it("keeps a fresh reload request active when the obsolete request succeeds", async () => {
+        let resolveFirstResponse: ((response: ReturnType<typeof CreateGltfResponse>) => void) | undefined;
+        const firstResponse = new Promise<ReturnType<typeof CreateGltfResponse>>((resolve) => {
+            resolveFirstResponse = resolve;
+        });
+        let resolveSecondResponse: ((response: ReturnType<typeof CreateGltfResponse>) => void) | undefined;
+        const secondResponse = new Promise<ReturnType<typeof CreateGltfResponse>>((resolve) => {
+            resolveSecondResponse = resolve;
+        });
+        const sourceFetcher = vi
+            .fn<GLTFSourceFetcher>()
+            .mockImplementationOnce(async () => await firstResponse)
+            .mockImplementationOnce(async () => await secondResponse);
+        const buildClient: INodeAssetBuildClient = {
+            buildAsync: vi.fn(async () => new Uint8Array([1])),
+            dispose: vi.fn(),
+        };
+        const controller = new NodeAssetGraphController(buildClient, sourceFetcher);
+        const entries = CreateBuiltInNodeAssetLibraryEntries();
+        const defaultGraph = entries[0].serializedGraph;
+        const embeddedGraph = entries[5].serializedGraph;
+        const obsoleteBase64 = Buffer.from(BuiltInLibraryFixtures.unweldedGltf).toString("base64");
+        const activeBase64 = Buffer.from(BuiltInLibraryFixtures.gltf).toString("base64");
+        let pendingBuild: Promise<Uint8Array> | undefined;
+        let pendingHydration: Promise<void> | undefined;
+        let pendingHydrationResolved = false;
+        try {
+            const startup = controller.loadDefaultImportAsync();
+            await vi.waitFor(() => expect(sourceFetcher).toHaveBeenCalledTimes(1));
+            controller.load(embeddedGraph);
+            await expect(startup).resolves.toBeUndefined();
+
+            controller.load(defaultGraph);
+            pendingBuild = controller.buildAsync();
+            await vi.waitFor(() => expect(sourceFetcher).toHaveBeenCalledTimes(2), { timeout: 100 });
+
+            resolveFirstResponse?.(CreateGltfResponse(BuiltInLibraryFixtures.unweldedGltf));
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            pendingHydration = (async () => {
+                await controller.loadDefaultImportAsync();
+                pendingHydrationResolved = true;
+            })();
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            expect(sourceFetcher).toHaveBeenCalledTimes(2);
+            expect(pendingHydrationResolved).toBe(false);
+
+            resolveSecondResponse?.(CreateGltfResponse(BuiltInLibraryFixtures.gltf));
+            await expect(pendingBuild).resolves.toEqual(new Uint8Array([1]));
+            await expect(pendingHydration).resolves.toBeUndefined();
+            expect(pendingHydrationResolved).toBe(true);
+            expect(controller.serialize()).toContain(activeBase64);
+            expect(controller.serialize()).not.toContain(obsoleteBase64);
+
+            controller.load(defaultGraph);
+            await expect(controller.buildAsync()).resolves.toEqual(new Uint8Array([1]));
+            expect(sourceFetcher).toHaveBeenCalledTimes(2);
+            const reloadedBuild = JSON.stringify(vi.mocked(buildClient.buildAsync).mock.calls[1][0]);
+            expect(reloadedBuild).toContain(activeBase64);
+            expect(reloadedBuild).not.toContain(obsoleteBase64);
+        } finally {
+            resolveFirstResponse?.(CreateGltfResponse(BuiltInLibraryFixtures.unweldedGltf));
+            resolveSecondResponse?.(CreateGltfResponse(BuiltInLibraryFixtures.gltf));
+            controller.dispose();
+            await Promise.allSettled([pendingBuild, pendingHydration].filter((promise): promise is Promise<Uint8Array> | Promise<void> => promise !== undefined));
+        }
+    });
+
+    it("keeps a fresh reload request active when the obsolete request fails", async () => {
+        type SourceResponse = Awaited<ReturnType<GLTFSourceFetcher>>;
+
+        let resolveFirstResponse: ((response: SourceResponse) => void) | undefined;
+        const firstResponse = new Promise<SourceResponse>((resolve) => {
+            resolveFirstResponse = resolve;
+        });
+        let resolveSecondResponse: ((response: SourceResponse) => void) | undefined;
+        const secondResponse = new Promise<SourceResponse>((resolve) => {
+            resolveSecondResponse = resolve;
+        });
+        const sourceFetcher = vi
+            .fn<GLTFSourceFetcher>(async () => CreateGltfResponse(BuiltInLibraryFixtures.unweldedGltf))
+            .mockImplementationOnce(async () => await firstResponse)
+            .mockImplementationOnce(async () => await secondResponse);
+        const buildClient: INodeAssetBuildClient = {
+            buildAsync: vi.fn(async () => new Uint8Array([1])),
+            dispose: vi.fn(),
+        };
+        const controller = new NodeAssetGraphController(buildClient, sourceFetcher);
+        const entries = CreateBuiltInNodeAssetLibraryEntries();
+        const defaultGraph = entries[0].serializedGraph;
+        const embeddedGraph = entries[5].serializedGraph;
+        const activeBase64 = Buffer.from(BuiltInLibraryFixtures.gltf).toString("base64");
+        let pendingBuild: Promise<Uint8Array> | undefined;
+        let pendingHydration: Promise<void> | undefined;
+        try {
+            const startup = controller.loadDefaultImportAsync();
+            await vi.waitFor(() => expect(sourceFetcher).toHaveBeenCalledTimes(1));
+            controller.load(embeddedGraph);
+            await expect(startup).resolves.toBeUndefined();
+
+            controller.load(defaultGraph);
+            pendingBuild = controller.buildAsync();
+            await vi.waitFor(() => expect(sourceFetcher).toHaveBeenCalledTimes(2));
+
+            resolveFirstResponse?.({
+                ok: false,
+                status: 503,
+                statusText: "Obsolete",
+                arrayBuffer: async () => new ArrayBuffer(0),
+            });
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            pendingHydration = controller.loadDefaultImportAsync();
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            expect(sourceFetcher).toHaveBeenCalledTimes(2);
+
+            resolveSecondResponse?.(CreateGltfResponse(BuiltInLibraryFixtures.gltf));
+            await expect(pendingBuild).resolves.toEqual(new Uint8Array([1]));
+            await expect(pendingHydration).resolves.toBeUndefined();
+            expect(controller.serialize()).toContain(activeBase64);
+
+            controller.load(defaultGraph);
+            await expect(controller.buildAsync()).resolves.toEqual(new Uint8Array([1]));
+            expect(sourceFetcher).toHaveBeenCalledTimes(2);
+        } finally {
+            resolveFirstResponse?.(CreateGltfResponse(BuiltInLibraryFixtures.unweldedGltf));
+            resolveSecondResponse?.(CreateGltfResponse(BuiltInLibraryFixtures.gltf));
+            controller.dispose();
+            await Promise.allSettled([pendingBuild, pendingHydration].filter((promise): promise is Promise<Uint8Array> | Promise<void> => promise !== undefined));
+        }
+    });
+
+    it("follows a replacement startup graph without surfacing a stale URL failure", async () => {
+        let resolveResponse: ((response: Awaited<ReturnType<GLTFSourceFetcher>>) => void) | undefined;
+        const response = new Promise<Awaited<ReturnType<GLTFSourceFetcher>>>((resolve) => {
+            resolveResponse = resolve;
+        });
+        const sourceFetcher = vi.fn<GLTFSourceFetcher>(async () => await response);
+        const controller = new NodeAssetGraphController(CreateUnusedBuildClient(), sourceFetcher);
+        const replacement = CreateBuiltInNodeAssetLibraryEntries()[3].serializedGraph;
+        try {
+            const startup = controller.loadDefaultImportAsync();
+            await vi.waitFor(() => expect(sourceFetcher).toHaveBeenCalledTimes(1));
+            controller.load(replacement);
+
+            resolveResponse?.({
+                ok: false,
+                status: 503,
+                statusText: "Unavailable",
+                arrayBuffer: async () => new ArrayBuffer(0),
+            });
+            await expect(startup).resolves.toBeUndefined();
+            expect(JSON.parse(controller.serialize())).toEqual(JSON.parse(replacement));
+        } finally {
+            controller.dispose();
+        }
+    });
+
+    it("does not serialize a graph superseded during hydration", async () => {
+        let resolveResponse: ((response: ReturnType<typeof CreateGltfResponse>) => void) | undefined;
+        const response = new Promise<ReturnType<typeof CreateGltfResponse>>((resolve) => {
+            resolveResponse = resolve;
+        });
+        const sourceFetcher = vi.fn<GLTFSourceFetcher>(async () => await response);
+        const buildClient: INodeAssetBuildClient = {
+            buildAsync: vi.fn(async () => new Uint8Array([1])),
+            dispose: vi.fn(),
+        };
+        const controller = new NodeAssetGraphController(buildClient, sourceFetcher);
+        try {
+            const build = controller.buildAsync();
+            await vi.waitFor(() => expect(sourceFetcher).toHaveBeenCalledTimes(1));
+            controller.load(CreateBuiltInNodeAssetLibraryEntries()[3].serializedGraph);
+            resolveResponse?.(CreateGltfResponse(BuiltInLibraryFixtures.gltf));
+
+            await expect(build).rejects.toThrow("graph changed");
+            expect(buildClient.buildAsync).not.toHaveBeenCalled();
+        } finally {
+            controller.dispose();
         }
     });
 


### PR DESCRIPTION
## Summary

- serialize the default glTF Optimization source as the exact rounded-cube CDN URL with no embedded bytes
- hydrate only active URL-backed Read glTF blocks before worker serialization, with exact-URL caching and stale graph/read ownership guards
- preserve startup failure UX and later recovery while hardening latest-wins scheduling
- add deterministic generated-GLB unit and Playwright coverage with zero live CDN requests

## Validation

- focused Vitest: 122 passed
- Node Assets Editor Playwright: 40 passed
- Node Assets Editor production build: passed
- focused Prettier, ESLint, and `git diff --check`: passed
- broad Node Assets Editor TypeScript check remains at the existing 558-error repository baseline, with no changed production-source diagnostics

## Network and scope

- automated tests intercept the exact URL before navigation and abort unexpected Babylon asset-CDN requests
- no binary assets, dependencies, test configuration, third-party URLs, or issue 02 format mappings were added
- separate direct CDN evidence confirms HTTP 200, no redirect, `model/gltf-binary`, 13,624 bytes, and `Access-Control-Allow-Origin: *`
