### PR TITLE
test(nae): cover OBJ URL and palette regressions

### DIFF
--- a/packages/dev/node-assets/test/unit/objUniversalFunnel.test.ts
+++ b/packages/dev/node-assets/test/unit/objUniversalFunnel.test.ts
@@ -49,7 +49,10 @@ async function GetAssetFactsAsync(glb: Uint8Array): Promise<{ readonly sceneCoun
     };
 }
 
-function CreatePrimitivePipeline(bytes = OBJFixture, fileName = "fixture.OBJ"): {
+function CreatePrimitivePipeline(
+    bytes = OBJFixture,
+    fileName = "fixture.OBJ"
+): {
     readonly asset: NodeAsset;
     readonly read: ReadOBJBlock;
     readonly transcoder: OBJToUniversalBlock;
@@ -96,11 +99,18 @@ describe("OBJ Universal funnel", () => {
         expect(IsOBJSourceAsset(read.output.value)).toBe(true);
     });
 
+    it("accepts an extensionless direct URL identified as OBJ by its query", () => {
+        const source = "https://example.com/assets/model?format=obj";
+        const asset = new OBJSourceAsset({ path: source, bytes: OBJFixture }, source, "url", []);
+
+        expect(asset.primary.path).toBe(source);
+        expect(asset.source).toBe(source);
+        expect(asset.sourceKind).toBe("url");
+    });
+
     it("rejects incoherent direct OBJ source payloads", () => {
         expect(() => new OBJSourceAsset({ path: "fixture.obj", bytes: OBJFixture }, "different.obj", "upload", [])).toThrow(/source identity must match the primary path/);
-        expect(() => new OBJSourceAsset({ path: "fixture.txt", bytes: OBJFixture }, "fixture.txt", "upload", [])).toThrow(
-            /uploaded OBJ primary path must end in \.obj/
-        );
+        expect(() => new OBJSourceAsset({ path: "fixture.txt", bytes: OBJFixture }, "fixture.txt", "upload", [])).toThrow(/uploaded OBJ primary path must end in \.obj/);
         expect(() => new OBJSourceAsset({ path: "fixture.OBJ", bytes: OBJFixture }, "fixture.OBJ", "upload", [])).not.toThrow();
     });
 

--- a/packages/tools/nodeAssetsEditor/test/playwright/nodeAssetsEditor.test.ts
+++ b/packages/tools/nodeAssetsEditor/test/playwright/nodeAssetsEditor.test.ts
@@ -582,6 +582,7 @@ test.describe("Node Assets Editor — maintained default pipeline", () => {
         const exportNode = editor.nodeByTitle("Export glTF");
         const defaultItems = [
             "Import glTF",
+            "Import OBJ",
             "Import USD",
             "Import Babylon",
             "Import Node Geometry",
@@ -609,7 +610,7 @@ test.describe("Node Assets Editor — maintained default pipeline", () => {
 
         await expect(showPrimitives).not.toBeChecked();
         await expect(nodeGeometryCategory).toHaveCount(0);
-        await expect(categories).toHaveText(["Inputs (4)", "Universal (17)", "glTF (3)"]);
+        await expect(categories).toHaveText(["Inputs (5)", "Universal (17)", "glTF (3)"]);
         await expect(families).toHaveText(["Aggregate imports", "Cleanup", "Reduction", "Structure", "Attributes", "Textures", "Encoding/output"]);
         await expect(items).toHaveText(defaultItems);
         await search.fill("Write glTF");
@@ -621,23 +622,25 @@ test.describe("Node Assets Editor — maintained default pipeline", () => {
         await showPrimitives.check();
         await expect(items).toHaveText(["Write glTF"]);
         await search.clear();
-        await expect(categories).toHaveText(["Inputs (8)", "Universal (22)", "glTF (5)", "USD (1)", "Babylon (1)", "Node Geometry (1)"]);
+        await expect(categories).toHaveText(["Inputs (10)", "Universal (22)", "glTF (5)", "OBJ (1)", "USD (1)", "Babylon (1)", "Node Geometry (1)"]);
         await expect(families).toHaveText(["Aggregate imports", "Cleanup", "Reduction", "Structure", "Attributes", "Textures", "Encoding/output"]);
         await expect(items).toHaveText([
-            ...defaultItems.slice(0, 4),
+            ...defaultItems.slice(0, 5),
             "Read glTF",
+            "Read OBJ",
             "Read USD",
             "Read Babylon",
             "Read Node Geometry",
-            ...defaultItems.slice(4, 21),
+            ...defaultItems.slice(5, 22),
             "Universal → glTF",
             "Deduplicate Materials",
             "Deduplicate Textures",
             "Reuse Identical Meshes",
             "Deduplicate Data",
-            ...defaultItems.slice(21),
+            ...defaultItems.slice(22),
             "glTF → Universal",
             "Write glTF",
+            "OBJ to Universal",
             "USD → Universal",
             "Babylon → Universal",
             "Node Geometry → Universal",
@@ -651,7 +654,7 @@ test.describe("Node Assets Editor — maintained default pipeline", () => {
         await showPrimitives.uncheck();
         await expect(nodeGeometryCategory).toHaveCount(0);
         await expect(page.getByTitle("Read Babylon", { exact: true })).toHaveCount(0);
-        await expect(categories).toHaveText(["Inputs (4)", "Universal (17)", "glTF (3)"]);
+        await expect(categories).toHaveText(["Inputs (5)", "Universal (17)", "glTF (3)"]);
         await expect(items).toHaveText(defaultItems);
         await expect(editor.nodeByTitle("Read Babylon")).toBeVisible();
         await expect(editor.nodeByTitle("Write glTF")).toBeVisible();
@@ -659,7 +662,7 @@ test.describe("Node Assets Editor — maintained default pipeline", () => {
         await showPrimitives.check();
         await page.reload({ waitUntil: "load" });
         await expect(showPrimitives).toBeChecked();
-        await expect(categories).toHaveText(["Inputs (8)", "Universal (22)", "glTF (5)", "USD (1)", "Babylon (1)", "Node Geometry (1)"]);
+        await expect(categories).toHaveText(["Inputs (10)", "Universal (22)", "glTF (5)", "OBJ (1)", "USD (1)", "Babylon (1)", "Node Geometry (1)"]);
     });
 
     test("extends node selection with the platform multi-select modifier", async ({ page }) => {


### PR DESCRIPTION
## Summary

- cover direct OBJ URL construction when the pathname is extensionless and the query identifies the format
- update the Node Assets Editor palette scenario for the rendered OBJ aggregate and primitive catalog entries

## Testing

- `npx vitest run --project=unit packages/dev/node-assets/test/unit/objUniversalFunnel.test.ts`
- `NAE_BASE_URL=http://127.0.0.1:1359/ npx playwright test --config ./playwright.config.ts --project=nodeAssetsEditor packages/tools/nodeAssetsEditor/test/playwright/nodeAssetsEditor.test.ts -g "persists Show primitives without changing canvas or expanded aggregate nodes"`
- `npx prettier --check packages/dev/node-assets/test/unit/objUniversalFunnel.test.ts packages/tools/nodeAssetsEditor/test/playwright/nodeAssetsEditor.test.ts`
- `npx eslint packages/dev/node-assets/test/unit/objUniversalFunnel.test.ts packages/tools/nodeAssetsEditor/test/playwright/nodeAssetsEditor.test.ts`
- `git diff --check`
