### PR TITLE
Fix OBJ host-root URL resolution

### DIFF
--- a/packages/dev/node-assets/src/Blocks/objToUniversalBlock.ts
+++ b/packages/dev/node-assets/src/Blocks/objToUniversalBlock.ts
@@ -14,6 +14,17 @@ import { type NodeAsset } from "../nodeAsset";
 import { GltfAsset } from "../representations/gltfAsset";
 import { IsOBJSourceAsset } from "../representations/objSourceAsset";
 
+function GetOBJRootUrl(source: string): string {
+    try {
+        return new URL(".", source).href;
+    } catch (error) {
+        if (error instanceof TypeError) {
+            return Tools.GetFolderPath(source);
+        }
+        throw error;
+    }
+}
+
 /** Parses an OBJ source payload and explicitly crosses into Universal. */
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export class OBJToUniversalBlock extends NodeAssetBlock {
@@ -47,7 +58,7 @@ export class OBJToUniversalBlock extends NodeAssetBlock {
         let scene: Scene | undefined;
         try {
             scene = new Scene(engine);
-            const rootUrl = source.sourceKind === "url" ? Tools.GetFolderPath(source.source) : "";
+            const rootUrl = source.sourceKind === "url" ? GetOBJRootUrl(source.source) : "";
             const obj = new TextDecoder().decode(primary.bytes);
             const container = await LoadAssetContainerAsync(`data:${obj}`, scene, { pluginExtension: ".obj", rootUrl });
             container.addAllToScene();

--- a/packages/dev/node-assets/test/unit/objUniversalFunnel.test.ts
+++ b/packages/dev/node-assets/test/unit/objUniversalFunnel.test.ts
@@ -171,6 +171,30 @@ describe("OBJ Universal funnel", () => {
         }
     });
 
+    it("builds a host-root query OBJ URL and resolves its MTL without dropping the host", async () => {
+        const source = "https://example.com?format=obj";
+        const materialUrl = "https://example.com/model.mtl";
+        const loadFile = vi.spyOn(Tools, "LoadFile").mockImplementation((url, onSuccess, _onProgress, _offlineProvider, _useArrayBuffer, onError) => {
+            if (url === materialUrl) {
+                onSuccess(MTLFixture);
+            } else {
+                onError?.(undefined, new Error(`Unexpected MTL URL: ${url}`));
+            }
+            return { abort: () => undefined, onCompleteObservable: new Observable() };
+        });
+        try {
+            const { asset, fetcher } = await CreateUrlPipelineAsync(source, OBJWithMaterialFixture);
+            const result = await asset.buildAsync();
+
+            expect(fetcher).toHaveBeenCalledExactlyOnceWith(source);
+            expect(loadFile).toHaveBeenCalledExactlyOnceWith(materialUrl, expect.any(Function), undefined, undefined, false, expect.any(Function));
+            expect(result.byteLength).toBeGreaterThan(0);
+            expect(await GetAssetFactsAsync(result)).toMatchObject({ meshCount: 1, primitiveCount: 1 });
+        } finally {
+            loadFile.mockRestore();
+        }
+    });
+
     it("rejects incoherent direct OBJ source payloads", () => {
         expect(() => new OBJSourceAsset({ path: "fixture.obj", bytes: OBJFixture }, "different.obj", "upload", [])).toThrow(/source identity must match the primary path/);
         expect(() => new OBJSourceAsset({ path: "fixture.txt", bytes: OBJFixture }, "fixture.txt", "upload", [])).toThrow(/uploaded OBJ primary path must end in \.obj/);


### PR DESCRIPTION
## Summary

- resolve absolute OBJ source directories with URL semantics so host-root query URLs keep their host
- preserve path-based fallback resolution for relative/non-URL source strings and empty roots for uploads
- add production-boundary coverage through the full OBJ-to-GLB build path

## Validation

- host-root OBJ regression: 1 passed
- OBJ Universal funnel: 15 passed
- node-assets unit suite: 690 passed
- changed-file Prettier and ESLint
- node-assets and repository TypeScript source builds
- repository format and lint checks
