### PR TITLE
fix(nae): close remaining pan ownership escapes

### DIFF
--- a/packages/dev/sharedUiComponents/src/fluent/primitives/contextMenu.tsx
+++ b/packages/dev/sharedUiComponents/src/fluent/primitives/contextMenu.tsx
@@ -1,4 +1,4 @@
-import { type ReactElement, type ReactNode, forwardRef, useState } from "react";
+import { type ReactElement, type ReactNode, forwardRef, useEffect, useState } from "react";
 import {
     Menu,
     MenuTrigger,
@@ -185,12 +185,22 @@ export const ContextMenu = forwardRef<HTMLButtonElement, ContextMenuProps>((prop
     const classes = useStyles();
 
     const handleOpenChange = (_: unknown, data: { open: boolean }) => {
+        if (disabled && data.open) {
+            return;
+        }
         setOpen(data.open);
         onOpenChange?.(data.open);
     };
 
+    useEffect(() => {
+        if (disabled && open) {
+            setOpen(false);
+            onOpenChange?.(false);
+        }
+    }, [disabled, open, onOpenChange]);
+
     return (
-        <Menu openOnContext open={open} onOpenChange={handleOpenChange}>
+        <Menu openOnContext open={disabled ? false : open} onOpenChange={handleOpenChange}>
             <MenuTrigger disableButtonEnhancement>
                 {props.trigger ?? (
                     <Button

--- a/packages/dev/sharedUiComponents/test/unit/fluent/contextMenu.test.tsx
+++ b/packages/dev/sharedUiComponents/test/unit/fluent/contextMenu.test.tsx
@@ -1,0 +1,64 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { describe, expect, it, vi } from "vitest";
+
+import { ContextMenu } from "../../../src/fluent/primitives/contextMenu";
+
+describe("ContextMenu", () => {
+    it("closes an open custom-trigger menu and suppresses reopening when disabled", async () => {
+        Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true, NodeFilter: window.NodeFilter });
+        const container = document.createElement("div");
+        document.body.appendChild(container);
+        const root = createRoot(container);
+        const onClick = vi.fn();
+        const render = (disabled: boolean) => (
+            <ContextMenu disabled={disabled} items={[{ key: "action", label: "Action", onClick }]} trigger={<div data-testid="custom-context-trigger">Trigger</div>} />
+        );
+
+        await act(async () => {
+            root.render(render(false));
+        });
+        const trigger = container.querySelector('[data-testid="custom-context-trigger"]');
+        if (!trigger) {
+            throw new Error("The custom context-menu trigger did not render.");
+        }
+
+        await act(async () => {
+            trigger.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true }));
+        });
+        expect(document.body.querySelector('[role="menu"]')).not.toBeNull();
+
+        await act(async () => {
+            root.render(render(true));
+        });
+        expect(document.body.querySelector('[role="menu"]')).toBeNull();
+
+        await act(async () => {
+            trigger.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true }));
+        });
+        expect(document.body.querySelector('[role="menu"]')).toBeNull();
+        expect(onClick).not.toHaveBeenCalled();
+
+        await act(async () => {
+            root.render(render(false));
+        });
+        await act(async () => {
+            trigger.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true }));
+        });
+        const menuItem = document.body.querySelector('[role="menuitem"]');
+        if (!menuItem) {
+            throw new Error("The custom context-menu action did not render after re-enabling.");
+        }
+        await act(async () => {
+            menuItem.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+        });
+        expect(onClick).toHaveBeenCalledOnce();
+
+        await act(async () => {
+            root.unmount();
+        });
+        container.remove();
+    });
+});

--- a/packages/tools/nodeAssetsEditor/src/nodeGraph/components/GraphCanvas.tsx
+++ b/packages/tools/nodeAssetsEditor/src/nodeGraph/components/GraphCanvas.tsx
@@ -2,6 +2,7 @@ import {
     type CSSProperties,
     type DragEvent as ReactDragEvent,
     type FunctionComponent,
+    type MouseEvent as ReactMouseEvent,
     type PointerEvent as ReactPointerEvent,
     useCallback,
     useEffect,
@@ -46,6 +47,11 @@ const GridSpacing = 24;
 const PasteOffset = 24;
 // Screen-space radius (px) within which a released wire snaps to the nearest compatible port.
 const ConnectSnapRadius = 28;
+
+type ActiveGestureOwner = {
+    readonly kind: Exclude<Gesture["kind"], "none">;
+    readonly pointerId: number;
+};
 
 const useStyles = makeStyles({
     root: {
@@ -104,8 +110,10 @@ export const GraphCanvas: FunctionComponent<{ context: EditorContextValue }> = (
     const [size, setSize] = useState({ width: 0, height: 0 });
     const [pendingWire, setPendingWire] = useState<PendingWire | null>(null);
     const [marquee, setMarquee] = useState<MarqueeRect | null>(null);
-    const [isPanning, setIsPanning] = useState(false);
+    const [activeGestureOwner, setActiveGestureOwner] = useState<ActiveGestureOwner | null>(null);
     const [contextTarget, setContextTarget] = useState<ContextMenuTarget>({ kind: "canvas" });
+    const isGestureActive = activeGestureOwner !== null;
+    const isPanning = activeGestureOwner?.kind === "pan";
 
     const setCamera = useCallback((next: Camera | ((current: Camera) => Camera)) => {
         const value = typeof next === "function" ? (next as (current: Camera) => Camera)(cameraRef.current) : next;
@@ -225,11 +233,12 @@ export const GraphCanvas: FunctionComponent<{ context: EditorContextValue }> = (
 
     const applyGestureResult = useCallback(
         (result: GestureResult) => {
-            const wasPanning = gestureRef.current.kind === "pan";
-            const willPan = result.gesture.kind === "pan";
+            const current = gestureRef.current;
+            const ownerChanged =
+                current.kind !== result.gesture.kind || (current.kind !== "none" && result.gesture.kind !== "none" && current.pointerId !== result.gesture.pointerId);
             gestureRef.current = result.gesture;
-            if (wasPanning !== willPan) {
-                setIsPanning(willPan);
+            if (ownerChanged) {
+                setActiveGestureOwner(result.gesture.kind === "none" ? null : { kind: result.gesture.kind, pointerId: result.gesture.pointerId });
             }
             executeActions(result.actions);
         },
@@ -275,7 +284,13 @@ export const GraphCanvas: FunctionComponent<{ context: EditorContextValue }> = (
         [applyGestureResult, releasePointer]
     );
 
-    const canHandleIndependentPointerAction = useCallback(() => gestureRef.current.kind === "none", []);
+    const runWhenIdle = useCallback((action: () => void): boolean => {
+        if (gestureRef.current.kind !== "none") {
+            return false;
+        }
+        action();
+        return true;
+    }, []);
 
     // Persistent window listeners drive the active gesture so dragging continues outside the canvas.
     useEffect(() => {
@@ -448,25 +463,52 @@ export const GraphCanvas: FunctionComponent<{ context: EditorContextValue }> = (
                 startGesture(event, BeginPortGesture({ pointerId: event.pointerId, portId, anchor, world: screenToWorld(event.clientX, event.clientY) }));
             },
             selectWire: (wireId) => {
-                if (!canHandleIndependentPointerAction()) {
-                    return;
-                }
-                state.selectWire(wireId);
+                runWhenIdle(() => state.selectWire(wireId));
             },
-            openContextMenu: (target) => {
-                if (!canHandleIndependentPointerAction()) {
-                    return;
+            openContextMenu: (target, event) => {
+                const handled = runWhenIdle(() => {
+                    if (target.kind === "node" && !state.isNodeSelected(target.nodeId)) {
+                        state.selectNodes([target.nodeId]);
+                    }
+                    setContextTarget(target);
+                });
+                if (!handled) {
+                    event.preventDefault();
+                    event.stopPropagation();
                 }
-                if (target.kind === "node" && !state.isNodeSelected(target.nodeId)) {
-                    state.selectNodes([target.nodeId]);
-                }
-                setContextTarget(target);
             },
+            runWhenIdle,
         }),
-        [context, state, screenToWorld, startGesture, canHandleIndependentPointerAction]
+        [context, state, screenToWorld, startGesture, runWhenIdle]
     );
 
+    const onPointerDownCapture = (event: ReactPointerEvent<HTMLDivElement>) => {
+        const current = gestureRef.current;
+        if (current.kind !== "none" && current.pointerId !== event.pointerId) {
+            event.preventDefault();
+            event.stopPropagation();
+        }
+    };
+
+    const onClickCapture = (event: ReactMouseEvent<HTMLDivElement>) => {
+        if (gestureRef.current.kind !== "none") {
+            event.preventDefault();
+            event.stopPropagation();
+        }
+    };
+
+    const onContextMenuCapture = (event: ReactMouseEvent<HTMLDivElement>) => {
+        const handled = runWhenIdle(() => setContextTarget({ kind: "canvas" }));
+        if (!handled) {
+            event.preventDefault();
+            event.stopPropagation();
+        }
+    };
+
     const onBackgroundPointerDown = (event: ReactPointerEvent<HTMLDivElement>) => {
+        if (!event.nativeEvent.composedPath().includes(event.currentTarget)) {
+            return;
+        }
         // A child view (node/port/frame) already claimed this gesture.
         if (gestureRef.current.kind !== "none") {
             return;
@@ -510,27 +552,35 @@ export const GraphCanvas: FunctionComponent<{ context: EditorContextValue }> = (
     const contextItems = useMemo<ContextMenuItem[]>(() => {
         if (contextTarget.kind === "wire") {
             const wireId = contextTarget.wireId;
-            return [{ key: "delete-wire", label: "Delete wire", onClick: () => state.removeWire(wireId) }];
+            return [{ key: "delete-wire", label: "Delete wire", onClick: () => runWhenIdle(() => state.removeWire(wireId)) }];
         }
         if (contextTarget.kind === "node") {
             const primary = state.primarySelectedNode;
             return [
-                { key: "copy", label: "Copy", onClick: () => (clipboardRef.current = state.copyNodes([...state.selectedNodeIds])) },
+                {
+                    key: "copy",
+                    label: "Copy",
+                    onClick: () =>
+                        runWhenIdle(() => {
+                            clipboardRef.current = state.copyNodes([...state.selectedNodeIds]);
+                        }),
+                },
                 {
                     key: "cut",
                     label: "Cut",
-                    onClick: () => {
-                        clipboardRef.current = state.copyNodes([...state.selectedNodeIds]);
-                        state.removeNodes([...state.selectedNodeIds]);
-                    },
+                    onClick: () =>
+                        runWhenIdle(() => {
+                            clipboardRef.current = state.copyNodes([...state.selectedNodeIds]);
+                            state.removeNodes([...state.selectedNodeIds]);
+                        }),
                 },
-                { key: "delete", label: "Delete", onClick: () => state.removeNodes([...state.selectedNodeIds]) },
+                { key: "delete", label: "Delete", onClick: () => runWhenIdle(() => state.removeNodes([...state.selectedNodeIds])) },
                 { key: "divider-1", type: "divider" },
                 {
                     key: "collapse",
                     label: primary?.collapsed ? "Expand" : "Collapse",
                     disabled: !primary,
-                    onClick: () => primary && state.setNodeCollapsed(primary.id, !primary.collapsed),
+                    onClick: () => runWhenIdle(() => primary && state.setNodeCollapsed(primary.id, !primary.collapsed)),
                 },
             ];
         }
@@ -539,11 +589,11 @@ export const GraphCanvas: FunctionComponent<{ context: EditorContextValue }> = (
                 key: "paste",
                 label: "Paste",
                 disabled: !clipboardRef.current,
-                onClick: () => clipboardRef.current && state.pasteNodes(clipboardRef.current, { x: PasteOffset, y: PasteOffset }),
+                onClick: () => runWhenIdle(() => clipboardRef.current && state.pasteNodes(clipboardRef.current, { x: PasteOffset, y: PasteOffset })),
             },
-            { key: "fit", label: "Zoom to fit", onClick: () => fitRef.current() },
+            { key: "fit", label: "Zoom to fit", onClick: () => runWhenIdle(() => fitRef.current()) },
         ];
-    }, [contextTarget, state]);
+    }, [contextTarget, state, runWhenIdle]);
 
     const worldStyle: CSSProperties = { transform: `translate(${camera.x}px, ${camera.y}px) scale(${camera.zoom})` };
     // The grid is locked to world space: both the dot spacing and the dot radius scale with zoom, so the
@@ -568,16 +618,20 @@ export const GraphCanvas: FunctionComponent<{ context: EditorContextValue }> = (
             role="application"
             aria-label="Node graph canvas"
             data-panning={isPanning ? "true" : undefined}
+            onPointerDownCapture={onPointerDownCapture}
             onPointerDown={onBackgroundPointerDown}
+            onClickCapture={onClickCapture}
+            onContextMenuCapture={onContextMenuCapture}
             onLostPointerCapture={(event) => cancelGesture(event.pointerId, false)}
             onDragOver={onDragOver}
             onDrop={onDrop}
         >
             <CanvasContextProvider value={canvasContextValue}>
                 <ContextMenu
+                    disabled={isGestureActive}
                     items={contextItems}
                     trigger={
-                        <div className={classes.trigger} onContextMenuCapture={() => setContextTarget({ kind: "canvas" })}>
+                        <div className={classes.trigger}>
                             <div className={classes.world} style={worldStyle}>
                                 {state.frames.map((frame) => (
                                     <GraphFrameView key={frame.id} frame={frame} />
@@ -595,10 +649,7 @@ export const GraphCanvas: FunctionComponent<{ context: EditorContextValue }> = (
                     camera={camera}
                     viewport={size}
                     onNavigate={(world) => {
-                        if (!canHandleIndependentPointerAction()) {
-                            return;
-                        }
-                        setCamera((current) => CenterCameraOn(world, size, current.zoom));
+                        runWhenIdle(() => setCamera((current) => CenterCameraOn(world, size, current.zoom)));
                     }}
                 />
             </CanvasContextProvider>

--- a/packages/tools/nodeAssetsEditor/src/nodeGraph/components/GraphFrameView.tsx
+++ b/packages/tools/nodeAssetsEditor/src/nodeGraph/components/GraphFrameView.tsx
@@ -57,6 +57,7 @@ export const GraphFrameView: FunctionComponent<{ frame: IGraphFrame }> = (props)
     const { frame } = props;
     const classes = useStyles();
     const canvas = useCanvasContext();
+    const aggregateNodeId = frame.aggregateNodeId;
 
     const onPointerDown = (event: ReactPointerEvent) => {
         if (event.button !== 0) {
@@ -79,14 +80,14 @@ export const GraphFrameView: FunctionComponent<{ frame: IGraphFrame }> = (props)
             <div className={classes.fill} style={{ backgroundColor: frame.color }} />
             <div className={classes.header} style={{ backgroundColor: frame.color }}>
                 <Caption1 className={classes.headerLabel}>{frame.label}</Caption1>
-                {frame.kind === "aggregate" && frame.aggregateNodeId && (
+                {frame.kind === "aggregate" && aggregateNodeId && (
                     <Button
                         appearance="transparent"
                         icon={ChevronUpRegular}
                         title="Collapse aggregate"
                         ariaLabel="Collapse aggregate"
                         onPointerDown={onCollapsePointerDown}
-                        onClick={() => canvas.editor.aggregatePresentation?.setExpanded(frame.aggregateNodeId!, false)}
+                        onClick={() => canvas.runWhenIdle(() => canvas.editor.aggregatePresentation?.setExpanded(aggregateNodeId, false))}
                     />
                 )}
             </div>

--- a/packages/tools/nodeAssetsEditor/src/nodeGraph/components/GraphNodeView.tsx
+++ b/packages/tools/nodeAssetsEditor/src/nodeGraph/components/GraphNodeView.tsx
@@ -152,11 +152,13 @@ export const GraphNodeView: FunctionComponent<{ node: IGraphNode }> = (props) =>
 
     const onChevronClick = (event: ReactMouseEvent) => {
         event.stopPropagation();
-        if (isAggregate) {
-            canvas.editor.aggregatePresentation?.setExpanded(node.id, !node.aggregateExpanded);
-            return;
-        }
-        state.setNodeCollapsed(node.id, !node.collapsed);
+        canvas.runWhenIdle(() => {
+            if (isAggregate) {
+                canvas.editor.aggregatePresentation?.setExpanded(node.id, !node.aggregateExpanded);
+                return;
+            }
+            state.setNodeCollapsed(node.id, !node.collapsed);
+        });
     };
 
     // Note: intentionally does not stop propagation so the event reaches the canvas ContextMenu

--- a/packages/tools/nodeAssetsEditor/src/nodeGraph/components/canvasContext.ts
+++ b/packages/tools/nodeAssetsEditor/src/nodeGraph/components/canvasContext.ts
@@ -34,6 +34,8 @@ export type CanvasContextValue = {
     readonly selectWire: (wireId: string, event: ReactPointerEvent) => void;
     /** Opens a context menu for the given target at the pointer position. */
     readonly openContextMenu: (target: ContextMenuTarget, event: ReactMouseEvent) => void;
+    /** Runs a discrete canvas action only when no pointer gesture owns the canvas. */
+    readonly runWhenIdle: (action: () => void) => boolean;
 };
 
 const CanvasContext = createContext<CanvasContextValue | undefined>(undefined);

--- a/packages/tools/nodeAssetsEditor/test/playwright/nodeAssetsEditor.test.ts
+++ b/packages/tools/nodeAssetsEditor/test/playwright/nodeAssetsEditor.test.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page, type Download } from "@playwright/test";
+import { test, expect, type Page, type Download, type Locator } from "@playwright/test";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
@@ -29,6 +29,66 @@ type SavedEditorGraph = {
         readonly blocks: readonly SavedBlock[];
     };
 };
+
+type SyntheticTouchPan = {
+    readonly pointerId: number;
+    readonly point: { readonly x: number; readonly y: number };
+};
+
+async function installSyntheticPointerCapture(editor: NodeAssetsEditorPage): Promise<void> {
+    await editor.canvas.evaluate((canvas) => {
+        const capturedPointerIds = new Set<number>();
+        Object.defineProperties(canvas, {
+            hasPointerCapture: { configurable: true, value: (pointerId: number) => capturedPointerIds.has(pointerId) },
+            setPointerCapture: { configurable: true, value: (pointerId: number) => capturedPointerIds.add(pointerId) },
+            releasePointerCapture: { configurable: true, value: (pointerId: number) => capturedPointerIds.delete(pointerId) },
+        });
+    });
+}
+
+async function beginSyntheticTouchPan(editor: NodeAssetsEditorPage, pointerId: number): Promise<SyntheticTouchPan> {
+    const point = await editor.findEmptyCanvasPoint();
+    await editor.canvas.dispatchEvent("pointerdown", {
+        pointerId,
+        pointerType: "touch",
+        isPrimary: true,
+        button: 0,
+        buttons: 1,
+        clientX: point.x,
+        clientY: point.y,
+    });
+    await expect(editor.canvas).toHaveCSS("cursor", "grabbing");
+    return { pointerId, point };
+}
+
+async function endSyntheticTouchPan(editor: NodeAssetsEditorPage, pan: SyntheticTouchPan, eventName: "pointerup" | "pointercancel" | "lostpointercapture"): Promise<void> {
+    if (eventName === "lostpointercapture") {
+        await editor.canvas.evaluate((canvas, pointerId) => canvas.releasePointerCapture(pointerId), pan.pointerId);
+    }
+    await editor.canvas.dispatchEvent(eventName, {
+        pointerId: pan.pointerId,
+        pointerType: "touch",
+        isPrimary: true,
+        button: 0,
+        buttons: 0,
+        clientX: pan.point.x,
+        clientY: pan.point.y,
+    });
+    await expect(editor.canvas).toHaveCSS("cursor", "grab");
+}
+
+async function clickWirePath(page: Page, path: Locator, button: "left" | "right" = "left"): Promise<void> {
+    const point = await path.evaluate((element: SVGPathElement) => {
+        const matrix = element.getScreenCTM();
+        if (!matrix) {
+            throw new Error("Could not resolve the wire path screen transform.");
+        }
+        const pathPoint = element.getPointAtLength(element.getTotalLength() / 2);
+        const screenPoint = pathPoint.matrixTransform(matrix);
+        return { x: screenPoint.x, y: screenPoint.y };
+    });
+    await page.mouse.click(point.x, point.y, { button });
+}
 
 const DefaultOptimizationPipeline: readonly (readonly [string, string])[] = [
     ["Import glTF", "Weld Vertices"],
@@ -680,12 +740,59 @@ test.describe("Node Assets Editor — maintained default pipeline", () => {
         await expect(editor.nodes).toHaveCount(2);
     });
 
-    test("blocks foreign canvas controls while another pointer owns the active pan", async ({ page }) => {
+    test("keeps an ordinary node presentation inert while a touch pan owns the canvas, then restores it on pointerup", async ({ page }) => {
         const editor = new NodeAssetsEditorPage(page);
         await editor.goto();
+        await installSyntheticPointerCapture(editor);
+
+        const node = editor.nodeByTitle("Remove Unused Resources");
+        const collapseNode = node.getByRole("button", { name: "Collapse node" });
+        const pan = await beginSyntheticTouchPan(editor, 11);
+
+        await collapseNode.click();
+        await expect(collapseNode).toBeVisible();
+
+        await endSyntheticTouchPan(editor, pan, "pointerup");
+        await collapseNode.click();
+        const expandNode = node.getByRole("button", { name: "Expand node" });
+        await expect(expandNode).toBeVisible();
+        await expandNode.click();
+        await expect(collapseNode).toBeVisible();
+    });
+
+    test("keeps aggregate presentation inert while a touch pan owns the canvas, then restores it on pointerup", async ({ page }) => {
+        const editor = new NodeAssetsEditorPage(page);
+        await editor.goto();
+        await installSyntheticPointerCapture(editor);
+
+        const aggregateNode = editor.nodeByTitle("Import glTF");
+        const expandAggregate = aggregateNode.getByRole("button", { name: "Expand aggregate" });
+        const compactPan = await beginSyntheticTouchPan(editor, 21);
+
+        await expandAggregate.click();
+        await expect(expandAggregate).toBeVisible();
+
+        await endSyntheticTouchPan(editor, compactPan, "pointerup");
+        await expandAggregate.click();
+        const aggregateFrame = page.getByTestId("aggregate-frame").filter({ hasText: "Import glTF" });
+        const collapseAggregate = aggregateFrame.getByRole("button", { name: "Collapse aggregate" });
+        await expect(collapseAggregate).toBeVisible();
+
+        const expandedPan = await beginSyntheticTouchPan(editor, 22);
+        await collapseAggregate.click();
+        await expect(aggregateFrame).toBeVisible();
+
+        await endSyntheticTouchPan(editor, expandedPan, "pointerup");
+        await collapseAggregate.click();
+        await expect(expandAggregate).toBeVisible();
+    });
+
+    test("keeps minimap and wire selection inert while a touch pan owns the canvas, then restores them on lost capture", async ({ page }) => {
+        const editor = new NodeAssetsEditorPage(page);
+        await editor.goto();
+        await installSyntheticPointerCapture(editor);
 
         const importNode = editor.nodeByTitle("Import glTF");
-        const contextNode = editor.nodeByTitle("Remove Unused Resources");
         const minimap = editor.canvas.locator('[role="presentation"]');
         const wireHitTarget = editor.wires.first().locator("path").first();
         await editor.selectNode("Import glTF");
@@ -698,56 +805,10 @@ test.describe("Node Assets Editor — maintained default pipeline", () => {
                 return { screenX: rect.x, screenY: rect.y };
             });
 
-        const start = await editor.findEmptyCanvasPoint();
-        const minimapBox = await minimap.boundingBox();
-        if (!minimapBox) {
-            throw new Error("Could not resolve the graph minimap for pointer ownership testing.");
-        }
-        await editor.canvas.evaluate((canvas) => {
-            const capturedPointerIds = new Set<number>();
-            Object.defineProperties(canvas, {
-                hasPointerCapture: { configurable: true, value: (pointerId: number) => capturedPointerIds.has(pointerId) },
-                setPointerCapture: { configurable: true, value: (pointerId: number) => capturedPointerIds.add(pointerId) },
-                releasePointerCapture: { configurable: true, value: (pointerId: number) => capturedPointerIds.delete(pointerId) },
-            });
-        });
-        const ownerPointer = {
-            pointerId: 11,
-            pointerType: "touch",
-            isPrimary: true,
-        };
-        const foreignPointer = {
-            pointerId: 22,
-            pointerType: "touch",
-            isPrimary: false,
-        };
-        const minimapPoint = { clientX: minimapBox.x + 16, clientY: minimapBox.y + 16 };
-        await expect(editor.canvas).toHaveCSS("cursor", "grab");
-        await editor.canvas.dispatchEvent("pointerdown", {
-            ...ownerPointer,
-            button: 0,
-            buttons: 1,
-            clientX: start.x,
-            clientY: start.y,
-        });
-        await expect(editor.canvas).toHaveCSS("cursor", "grabbing");
+        const pan = await beginSyntheticTouchPan(editor, 31);
         const beforeForeignActions = await readNodePosition();
-        await minimap.dispatchEvent("pointerdown", {
-            ...foreignPointer,
-            ...minimapPoint,
-            button: 0,
-            buttons: 1,
-        });
-        await wireHitTarget.dispatchEvent("pointerdown", {
-            ...foreignPointer,
-            button: 0,
-            buttons: 1,
-        });
-        await contextNode.dispatchEvent("contextmenu", {
-            ...foreignPointer,
-            button: 2,
-            buttons: 0,
-        });
+        await minimap.click({ position: { x: 16, y: 16 } });
+        await clickWirePath(page, wireHitTarget);
         const afterForeignActions = await readNodePosition();
         expect({
             screenX: afterForeignActions.screenX,
@@ -758,41 +819,99 @@ test.describe("Node Assets Editor — maintained default pipeline", () => {
             screenY: beforeForeignActions.screenY,
             selectedNodeName: "Import glTF",
         });
-        await page.keyboard.press("Escape");
-        await editor.canvas.dispatchEvent("pointercancel", {
-            ...ownerPointer,
-            buttons: 0,
-            clientX: start.x,
-            clientY: start.y,
-        });
-        await expect(editor.canvas).toHaveCSS("cursor", "grab");
 
+        await endSyntheticTouchPan(editor, pan, "lostpointercapture");
+
+        await clickWirePath(page, wireHitTarget);
+        await expect(page.getByText("No selection", { exact: true })).toBeVisible();
+        await editor.selectNode("Import glTF");
         const beforeIdleMinimapNavigation = await readNodePosition();
-        await minimap.dispatchEvent("pointerdown", {
-            ...foreignPointer,
-            ...minimapPoint,
-            button: 0,
-            buttons: 1,
-        });
+        await minimap.click({ position: { x: 16, y: 16 } });
         await expect
             .poll(async () => {
                 const current = await readNodePosition();
                 return Math.abs(current.screenX - beforeIdleMinimapNavigation.screenX) + Math.abs(current.screenY - beforeIdleMinimapNavigation.screenY);
             })
             .toBeGreaterThan(1);
+    });
 
-        await wireHitTarget.dispatchEvent("pointerdown", {
-            ...foreignPointer,
-            button: 0,
-            buttons: 1,
+    test("closes and suppresses context menus while a touch pan owns the canvas, then restores them on pointercancel", async ({ page }) => {
+        const editor = new NodeAssetsEditorPage(page);
+        await editor.goto();
+        await installSyntheticPointerCapture(editor);
+
+        const importNode = editor.nodeByTitle("Import glTF");
+        const contextNode = editor.nodeByTitle("Remove Unused Resources");
+        const wireHitTarget = editor.wires.first().locator("path").first();
+        const visibleMenus = page.locator('[role="menu"]:visible');
+        const selectedNodeName = page.getByRole("textbox").nth(0);
+        await editor.selectNode("Import glTF");
+        await expect(selectedNodeName).toHaveValue("Import glTF");
+        await importNode.getByText("Import glTF", { exact: true }).click({ button: "right" });
+        await page.getByRole("menuitem", { name: "Copy" }).click();
+        await expect(selectedNodeName).toHaveValue("Import glTF");
+
+        const menuPoint = await editor.findEmptyCanvasPoint();
+        await page.mouse.click(menuPoint.x, menuPoint.y, { button: "right" });
+        const paste = page.getByRole("menuitem", { name: "Paste" });
+        await expect(paste).toBeVisible();
+        await expect(paste).toBeEnabled();
+        await expect(selectedNodeName).toHaveValue("Import glTF");
+
+        const beforeOwner = {
+            nodeCount: await editor.nodes.count(),
+            position: await importNode.evaluate((node: HTMLElement) => {
+                const rect = node.getBoundingClientRect();
+                return { x: rect.x, y: rect.y };
+            }),
+        };
+        const pan = await beginSyntheticTouchPan(editor, 41);
+        await expect(selectedNodeName).toHaveValue("Import glTF");
+
+        await expect.soft(visibleMenus).toHaveCount(0);
+        await page.keyboard.press("Enter");
+        await expect.soft(editor.nodes).toHaveCount(beforeOwner.nodeCount);
+        const positionAfterStaleAction = await importNode.evaluate((node: HTMLElement) => {
+            const rect = node.getBoundingClientRect();
+            return { x: rect.x, y: rect.y };
         });
-        await expect(page.getByText("No selection", { exact: true })).toBeVisible();
-        await contextNode.dispatchEvent("contextmenu", {
-            ...foreignPointer,
-            button: 2,
-            buttons: 0,
-        });
-        await expect(page.getByRole("textbox").nth(0)).toHaveValue("Remove Unused Resources");
+        expect.soft(positionAfterStaleAction).toEqual(beforeOwner.position);
+        await expect(selectedNodeName).toHaveValue("Import glTF");
+
+        for (const openMenu of [
+            async () => contextNode.getByText("Remove Unused Resources", { exact: true }).click({ button: "right" }),
+            async () => clickWirePath(page, wireHitTarget, "right"),
+            async () => {
+                const point = await editor.findEmptyCanvasPoint();
+                await page.mouse.click(point.x, point.y, { button: "right" });
+            },
+        ]) {
+            await openMenu();
+            await expect.soft(visibleMenus).toHaveCount(0);
+            if ((await visibleMenus.count()) > 0) {
+                await page.keyboard.press("Escape");
+            }
+            await expect(selectedNodeName).toHaveValue("Import glTF");
+        }
+
+        await endSyntheticTouchPan(editor, pan, "pointercancel");
+
+        await contextNode.getByText("Remove Unused Resources", { exact: true }).click({ button: "right" });
+        await expect(page.getByRole("menuitem", { name: "Copy" })).toBeVisible();
+        await page.keyboard.press("Escape");
+        await clickWirePath(page, wireHitTarget, "right");
+        await expect(page.getByRole("menuitem", { name: "Delete wire" })).toBeVisible();
+        await page.keyboard.press("Escape");
+        const idleCanvasPoint = await editor.findEmptyCanvasPoint();
+        await page.mouse.click(idleCanvasPoint.x, idleCanvasPoint.y, { button: "right" });
+        const beforeIdlePaste = await editor.nodes.count();
+        await expect(paste).toBeVisible();
+        await expect(paste).toBeEnabled();
+        await paste.click();
+        await expect(editor.nodes).toHaveCount(beforeIdlePaste + 1);
+        const fitMenuPoint = await editor.findEmptyCanvasPoint();
+        await page.mouse.click(fitMenuPoint.x, fitMenuPoint.y, { button: "right" });
+        await expect(page.getByRole("menuitem", { name: "Zoom to fit" })).toBeVisible();
         await page.keyboard.press("Escape");
     });
 

--- a/packages/tools/nodeAssetsEditor/test/unit/graphNodeDiagnostics.test.tsx
+++ b/packages/tools/nodeAssetsEditor/test/unit/graphNodeDiagnostics.test.tsx
@@ -41,6 +41,10 @@ describe("GraphNodeView diagnostics", () => {
             beginPortInteraction: () => undefined,
             selectWire: () => undefined,
             openContextMenu: () => undefined,
+            runWhenIdle: (action) => {
+                action();
+                return true;
+            },
         };
 
         const markup = renderToStaticMarkup(


### PR DESCRIPTION
## Summary

- centralize active gesture ownership in `GraphCanvas` and gate foreign discrete actions through an idle-only canvas context boundary
- keep node, aggregate, minimap, wire, selection, and context-menu mutations inert while a pan owns the canvas
- close and disable already-open Fluent context menus during ownership, then restore controls after pointer completion or cancellation

## Testing

- `npx vitest run --project=unit packages/dev/sharedUiComponents/test/unit/fluent/contextMenu.test.tsx packages/tools/nodeAssetsEditor/test/unit/nodeGraph/gestureInterpreter.test.ts packages/tools/nodeAssetsEditor/test/unit/graphNodeDiagnostics.test.tsx` (38 passed)
- `NAE_BASE_URL=http://127.0.0.1:1348 npx playwright test -c playwright.config.ts --project=nodeAssetsEditor packages/tools/nodeAssetsEditor/test/playwright/nodeAssetsEditor.test.ts -g 'while a touch pan owns|pans empty canvas without mutating' --workers=1 --retries=0` (5 passed)
- `npm run build:deployment -w @tools/node-assets-editor`
- `npm run format:check --silent`
- `npm run lint:check --silent`
