### PR TITLE
docs(nae): resolve palette tooltip tracker

### DIFF
--- a/.scratch/palette-description-tooltips/PRD.md
+++ b/.scratch/palette-description-tooltips/PRD.md
@@ -1,6 +1,6 @@
 # PRD — Palette description tooltips
 
-Status: ready-for-agent
+Status: resolved
 
 ## Problem Statement
 
@@ -33,19 +33,19 @@ Render each palette item with its node name as the only always-visible item text
 
 ## Acceptance Criteria
 
-- [ ] Each palette item shows its node name as the only always-visible item copy; descriptions are absent from row layout and are not rendered as visible subheadings.
-- [ ] The existing optional description metadata remains in palette items and remains part of `PaletteItemMatchesFilter`; category, family, Show primitives, and empty-search behavior are unchanged.
-- [ ] Every non-empty description is supplied to `shared-ui-components/fluent/primitives/tooltip`; no raw HTML `title` is used as a substitute or competing native tooltip.
-- [ ] The whole draggable palette row triggers the tooltip on mouse or pen hover and keyboard focus using the shared primitive's accessible description relationship.
-- [ ] The focusable trigger's visible node name remains its accessible name, and the tooltip text is exposed as its accessible description rather than replacing the name.
-- [ ] Missing, empty, or whitespace-only descriptions do not create an empty tooltip.
-- [ ] Tooltip delay, positioning, portal behavior, and text wrapping use the existing shared Fluent defaults; controlled visibility only suppresses touch-originated open requests.
-- [ ] Existing label wrapping/truncation behavior, row border/padding/minimum height, family spacing, and category density are preserved except for removal of the description line.
-- [ ] Tooltip plumbing does not change native drag payloads, canvas drops, clicking, pane scrolling, filtering, category toggling, or virtualization assumptions.
-- [ ] Holding touch contact beyond Fluent's show delay does not open a tooltip or add a touch long-press help gesture.
-- [ ] Automated browser coverage proves descriptions are absent before interaction, remain hidden during touch contact, appear as accessible tooltips on mouse hover and keyboard focus, remain searchable, and do not break an existing node drop.
-- [ ] Focused unit tests for palette search/projection, the targeted Node Assets Editor Playwright test, package build/type-check, and changed-file lint/format checks pass.
-- [ ] The rendered editor at the existing Node Assets Editor dev surface (default port 1348) is checked for compact rows, themed tooltip rendering, keyboard focus, and successful drag/drop.
+- [x] Each palette item shows its node name as the only always-visible item copy; descriptions are absent from row layout and are not rendered as visible subheadings.
+- [x] The existing optional description metadata remains in palette items and remains part of `PaletteItemMatchesFilter`; category, family, Show primitives, and empty-search behavior are unchanged.
+- [x] Every non-empty description is supplied to `shared-ui-components/fluent/primitives/tooltip`; no raw HTML `title` is used as a substitute or competing native tooltip.
+- [x] The whole draggable palette row triggers the tooltip on mouse or pen hover and keyboard focus using the shared primitive's accessible description relationship.
+- [x] The focusable trigger's visible node name remains its accessible name, and the tooltip text is exposed as its accessible description rather than replacing the name.
+- [x] Missing, empty, or whitespace-only descriptions do not create an empty tooltip.
+- [x] Tooltip delay, positioning, portal behavior, and text wrapping use the existing shared Fluent defaults; controlled visibility only suppresses touch-originated open requests.
+- [x] Existing label wrapping/truncation behavior, row border/padding/minimum height, family spacing, and category density are preserved except for removal of the description line.
+- [x] Tooltip plumbing does not change native drag payloads, canvas drops, clicking, pane scrolling, filtering, category toggling, or virtualization assumptions.
+- [x] Holding touch contact beyond Fluent's show delay does not open a tooltip or add a touch long-press help gesture.
+- [x] Automated browser coverage proves descriptions are absent before interaction, remain hidden during touch contact, appear as accessible tooltips on mouse hover and keyboard focus, remain searchable, and do not break an existing node drop.
+- [x] Focused unit tests for palette search/projection, the targeted Node Assets Editor Playwright test, package build/type-check, and changed-file lint/format checks pass.
+- [x] The rendered editor at the existing Node Assets Editor dev surface (default port 1348) is checked for compact rows, themed tooltip rendering, keyboard focus, and successful drag/drop.
 
 ## Implementation Decisions
 
@@ -76,4 +76,8 @@ Render each palette item with its node name as the only always-visible item text
 
 ## Further Notes
 
-The implementation baseline is the latest `preview/nae`. Concurrent graph-panning work is expected to stay in canvas files, while concurrent import-node work may update block descriptors, palette catalog tests, and the large Node Assets Editor Playwright file. Keep edits surgical, rebase before integration, and resolve nearby test changes without overwriting new import coverage.
+The implementation was based on the latest `preview/nae` and stayed surgical alongside concurrent graph-panning and import-node work.
+
+## Delivery Status
+
+Resolved. Feature PR #20 landed in `preview/nae` at merge commit `dea408ba`. Final integration evidence: palette units 13/13; targeted Chromium 1/1 with `retries=0`; full NAE Playwright 44/44 in one run with `retries=0`; NAE production build and changed-file Prettier, ESLint, and CRLF-aware diff checks clean; automatic instruction and agnostic reviews at Sol/Max clean. Browser coverage exercised the complete touch lifecycle and verified mouse hover, keyboard focus, and palette drop recovery afterward.

--- a/.scratch/palette-description-tooltips/issues/01-implement-accessible-palette-description-tooltips.md
+++ b/.scratch/palette-description-tooltips/issues/01-implement-accessible-palette-description-tooltips.md
@@ -1,6 +1,6 @@
 # Implement accessible palette description tooltips
 
-Status: ready-for-agent
+Status: resolved
 
 ## Parent
 
@@ -24,15 +24,20 @@ Make the Node Assets Editor palette name-first and compact by removing always-vi
 - [x] Tests are developed first and prove hidden descriptions, touch suppression, mouse hover, focus, accessible semantics, search, and an unchanged palette-item drop through stable locators.
 - [x] Focused unit, Playwright, build/type-check, lint, and format validation passes, followed by a rendered check of the Node Assets Editor dev surface.
 - [x] `/code-review` reports no unresolved findings.
+- [x] The corrected touch-lifecycle implementation landed and root completed final validation and integration.
 
 ## Blocked by
 
-None - can start immediately.
+None.
+
+## Delivery status (resolved)
+
+Feature PR #20 landed in `preview/nae` at merge commit `dea408ba`. Final integration evidence: palette units 13/13; targeted Chromium 1/1 with `retries=0`; full NAE Playwright 44/44 in one run with `retries=0`; NAE production build and changed-file Prettier, ESLint, and CRLF-aware diff checks clean; automatic instruction and agnostic reviews at Sol/Max clean. The browser proof covers the complete touch lifecycle plus mouse-hover, keyboard-focus, and palette-drop recovery.
 
 ## Comments
 
 - 2026-07-21: Implemented compact label-only rows with trimmed shared Fluent description tooltips, visible-label accessible names, keyboard focus, and unchanged drag payloads/search metadata.
 - 2026-07-21: Root review reopened the issue because Fluent also reacts to touch pointer entry, allowing a held contact to open the tooltip after the show delay.
 - Earlier validation, rendered-check, and child-review claims do not cover the reopened final head and are not accepted as landing evidence.
-- The complete touch lifecycle regression and controlled Fluent visibility path passed the palette unit seam (13/13), targeted tooltip Playwright test (1/1), full NAE Playwright project (44/44), NAE production build, changed-file Prettier/ESLint, and diff checks under the exclusive local lease.
-- Automatic agnostic and instructions review lenses at Sol/Max reported no significant issues; landing remains pending, so the issue stays unresolved.
+- 2026-07-21: The corrected controlled-visibility path passed the complete final validation recorded above, including recovery of mouse hover, keyboard focus, and palette drop after touch.
+- 2026-07-21: Automatic instruction and agnostic review lenses at Sol/Max were clean; PR #20 then landed at `dea408ba`, resolving the issue.


### PR DESCRIPTION
## Summary

- resolve the palette description tooltip PRD and implementation tracker after feature landing
- record final touch-lifecycle, validation, review, and merge evidence

## Validation

Documentation-only follow-up; the exact two-file diff was reviewed.
