### PR TITLE
fix(node-assets): resolve duplicate OBJ companion basenames

### DIFF
--- a/packages/dev/node-assets/src/io/objLocalFileBundle.ts
+++ b/packages/dev/node-assets/src/io/objLocalFileBundle.ts
@@ -47,6 +47,10 @@ function GetFileName(path: string): string {
     return path.slice(path.lastIndexOf("/") + 1);
 }
 
+function GetOnlyCandidate(candidates: ReadonlySet<IOBJSourceFile> | undefined): IOBJSourceFile | undefined {
+    return candidates?.size === 1 ? candidates.values().next().value : undefined;
+}
+
 function GetLastMaterialLibraryReference(bytes: Uint8Array): string | undefined {
     const source = TextDecoderInstance.decode(bytes).replace(/#.*$/gm, "").trim();
     let reference: string | undefined;
@@ -141,7 +145,8 @@ export function AcquireOBJLocalFileBundle(
     const primaryDirectory = GetDirectory(primaryPath);
     const rootKey = `${prefix}${primaryDirectory}`;
     const aliases = new Map<string, IOBJSourceFile>();
-    const companionsByBaseName = new Map<string, IOBJSourceFile>();
+    const companionsByPath = new Map<string, IOBJSourceFile>();
+    const companionsByBaseName = new Map<string, Set<IOBJSourceFile>>();
 
     const addAlias = (key: string, file: IOBJSourceFile) => {
         const existing = aliases.get(key);
@@ -154,10 +159,23 @@ export function AcquireOBJLocalFileBundle(
     for (const companion of source.companions) {
         const normalizedPath = _NormalizeOBJSourcePath(companion.path);
         const relativePath = GetRelativePath(primaryDirectory, normalizedPath);
-        companionsByBaseName.set(GetFileName(normalizedPath), companion);
+        const baseName = GetFileName(normalizedPath);
+        companionsByPath.set(normalizedPath, companion);
+        let candidates = companionsByBaseName.get(baseName);
+        if (!candidates) {
+            candidates = new Set();
+            companionsByBaseName.set(baseName, candidates);
+        }
+        candidates.add(companion);
         addAlias(`${prefix}${normalizedPath}`, companion);
         addAlias(`${rootKey}${relativePath}`, companion);
-        addAlias(`${rootKey}${GetFileName(normalizedPath)}`, companion);
+    }
+
+    for (const [baseName, candidates] of companionsByBaseName) {
+        const companion = GetOnlyCandidate(candidates);
+        if (companion) {
+            addAlias(`${rootKey}${baseName}`, companion);
+        }
     }
 
     const addReferenceAlias = (reference: string): IOBJSourceFile | undefined => {
@@ -174,7 +192,7 @@ export function AcquireOBJLocalFileBundle(
             }
             throw error;
         }
-        const companion = companionsByBaseName.get(GetFileName(normalizedReference));
+        const companion = companionsByPath.get(normalizedReference) ?? GetOnlyCandidate(companionsByBaseName.get(GetFileName(normalizedReference)));
         if (!companion) {
             return undefined;
         }

--- a/packages/dev/node-assets/src/representations/objSourceAsset.ts
+++ b/packages/dev/node-assets/src/representations/objSourceAsset.ts
@@ -76,7 +76,6 @@ function GetSourceFileMimeType(path: string): string | undefined {
 
 function ValidateUploadedFiles(primary: IOBJSourceFile, companions: ReadonlyArray<IOBJSourceFile>): void {
     const normalizedPaths = new Set<string>();
-    const companionBaseNames = new Set<string>();
     const files = [primary, ...companions];
 
     for (let index = 0; index < files.length; index++) {
@@ -103,12 +102,6 @@ function ValidateUploadedFiles(primary: IOBJSourceFile, companions: ReadonlyArra
         if (!normalizedPath.endsWith(".mtl") && (!mimeType || !SupportedTextureMimeTypes.has(mimeType))) {
             throw new TypeError(`The OBJ companion "${file.path}" must be an MTL or supported texture file.`);
         }
-
-        const baseName = normalizedPath.slice(normalizedPath.lastIndexOf("/") + 1);
-        if (companionBaseNames.has(baseName)) {
-            throw new TypeError(`The OBJ companion basename "${baseName}" is ambiguous.`);
-        }
-        companionBaseNames.add(baseName);
     }
 }
 

--- a/packages/dev/node-assets/test/unit/objLocalFileBundle.test.ts
+++ b/packages/dev/node-assets/test/unit/objLocalFileBundle.test.ts
@@ -66,6 +66,40 @@ describe("OBJ local file bundle", () => {
         expect(store).toEqual({});
     });
 
+    it("keeps repeated basenames exact and leaves basename-only references unresolved", async () => {
+        const store: Record<string, File> = {};
+        const firstTextureBytes = new Uint8Array([1]);
+        const secondTextureBytes = new Uint8Array([2]);
+        const source = new OBJSourceAsset(
+            {
+                path: "model.obj",
+                bytes: new TextEncoder().encode("mtllib materials/catalog.mtl"),
+            },
+            "model.obj",
+            "upload",
+            [
+                {
+                    path: "materials/catalog.mtl",
+                    bytes: new TextEncoder().encode("newmtl Catalog\nmap_Kd shared.png"),
+                },
+                { path: "materials/a/shared.png", bytes: firstTextureBytes },
+                { path: "materials/b/shared.png", bytes: secondTextureBytes },
+            ]
+        );
+        const lease = AcquireOBJLocalFileBundle(source, {
+            store,
+            createFile: (file) => new File([file.bytes], file.path),
+        });
+        const rootKey = lease.rootUrl.slice("file:".length);
+
+        expect(new Uint8Array(await store[`${rootKey}materials/a/shared.png`].arrayBuffer())).toEqual(firstTextureBytes);
+        expect(new Uint8Array(await store[`${rootKey}materials/b/shared.png`].arrayBuffer())).toEqual(secondTextureBytes);
+        expect(store[`${rootKey}shared.png`]).toBeUndefined();
+
+        lease.dispose();
+        expect(store).toEqual({});
+    });
+
     it("cleans only owned entries and is idempotent", () => {
         const store: Record<string, File> = {};
         const source = CreateSource([{ path: "material.mtl", bytes: Bytes }]);

--- a/packages/dev/node-assets/test/unit/objUniversalFunnel.test.ts
+++ b/packages/dev/node-assets/test/unit/objUniversalFunnel.test.ts
@@ -242,6 +242,45 @@ map_Kd Textures/tiny.png
     return { asset, read };
 }
 
+function CreateRepeatedBasenameBundlePipeline(textureReferences: readonly [string, string]): NodeAsset {
+    const obj = new TextEncoder().encode(`mtllib materials/catalog.mtl
+o SharedTextures
+v 0 0 0
+v 1 0 0
+v 1 1 0
+v 0 1 0
+vt 0 0
+vt 1 0
+vt 1 1
+vt 0 1
+vn 0 0 1
+usemtl FirstShared
+f 1/1/1 2/2/1 3/3/1
+usemtl SecondShared
+f 1/1/1 3/3/1 4/4/1
+`);
+    const mtl = new TextEncoder().encode(`newmtl FirstShared
+Kd 1.0 0.0 0.0
+map_Kd ${textureReferences[0]}
+newmtl SecondShared
+Kd 0.0 0.0 1.0
+map_Kd ${textureReferences[1]}
+`);
+    const asset = new NodeAsset("repeated-basename-bundle");
+    const read = new ReadOBJBlock("Read OBJ", asset);
+    read.setUploadedSourceBundle([
+        { path: "model.obj", bytes: obj },
+        { path: "materials/catalog.mtl", bytes: mtl },
+        { path: "materials/a/shared.png", bytes: TinyPng },
+        { path: "materials/b/shared.png", bytes: TinyPngWithTrailingByte },
+    ]);
+    const transcoder = new OBJToUniversalBlock("OBJ to Universal", asset);
+    const exporter = new ExportGLTFAggregateBlock("Export glTF", asset);
+    read.output.connectTo(transcoder.input);
+    transcoder.output.connectTo(exporter.input);
+    return asset;
+}
+
 async function CreateUrlPipelineAsync(url: string, bytes = OBJFixture) {
     const asset = new NodeAsset("url-obj");
     const read = new ReadOBJBlock("Read OBJ", asset);
@@ -480,7 +519,7 @@ describe("OBJ Universal funnel", () => {
         });
     });
 
-    it("rejects invalid or ambiguous bundles without replacing the active source", async () => {
+    it("rejects invalid bundles without replacing the active source", async () => {
         const { read } = CreateBundlePipeline();
         const expectedPrimary = read.primary;
         const expectedCompanions = read.companions;
@@ -498,11 +537,6 @@ describe("OBJ Universal funnel", () => {
                 { path: "fixture.obj", bytes: OBJFixture },
                 { path: "Materials/material.mtl", bytes: MTLBundleFixture },
                 { path: "materials/MATERIAL.MTL", bytes: MTLBundleFixture },
-            ],
-            [
-                { path: "fixture.obj", bytes: OBJFixture },
-                { path: "First/material.mtl", bytes: MTLBundleFixture },
-                { path: "Second/material.mtl", bytes: MTLBundleFixture },
             ],
             [
                 { path: "../fixture.obj", bytes: OBJFixture },
@@ -561,6 +595,25 @@ describe("OBJ Universal funnel", () => {
             ])
         );
         expect(facts.textures).toEqual([{ mimeType: "image/png", byteLength: TinyPng.byteLength }]);
+    });
+
+    it("builds exact directory-qualified references when companion basenames repeat", async () => {
+        const asset = CreateRepeatedBasenameBundlePipeline(["materials/a/shared.png", "materials/b/shared.png"]);
+        const facts = await GetAssetFactsAsync(await asset.buildAsync());
+
+        expect(facts.materials).toEqual(
+            expect.arrayContaining([
+                { name: "FirstShared", baseColorFactor: [0.5, 0, 0, 1], hasBaseColorTexture: true },
+                { name: "SecondShared", baseColorFactor: [0, 0, 0.5, 1], hasBaseColorTexture: true },
+            ])
+        );
+        expect(facts.textures).toHaveLength(2);
+        expect(facts.textures).toEqual(
+            expect.arrayContaining([
+                { mimeType: "image/png", byteLength: TinyPng.byteLength },
+                { mimeType: "image/png", byteLength: TinyPngWithTrailingByte.byteLength },
+            ])
+        );
     });
 
     it("uses unambiguous basename fallback for ordinary flat browser references", async () => {


### PR DESCRIPTION
## Summary

- allow local OBJ companions to reuse a basename in different directories
- resolve exact normalized relative paths before basename fallback
- create basename aliases only when exactly one companion matches
- cover exact repeated-basename loading and ambiguous basename-only behavior

## Validation

- RED on exact parent `2e8d047894998e9fa819ac5d62957d47de24bfc8`: 2 expected failures, 26 passes
- GREEN focused OBJ seams: 28 passes
- `@dev/node-assets` build passes after building declared core/loaders/serializers prerequisites
- changed-file Prettier and ESLint pass
- `git diff --check` passes
- automatic agnostic + repository-instructions review at GPT-5.6 Sol/max found no issues
