### PR TITLE
[KTX2 Decoder] Fix Zstd-compressed UASTC textures failing to load (bytesPlane[0] = 0)

### DIFF
--- a/packages/dev/core/test/unit/Materials/Textures/ktx2Decoder.test.ts
+++ b/packages/dev/core/test/unit/Materials/Textures/ktx2Decoder.test.ts
@@ -19,7 +19,14 @@ const DFD_TRANSFER_LINEAR = 1;
  * @param supercompressionScheme the supercompression scheme to declare in the header (the level data is left uncompressed)
  * @returns the raw KTX2 bytes
  */
-function createUncompressedKtx2(width: number, layerCount: number, levelCount: number, vkFormat = VK_FORMAT_R8G8B8A8_UNORM, supercompressionScheme = 0): Uint8Array {
+function createUncompressedKtx2(
+    width: number,
+    layerCount: number,
+    levelCount: number,
+    vkFormat = VK_FORMAT_R8G8B8A8_UNORM,
+    supercompressionScheme = 0,
+    bytesPlane0 = 4
+): Uint8Array {
     const numSamples = 4;
     const descriptorBlockSize = 24 + numSamples * 16;
     const dfdByteLength = 4 + descriptorBlockSize;
@@ -93,7 +100,7 @@ function createUncompressedKtx2(width: number, layerCount: number, levelCount: n
     data[offset + 13] = 0;
     data[offset + 14] = 0;
     data[offset + 15] = 0;
-    data[offset + 16] = 4; // bytesPlane0
+    data[offset + 16] = bytesPlane0; // bytesPlane0
     const samplesOffset = offset + 24;
     const channelTypes = [0, 1, 2, 15]; // R, G, B, A
     for (let i = 0; i < numSamples; i++) {
@@ -201,6 +208,44 @@ describe("KTX2Decoder", () => {
         expect(decoded.errors).toBeUndefined();
         expect(decoded.mipmaps).toHaveLength(3);
         // Each layer must be sliced out of the decompressed level, not silently replaced by the whole level.
+        expect(decoded.mipmaps.map((mipmap) => mipmap.data![0])).toEqual([1, 2, 3]);
+        expect(decoded.mipmaps.map((mipmap) => mipmap.data!.byteLength)).toEqual([4 * 4 * 4, 4 * 4 * 4, 4 * 4 * 4]);
+    });
+
+    it("decodes ZStandard-compressed data when bytesPlane[0] is zero", async () => {
+        // UASTC files with Zstd supercompression have bytesPlane[0] = 0 per the KTX2 spec. The per-image byte
+        // length must be derived from the level's uncompressedByteLength rather than the block-based formula.
+        const file = createUncompressedKtx2(4, 1, 1, VK_FORMAT_R8G8B8A8_UNORM, 2 /* SupercompressionScheme.ZStandard */, 0 /* bytesPlane0 */);
+
+        const decoder = new KTX2Decoder();
+        (decoder as any)._zstdDecoder = {
+            // eslint-disable-next-line @typescript-eslint/no-empty-function
+            init: async () => {},
+            decode: (array: Uint8Array) => array.slice(),
+        };
+
+        const decoded = await decoder.decode(file, EmptyCaps);
+
+        expect(decoded.errors).toBeUndefined();
+        expect(decoded.mipmaps).toHaveLength(1);
+        expect(decoded.mipmaps[0].data!.byteLength).toBe(4 * 4 * 4);
+        expect(decoded.mipmaps[0].data![0]).toBe(1);
+    });
+
+    it("decodes ZStandard-compressed multi-layer data when bytesPlane[0] is zero", async () => {
+        const file = createUncompressedKtx2(4, 3, 1, VK_FORMAT_R8G8B8A8_UNORM, 2 /* SupercompressionScheme.ZStandard */, 0 /* bytesPlane0 */);
+
+        const decoder = new KTX2Decoder();
+        (decoder as any)._zstdDecoder = {
+            // eslint-disable-next-line @typescript-eslint/no-empty-function
+            init: async () => {},
+            decode: (array: Uint8Array) => array.slice(),
+        };
+
+        const decoded = await decoder.decode(file, EmptyCaps);
+
+        expect(decoded.errors).toBeUndefined();
+        expect(decoded.mipmaps).toHaveLength(3);
         expect(decoded.mipmaps.map((mipmap) => mipmap.data![0])).toEqual([1, 2, 3]);
         expect(decoded.mipmaps.map((mipmap) => mipmap.data!.byteLength)).toEqual([4 * 4 * 4, 4 * 4 * 4, 4 * 4 * 4]);
     });

--- a/packages/tools/ktx2Decoder/src/ktx2Decoder.ts
+++ b/packages/tools/ktx2Decoder/src/ktx2Decoder.ts
@@ -121,13 +121,16 @@ export class KTX2Decoder {
             const levelHeight = Math.floor(height / (1 << level)) || 1;
 
             const numImagesInLevel = kfr.header.faceCount; // note that cubemap are not supported yet (see KTX2FileReader), so faceCount == 1
-            // The texel block dimension is 4x4 for the block-compressed source formats and 1x1 for the uncompressed ones,
-            // so this covers both without special casing.
+            const levelUncompressedByteLength = kfr.levels[level].uncompressedByteLength;
+
+            // bytesPlane[0] is 0 for supercompressed formats (e.g. UASTC + Zstd); fall back to uncompressedByteLength.
             const blockWidth = kfr.dfdBlock.texelBlockDimension.x;
             const blockHeight = kfr.dfdBlock.texelBlockDimension.y;
-            const levelImageByteLength = Math.ceil(levelWidth / blockWidth) * Math.ceil(levelHeight / blockHeight) * kfr.dfdBlock.bytesPlane[0];
-
-            const levelUncompressedByteLength = kfr.levels[level].uncompressedByteLength;
+            const bytesPerBlock = kfr.dfdBlock.bytesPlane[0];
+            const levelImageByteLength =
+                bytesPerBlock > 0
+                    ? Math.ceil(levelWidth / blockWidth) * Math.ceil(levelHeight / blockHeight) * bytesPerBlock
+                    : Math.floor(levelUncompressedByteLength / (layerCount * numImagesInLevel));
 
             let levelDataBuffer: ArrayBufferLike = kfr.data.buffer;
 


### PR DESCRIPTION
Fixes a regression from #18740 where KTX2 textures with Zstd supercompression fail to load.

Forum report: https://forum.babylonjs.com/t/failed-to-load-ktx2-texture-data-used-zstandard-zstd-compression/63871

## Root cause

PR #18740 changed the per-image byte length formula in `ktx2Decoder.ts` to:

```ts
Math.ceil(levelWidth / blockWidth) * Math.ceil(levelHeight / blockHeight) * bytesPlane[0]
```

The [KTX2 spec § "DFD for Supercompressed Data"](https://registry.khronos.org/KTX/specs/2.0/ktxspec.v2.html) contains a normative backwards-compatibility note:

> Previous document revisions required `bytesPlane[0-7]` to be set to 0 to indicate an *unsized format*. **For the foreseeable future software must be able to handle such KTX files.**

KTX-Software (the reference encoder) writes `bytesPlane[0] = 0` for Zstd-compressed UASTC files — confirmed by the repo's own test fixtures (`sample_uastc_zcmp.ktx2`, `testalpha_uastc_zcmp.ktx2`). With `bytesPlane[0] = 0`, the formula produces 0 and the transcoder receives an empty buffer.

The old code accidentally worked because it stored the Zstd-decompressed `Uint8Array` directly in `levelDataBuffer`, and the `Uint8Array(typedArray, offset, length)` constructor overload ignores offset/length and copies the whole array.

## Fix

When `bytesPlane[0]` is 0, fall back to `levelUncompressedByteLength / (layerCount * faceCount)` instead of the block-based formula.

## Tests

2 new regression tests covering single-layer and multi-layer Zstd-compressed files with `bytesPlane[0] = 0`. Both fail without the fix and pass with it. All 8 KTX2 decoder tests pass.